### PR TITLE
Improve bitrate profiling and scan reliability

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,9 @@ tauri-plugin-notification = "2"
 tauri-plugin-mcp = { git = "https://github.com/P3GLEG/tauri-plugin-mcp", features = ["devtools"] }
 fs2 = "0.4.3"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-liquid-glass = "0.1"
 tauri-plugin-macos-haptics = "1.0.0"

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -275,12 +275,12 @@ async fn compute_shared_url_result(
         return Ok((shared, timing));
     }
     let diagnostics_started_at = Instant::now();
-    let _diagnostics_permit = diagnostics_semaphore.clone().acquire_owned().await.ok();
+    let diagnostics_permit = diagnostics_semaphore.clone().acquire_owned().await.ok();
     let ffprobe_timeout_duration =
         std::time::Duration::from_secs_f64(ffprobe_timeout_secs.clamp(1.0, 300.0));
 
     // Run ffprobe and screenshot capture in parallel — they are independent.
-    // Bitrate profiling runs alongside screenshot after ffprobe starts.
+    // Bitrate profiling runs sequentially after both complete.
     let want_screenshot = !skip_screenshots && ffmpeg_ok && screenshots_dir.is_some();
 
     let ffprobe_fut = async {
@@ -342,6 +342,11 @@ async fn compute_shared_url_result(
     if let Some(path) = screenshot_result {
         shared.screenshot_path = Some(path);
     }
+
+    // Release the diagnostics permit before bitrate profiling. ffprobe and
+    // screenshot are done; holding the permit during the long bitrate sample
+    // (~30s) starves other channels' diagnostics.
+    drop(diagnostics_permit);
 
     if ffprobe_ok && !cancel.is_cancelled() && profile_bitrate_flag && ffmpeg_ok {
         match ffmpeg::profile_bitrate(

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -344,7 +344,7 @@ async fn compute_shared_url_result(
     }
 
     if ffprobe_ok && !cancel.is_cancelled() && profile_bitrate_flag && ffmpeg_ok {
-        if let Ok(bitrate) = ffmpeg::profile_bitrate(
+        match ffmpeg::profile_bitrate(
             app,
             &target_url,
             user_agent,
@@ -353,7 +353,13 @@ async fn compute_shared_url_result(
         )
         .await
         {
-            shared.video_bitrate = Some(bitrate);
+            Ok(bitrate) => {
+                shared.video_bitrate = Some(bitrate);
+            }
+            Err(AppError::Cancelled) => {}
+            Err(err) => {
+                log::warn!("Bitrate profiling failed for {target_url}: {err}");
+            }
         }
     }
     timing.diagnostics_ms = diagnostics_started_at.elapsed().as_secs_f64() * 1000.0;

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1859,7 +1859,9 @@ async fn execute_scan_run(
     drop(checkpoint_tx);
 
     for handle in handles {
-        let _ = handle.await;
+        if let Err(err) = handle.await {
+            log::error!("Scan worker task failed: {err}");
+        }
     }
 
     let event_result = event_task.await;

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1858,10 +1858,17 @@ async fn execute_scan_run(
     drop(tx);
     drop(checkpoint_tx);
 
+    let mut panicked_workers = 0u32;
     for handle in handles {
         if let Err(err) = handle.await {
+            panicked_workers += 1;
             log::error!("Scan worker task failed: {err}");
         }
+    }
+    if panicked_workers > 0 {
+        log::error!(
+            "{panicked_workers} scan worker(s) panicked — those channels are missing from results"
+        );
     }
 
     let event_result = event_task.await;

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -1009,9 +1009,10 @@ pub async fn profile_bitrate(
     let stderr_pipe = child.stderr.take();
     let stderr_reader = tokio::spawn(async move {
         use tokio::io::AsyncReadExt;
+        const MAX_STDERR_BYTES: usize = 1_024 * 1_024; // 1 MB
         let mut buf = Vec::new();
         if let Some(mut pipe) = stderr_pipe {
-            let _ = pipe.read_to_end(&mut buf).await;
+            let _ = (&mut pipe).take(MAX_STDERR_BYTES as u64).read_to_end(&mut buf).await;
         }
         buf
     });

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -1064,15 +1064,25 @@ pub async fn profile_bitrate(
         }
     }
 
-    if timed_out && total_bytes == 0 {
-        return Err(AppError::Other(format!(
-            "ffmpeg bitrate profiling timed out after {:.0}s (binary: {})",
-            timeout_duration.as_secs_f64(),
-            resolved_bin,
-        )));
-    }
-
     if total_bytes == 0 {
+        let tail: String = stderr
+            .lines()
+            .rev()
+            .take(5)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join(" | ");
+        if timed_out {
+            log::warn!("Bitrate profiling timed out after {:.0}s with no Statistics line. stderr tail: {tail}", timeout_duration.as_secs_f64());
+            return Err(AppError::Other(format!(
+                "ffmpeg bitrate profiling timed out after {:.0}s (binary: {})",
+                timeout_duration.as_secs_f64(),
+                resolved_bin,
+            )));
+        }
+        log::warn!("Bitrate profiling completed but no bytes-read data found in stderr. stderr tail: {tail}");
         return Ok("N/A".to_string());
     }
 

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -978,8 +978,8 @@ pub async fn profile_bitrate(
 
     // Leave at least 15s of headroom within the timeout for connection
     // setup and graceful shutdown. Minimum streaming duration is 3s.
-    let stream_secs = (timeout_duration.as_secs_f64() - 15.0).clamp(3.0, 10.0);
-    let stream_secs_str = format!("{:.0}", stream_secs);
+    let sample_secs = (timeout_duration.as_secs().saturating_sub(15)).clamp(3, 10);
+    let sample_secs_str = sample_secs.to_string();
 
     let mut command = tokio::process::Command::new(&resolved_bin);
     configure_background_process(&mut command);
@@ -993,7 +993,7 @@ pub async fn profile_bitrate(
             "-i",
             url,
             "-t",
-            &stream_secs_str,
+            &sample_secs_str,
             "-f",
             "null",
             "-",
@@ -1009,10 +1009,23 @@ pub async fn profile_bitrate(
     let stderr_pipe = child.stderr.take();
     let stderr_reader = tokio::spawn(async move {
         use tokio::io::AsyncReadExt;
-        const MAX_STDERR_BYTES: usize = 1_024 * 1_024; // 1 MB
+        const MAX_RETAIN_BYTES: usize = 1_024 * 1_024; // 1 MB
         let mut buf = Vec::new();
         if let Some(mut pipe) = stderr_pipe {
-            let _ = (&mut pipe).take(MAX_STDERR_BYTES as u64).read_to_end(&mut buf).await;
+            // Drain stderr fully to prevent the child from blocking on a full
+            // pipe, but only retain up to MAX_RETAIN_BYTES for parsing.
+            let mut chunk = [0u8; 8192];
+            loop {
+                match pipe.read(&mut chunk).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let remaining = MAX_RETAIN_BYTES.saturating_sub(buf.len());
+                        if remaining > 0 {
+                            buf.extend_from_slice(&chunk[..n.min(remaining)]);
+                        }
+                    }
+                }
+            }
         }
         buf
     });
@@ -1086,7 +1099,7 @@ pub async fn profile_bitrate(
         return Ok("N/A".to_string());
     }
 
-    let bitrate_kbps = (total_bytes * 8) / 1000 / (stream_secs as u64);
+    let bitrate_kbps = (total_bytes * 8) / 1000 / sample_secs;
     Ok(format!("{} kbps", bitrate_kbps))
 }
 

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -1013,18 +1013,24 @@ pub async fn profile_bitrate(
         let mut buf = Vec::new();
         if let Some(mut pipe) = stderr_pipe {
             // Drain stderr fully to prevent the child from blocking on a full
-            // pipe, but only retain up to MAX_RETAIN_BYTES for parsing.
+            // pipe. Keep the *tail* (last MAX_RETAIN_BYTES) since the
+            // Statistics line we parse is written near process exit.
             let mut chunk = [0u8; 8192];
             loop {
                 match pipe.read(&mut chunk).await {
                     Ok(0) | Err(_) => break,
                     Ok(n) => {
-                        let remaining = MAX_RETAIN_BYTES.saturating_sub(buf.len());
-                        if remaining > 0 {
-                            buf.extend_from_slice(&chunk[..n.min(remaining)]);
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.len() > MAX_RETAIN_BYTES * 2 {
+                            let start = buf.len() - MAX_RETAIN_BYTES;
+                            buf.drain(..start);
                         }
                     }
                 }
+            }
+            if buf.len() > MAX_RETAIN_BYTES {
+                let start = buf.len() - MAX_RETAIN_BYTES;
+                buf.drain(..start);
             }
         }
         buf

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -15,6 +15,7 @@ const MAX_FFPROBE_OUTPUT_CHARS: usize = 16_000;
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 const FFPROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const FFMPEG_BITRATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const GRACEFUL_KILL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -31,6 +32,30 @@ const TARGET_TRIPLE: &str = "aarch64-unknown-linux-gnu";
 const TARGET_TRIPLE: &str = "x86_64-pc-windows-msvc";
 #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
 const TARGET_TRIPLE: &str = "aarch64-pc-windows-msvc";
+
+/// Send SIGTERM (Unix) and wait up to `grace` for the process to exit.
+/// Falls back to SIGKILL if the grace period expires or on Windows.
+async fn graceful_kill(child: &mut tokio::process::Child, grace: std::time::Duration) {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child.id() {
+            // SAFETY: pid is valid — the child has not been waited yet.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            match tokio::time::timeout(grace, child.wait()).await {
+                Ok(_) => return,
+                Err(_) => {
+                    log::debug!(
+                        "ffmpeg pid {pid} did not exit within {grace:?} after SIGTERM, sending SIGKILL"
+                    );
+                }
+            }
+        }
+    }
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
 
 /// Resolve the path to an executable, preferring the bundled sidecar binary
 /// over the system PATH. This bypasses the Tauri shell plugin which can
@@ -324,8 +349,7 @@ async fn run_tool_command(
                 return Err(AppError::Cancelled);
             }
             _ = tokio::time::sleep(timeout_duration) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
+                graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
 
                 let stderr_buf = stderr_reader.await.unwrap_or_default();
                 stdout_reader.abort();
@@ -996,8 +1020,7 @@ pub async fn profile_bitrate(
             return Err(AppError::Cancelled);
         }
         _ = tokio::time::sleep(timeout_duration) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
+            graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
             true
         }
         _status = child.wait() => {

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -1053,6 +1053,17 @@ pub async fn profile_bitrate(
         }
     }
 
+    // Fallback: regex scan for "<digits> bytes read" anywhere in stderr.
+    // Handles format variations across ffmpeg versions.
+    if total_bytes == 0 {
+        let re = regex::Regex::new(r"(\d+)\s+bytes\s+read").unwrap();
+        if let Some(caps) = re.captures(&stderr) {
+            if let Ok(bytes) = caps[1].parse::<u64>() {
+                total_bytes = bytes;
+            }
+        }
+    }
+
     if timed_out && total_bytes == 0 {
         return Err(AppError::Other(format!(
             "ffmpeg bitrate profiling timed out after {:.0}s (binary: {})",

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -976,6 +976,11 @@ pub async fn profile_bitrate(
 
     let resolved_bin = resolve_binary(app, "ffmpeg");
 
+    // Leave at least 15s of headroom within the timeout for connection
+    // setup and graceful shutdown. Minimum streaming duration is 3s.
+    let stream_secs = (timeout_duration.as_secs_f64() - 15.0).clamp(3.0, 10.0);
+    let stream_secs_str = format!("{:.0}", stream_secs);
+
     let mut command = tokio::process::Command::new(&resolved_bin);
     configure_background_process(&mut command);
 
@@ -988,7 +993,7 @@ pub async fn profile_bitrate(
             "-i",
             url,
             "-t",
-            "10",
+            &stream_secs_str,
             "-f",
             "null",
             "-",
@@ -1059,7 +1064,7 @@ pub async fn profile_bitrate(
         return Ok("N/A".to_string());
     }
 
-    let bitrate_kbps = (total_bytes * 8) / 1000 / 10;
+    let bitrate_kbps = (total_bytes * 8) / 1000 / (stream_secs as u64);
     Ok(format!("{} kbps", bitrate_kbps))
 }
 


### PR DESCRIPTION
## Summary

Ref #157 — bitrate profiling is unreliable, especially under concurrency. Root cause: ffmpeg is killed with SIGKILL on timeout, preventing it from writing the Statistics line we parse for bytes-read data.

- **SIGTERM before SIGKILL** — give ffmpeg 3s to flush final output on timeout, fall back to SIGKILL. Applied to both `profile_bitrate()` and `run_tool_command()`.
- **Adaptive streaming duration** — scale `-t` based on timeout (leaves 15s headroom for connection + shutdown) instead of hardcoded 10s.
- **Cap stderr buffer** — limit to 1 MB during bitrate profiling to prevent unbounded memory growth under concurrent profiling.
- **Regex fallback parsing** — handle ffmpeg stderr format variations across versions when the exact-match parser misses.
- **Log failures** — both `profile_bitrate()` and its caller now log warnings on failure instead of silently swallowing errors.
- **Release diagnostics permit early** — drop the semaphore permit after ffprobe+screenshot, before bitrate profiling. Cuts permit hold time from ~60s to ~30s.
- **Log panicked workers** — scan worker `JoinError`s are now logged instead of silently discarded.

## Test plan
- [x] All 156 existing tests pass (`cargo test`)
- [ ] Scan a playlist with bitrate profiling enabled, check terminal logs for new warnings
- [ ] Test with concurrency > 4 to verify improved bitrate success rate
- [ ] Verify SIGTERM path works: no "sending SIGKILL" debug messages during normal scans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * More graceful process termination during scans to reduce hanging child processes.
  * Adaptive bitrate profiling duration with bounded sampling and improved byte-count extraction.
  * Bounded stderr collection to reduce memory use and clearer fallback/error reporting for missing data.
  * Better diagnostics permit handling to avoid resource contention.
  * Worker join failures are now detected, logged individually, and reported as aggregated errors.

* **Chores**
  * Added a Unix-specific dependency to ensure compatibility on Unix platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->