### PR TITLE
Improve scan reliability and status accuracy

### DIFF
--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -108,7 +108,13 @@ async fn resolve_host_ip(host: &str) -> Option<IpAddr> {
     }
 
     let mut fallback: Option<IpAddr> = None;
-    let addresses = tokio::net::lookup_host((host, 0)).await.ok()?;
+    let addresses = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::net::lookup_host((host, 0)),
+    )
+    .await
+    .ok()?
+    .ok()?;
     for socket_address in addresses {
         let ip = socket_address.ip();
         if is_routable_ip(&ip) {

--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -756,7 +756,10 @@ async fn fetch_xtream_json_array(
         .await
     {
         Ok(resp) if resp.status().is_success() => match resp.bytes().await {
-            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+                log::warn!("Failed to parse Xtream {} JSON response: {}", label, e);
+                Vec::new()
+            }),
             Err(e) => {
                 log::warn!("Failed to read Xtream {} response: {}", label, e);
                 Vec::new()

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1486,7 +1486,7 @@ async fn execute_scan_run(
             let pressure = timeout_pressure.load(Ordering::Relaxed);
             let successes = adaptive_success_count.load(Ordering::Relaxed);
             let total_so_far = pressure + successes;
-            if total_so_far >= 10 {
+            if total_so_far >= 25 {
                 let pressure_ratio = pressure as f64 / total_so_far as f64;
                 let delay_ms = if pressure_ratio > 0.5 {
                     1000u64

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -1661,7 +1661,7 @@ encrypted.ts
 
     #[test]
     fn test_geoblock_status_classification() {
-        for status in [401u16, 403, 423, 426, 451] {
+        for status in [403u16, 423, 426, 451] {
             assert_eq!(
                 classify_non_ok_status(status, Some(321)),
                 VerifyResult::Geoblocked {
@@ -1670,6 +1670,14 @@ encrypted.ts
                 }
             );
         }
+        // 401 (Unauthorized) should be Dead, not Geoblocked
+        assert_eq!(
+            classify_non_ok_status(401, Some(321)),
+            VerifyResult::Dead {
+                latency_ms: Some(321),
+                reason: Some("HTTP 401".to_string()),
+            }
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -18,7 +18,7 @@ const MAX_PLAYLIST_DEPTH: u32 = 4;
 const MAX_REDIRECT_DEPTH: u32 = 10;
 /// HTTP status codes indicating potential geoblocking.
 const GEOBLOCK_STATUSES: &[u16] = &[403, 451, 426];
-const SECONDARY_GEOBLOCK_STATUSES: &[u16] = &[401, 423, 451];
+const SECONDARY_GEOBLOCK_STATUSES: &[u16] = &[423, 451];
 /// HTTP status codes that are typically transient and should be retried.
 const RETRYABLE_HTTP_STATUSES: &[u16] = &[408, 425, 429, 500, 502, 503, 504];
 const FFPROBE_LIVENESS_SCHEMES: &[&str] = &["rtsp", "rtsps", "rtmp", "rtmps"];

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -520,6 +520,7 @@ async fn verify(
     client: &reqwest::Client,
     target_url: &str,
     timeout_secs: f64,
+    deadline: Instant,
     playlist_depth: u32,
     redirect_depth: u32,
     visited: &mut HashSet<String>,
@@ -539,6 +540,16 @@ async fn verify(
             reason: Some("Redirect loop".to_string()),
         };
     }
+
+    // Use the shorter of per-request timeout and remaining deadline budget.
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return VerifyResult::Dead {
+            latency_ms: root_latency_ms,
+            reason: Some("Timeout".to_string()),
+        };
+    }
+    let effective_timeout = Duration::from_secs_f64(timeout_secs).min(remaining);
 
     let normalized = target_url
         .split('#')
@@ -564,7 +575,7 @@ async fn verify(
     let request = client
         .get(target_url)
         .headers(headers.clone())
-        .timeout(Duration::from_secs_f64(timeout_secs));
+        .timeout(effective_timeout);
 
     let request_started_at = Instant::now();
     let resp = match request.send().await {
@@ -624,6 +635,7 @@ async fn verify(
             client,
             &next_url,
             timeout_secs,
+            deadline,
             playlist_depth,
             redirect_depth + 1,
             visited,
@@ -681,6 +693,7 @@ async fn verify(
                 client,
                 &next_url,
                 timeout_secs,
+                deadline,
                 playlist_depth + 1,
                 redirect_depth,
                 visited,
@@ -1125,10 +1138,15 @@ pub async fn check_channel_status_with_debug(
                 );
                 let mut metrics = VerifyMetrics::default();
                 let mut visited = HashSet::new();
+                // Bound total verify time: redirects and playlist hops share
+                // a single deadline instead of each getting a fresh timeout.
+                // Allow up to 3x the per-request timeout for the entire chain.
+                let deadline = Instant::now() + Duration::from_secs_f64(current_timeout * 3.0);
                 let result = verify(
                     &client,
                     &url,
                     current_timeout,
+                    deadline,
                     0,
                     0,
                     &mut visited,

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -452,7 +452,6 @@ async fn read_stream(
 
     let mut bytes_read: u64 = 0;
     let mut observed_latency_ms = latency_ms;
-    let mut stable = true;
     let mut stream = response.bytes_stream();
 
     while let Some(chunk_result) = stream.next().await {
@@ -478,17 +477,12 @@ async fn read_stream(
                     };
                 }
             }
-            Err(_) => {
-                stable = false;
-                break;
+            Err(err) => {
+                return VerifyResult::Retry {
+                    reason: Some(format!("Stream read interrupted: {err}")),
+                };
             }
         }
-    }
-
-    if !stable {
-        return VerifyResult::Retry {
-            reason: Some("Stream read interrupted".to_string()),
-        };
     }
 
     // Fallback threshold logic

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -18,7 +18,7 @@ const MAX_PLAYLIST_DEPTH: u32 = 4;
 const MAX_REDIRECT_DEPTH: u32 = 10;
 /// HTTP status codes indicating potential geoblocking.
 const GEOBLOCK_STATUSES: &[u16] = &[403, 451, 426];
-const SECONDARY_GEOBLOCK_STATUSES: &[u16] = &[423, 451];
+const SECONDARY_GEOBLOCK_STATUSES: &[u16] = &[423];
 /// HTTP status codes that are typically transient and should be retried.
 const RETRYABLE_HTTP_STATUSES: &[u16] = &[408, 425, 429, 500, 502, 503, 504];
 const FFPROBE_LIVENESS_SCHEMES: &[&str] = &["rtsp", "rtsps", "rtmp", "rtmps"];


### PR DESCRIPTION
## Summary

Four targeted reliability fixes for the scan pipeline.

- **Bound total verify time across redirect chains** — Each recursive `verify()` hop was getting the full timeout as a fresh per-request timeout. With 10 redirects, worst case was 10x timeout per channel. Now the entire redirect/playlist chain shares a deadline of 3x the per-request timeout.
- **Stop classifying HTTP 401 as Geoblocked** — 401 (Unauthorized) means missing/invalid credentials, not geo-restriction. Users were misled into trying proxies when they needed to fix auth. Now correctly reported as Dead with "HTTP 401".
- **Raise adaptive throttle minimum sample** — The throttle engaged after just 10 channels, where 5 timeouts would trigger 1s delays. Raised to 25 to avoid premature throttle engagement while still protecting against sustained server pressure.
- **Add timeout to DNS lookup** — `resolve_host_ip()` had no explicit timeout on `lookup_host()`, relying on variable OS resolver timeouts. Wrapped in 5s timeout as defensive measure.

## Test plan
- [x] All 156 tests pass (`cargo test`)
- [ ] Scan a playlist with channels behind deep redirect chains — verify faster completion
- [ ] Check that 401 channels show as Dead, not Geoblocked
- [ ] Verify adaptive throttle doesn't engage prematurely on small playlists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added DNS resolution timeout to prevent indefinite hangs during lookup.
* Fixed geoblocking classification: HTTP 401 responses now correctly identified as dead streams rather than geoblocked.
* Improved streaming verification error handling with immediate error reporting.
* Implemented overall timeout limit for stream verification to prevent indefinite operations.

## Improvements
* Enhanced JSON parsing error visibility with warning logs.
* Adjusted concurrency tuning parameters for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->