### PR TITLE
Add diagnostic logging for checkpoint and parser edge cases

### DIFF
--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -383,6 +383,7 @@ fn parse_playlist_reader<R: BufRead>(
     let mut pending_channel = false;
     let mut pending_extinf: Option<String> = None;
     let mut pending_metadata: Vec<String> = Vec::new();
+    let mut orphaned_extinf = 0u32;
 
     for raw_line in reader.split(b'\n') {
         let raw_line = raw_line.map_err(AppError::Io)?;
@@ -394,6 +395,9 @@ fn parse_playlist_reader<R: BufRead>(
 
         if line.starts_with("#EXTINF") {
             // A new EXTINF supersedes any pending entry that never got a stream URL.
+            if pending_channel && pending_extinf.is_some() {
+                orphaned_extinf += 1;
+            }
             pending_channel = true;
             pending_extinf = None;
             pending_metadata.clear();
@@ -443,6 +447,15 @@ fn parse_playlist_reader<R: BufRead>(
         }
     }
 
+    if pending_channel && pending_extinf.is_some() {
+        orphaned_extinf += 1;
+    }
+    if orphaned_extinf > 0 {
+        log::warn!(
+            "{}: {orphaned_extinf} EXTINF entry/entries had no stream URL and were skipped",
+            file_path
+        );
+    }
     log::info!(
         "Parsed {} channels in {} groups",
         channels.len(),

--- a/src-tauri/src/engine/resume.rs
+++ b/src-tauri/src/engine/resume.rs
@@ -126,18 +126,32 @@ pub fn load_checkpoint_results(checkpoint_file: &str) -> Vec<ChannelResult> {
 
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(err) => {
+            log::warn!("Failed to read checkpoint file {checkpoint_file}: {err}");
+            return Vec::new();
+        }
     };
 
     let mut by_index: BTreeMap<usize, ChannelResult> = BTreeMap::new();
+    let mut malformed = 0u32;
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        if let Ok(result) = serde_json::from_str::<ChannelResult>(line) {
-            by_index.insert(result.index, result);
+        match serde_json::from_str::<ChannelResult>(line) {
+            Ok(result) => {
+                by_index.insert(result.index, result);
+            }
+            Err(_) => {
+                malformed += 1;
+            }
         }
+    }
+    if malformed > 0 {
+        log::warn!(
+            "Checkpoint {checkpoint_file}: skipped {malformed} malformed JSON line(s)"
+        );
     }
 
     by_index.into_values().collect()


### PR DESCRIPTION
## Summary

Two targeted diagnostic logging improvements for previously silent failure paths.

- **Checkpoint resume logging** — `load_checkpoint_results()` silently returned empty on file read errors and silently skipped malformed JSON lines. Now logs warnings with error details and a count of skipped lines, making it possible to diagnose why resume didn't recover expected channels.
- **Parser orphaned EXTINF logging** — When an EXTINF line has no following stream URL (consecutive EXTINF lines or EXTINF at end of file), the channel is silently dropped. Now tracks and logs the count of orphaned entries, helping users identify malformed playlists where channels are mysteriously missing.

## Test plan
- [x] All 156 tests pass (`cargo test`)
- [ ] Import a malformed M3U with consecutive EXTINF lines — verify warning appears in terminal
- [ ] Corrupt a checkpoint file with invalid JSON — verify warning on resume