### PR TITLE
Add macOS AirPlay support via AVKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,11 @@ jobs:
           workspaces: src-tauri
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        # Don't pass --locked: cargo-fuzz's pinned Cargo.lock pulls
+        # rustix 0.36.5, which references internal `rustc_attrs` that
+        # current nightlies refuse to compile. Letting cargo resolve a
+        # newer rustix patch unblocks the install.
+        run: cargo install cargo-fuzz
 
       - name: Download ffmpeg binaries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,10 @@ jobs:
         # Don't pass --locked: cargo-fuzz's pinned Cargo.lock pulls
         # rustix 0.36.5, which references internal `rustc_attrs` that
         # current nightlies refuse to compile. Letting cargo resolve a
-        # newer rustix patch unblocks the install.
-        run: cargo install cargo-fuzz
+        # newer rustix patch unblocks the install. We pin the cargo-fuzz
+        # version itself so CI behavior doesn't drift with upstream
+        # releases between PRs.
+        run: cargo install cargo-fuzz --version 0.13.1
 
       - name: Download ffmpeg binaries
         run: |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2517,6 +2517,7 @@ name = "iptv-checker"
 version = "1.4.3"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "cast-sender",
  "core-foundation 0.10.1",
  "csv",
@@ -2528,6 +2529,10 @@ dependencies = [
  "log",
  "mdns-sd",
  "objc2",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-av-kit",
+ "objc2-foundation",
  "rand 0.10.0",
  "regex",
  "reqwest",
@@ -3208,8 +3213,64 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b375b013b8a710c67770ca8b45993f0fc22ad7a4ff88e95101b1efbc0b7de4"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-media",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3225,11 +3286,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3279,6 +3363,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,6 +3387,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3319,6 +3431,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,6 +3450,18 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,11 @@ tauri-plugin-liquid-glass = "0.1"
 tauri-plugin-macos-haptics = "1.0.0"
 objc2 = "0.6.4"
 core-foundation = "0.10"
+objc2-foundation = "0.3.2"
+objc2-app-kit = "0.3.2"
+objc2-av-kit = "0.3.2"
+objc2-av-foundation = "0.3.2"
+block2 = "0.6.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"

--- a/src-tauri/src/commands/airplay.rs
+++ b/src-tauri/src/commands/airplay.rs
@@ -12,6 +12,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::engine::airplay;
 use crate::engine::media_proxy::{self, ReceiverProfile};
+use crate::engine::stream_proxy;
 use crate::error::AppError;
 use crate::models::airplay::{AirPlayMediaRequest, AirPlaySession};
 use crate::state::AppState;
@@ -59,6 +60,13 @@ pub async fn start_airplay(
     if let Some(active) = prior_session {
         active.stop_silent(&app).await;
     }
+
+    // Free the upstream slot before ffmpeg fetches: the local stream player
+    // may still be holding it via the localhost streaming proxy, and single-
+    // credential IPTV portals reject the second concurrent fetch with
+    // HTTP 458 ("too many connections"), aborting the cast remux before its
+    // manifest becomes ready.
+    stream_proxy::cancel_active_local_streams(state.inner()).await;
 
     let proxy_handle = media_proxy::start(
         app.clone(),

--- a/src-tauri/src/commands/airplay.rs
+++ b/src-tauri/src/commands/airplay.rs
@@ -1,0 +1,111 @@
+//! macOS-only AirPlay commands.
+//!
+//! Mirrors the shape of `commands/chromecast.rs`: the lifecycle lock
+//! serializes start/stop so concurrent invocations cannot orphan a session
+//! or proxy. Mutual exclusion with Chromecast is enforced here too — only
+//! one external receiver is active at a time, so starting AirPlay tears
+//! down any live cast first (and `cast_to_device` reciprocates).
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Manager};
+
+use crate::engine::airplay;
+use crate::engine::media_proxy::{self, ReceiverProfile};
+use crate::error::AppError;
+use crate::models::airplay::{AirPlayMediaRequest, AirPlaySession};
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn start_airplay(
+    app: AppHandle,
+    request: AirPlayMediaRequest,
+) -> Result<AirPlaySession, AppError> {
+    let state = app.state::<Arc<AppState>>();
+
+    // Serialize the entire teardown/start/store sequence so overlapping
+    // start_airplay / stop_airplay calls can't interleave.
+    let _lifecycle = state.airplay_lifecycle_lock.lock().await;
+
+    // Mutual exclusion with Chromecast: if a cast is live we must stop it
+    // before opening a new upstream slot. Take the lifecycle lock through
+    // the same path stop_cast uses so we don't race a concurrent cast op.
+    {
+        let _cast_lifecycle = state.cast_lifecycle_lock.lock().await;
+        let (session, proxy) = {
+            let mut guard = state.cast_state.lock().await;
+            (guard.session.take(), guard.proxy.take())
+        };
+        if let Some(handle) = proxy {
+            handle.shutdown();
+        }
+        if let Some(active) = session {
+            active.stop_silent().await;
+        }
+    }
+
+    // Tear down any prior AirPlay session before starting a new one. Silent
+    // stop because the new `Playing` event published by start_session is
+    // the source of truth — emitting `Stopped` here would race it.
+    let (prior_session, prior_proxy) = {
+        let mut guard = state.airplay_state.lock().await;
+        (guard.session.take(), guard.proxy.take())
+    };
+    if let Some(handle) = prior_proxy {
+        handle.shutdown();
+    }
+    if let Some(active) = prior_session {
+        active.stop_silent(&app).await;
+    }
+
+    let proxy_handle = media_proxy::start(
+        app.clone(),
+        request.original_url.clone(),
+        request.stream_kind,
+        ReceiverProfile::AirPlay,
+    )
+    .await?;
+    let proxy_url = proxy_handle.url.clone();
+
+    let session = match airplay::start_session(app.clone(), request.clone(), proxy_url).await {
+        Ok(s) => s,
+        Err(err) => {
+            proxy_handle.shutdown();
+            return Err(err);
+        }
+    };
+
+    let snapshot = session.snapshot();
+    {
+        let mut guard = state.airplay_state.lock().await;
+        guard.session = Some(session);
+        guard.proxy = Some(proxy_handle);
+    }
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub async fn stop_airplay(app: AppHandle) -> Result<(), AppError> {
+    let state = app.state::<Arc<AppState>>();
+
+    let _lifecycle = state.airplay_lifecycle_lock.lock().await;
+
+    let (session, proxy) = {
+        let mut guard = state.airplay_state.lock().await;
+        (guard.session.take(), guard.proxy.take())
+    };
+    if let Some(handle) = proxy {
+        handle.shutdown();
+    }
+    if let Some(active) = session {
+        active.stop(&app).await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_airplay_status(app: AppHandle) -> Option<AirPlaySession> {
+    let state = app.state::<Arc<AppState>>();
+    let guard = state.airplay_state.lock().await;
+    guard.session.as_ref().map(|active| active.snapshot())
+}

--- a/src-tauri/src/commands/airplay.rs
+++ b/src-tauri/src/commands/airplay.rs
@@ -23,15 +23,17 @@ pub async fn start_airplay(
 ) -> Result<AirPlaySession, AppError> {
     let state = app.state::<Arc<AppState>>();
 
-    // Serialize the entire teardown/start/store sequence so overlapping
-    // start_airplay / stop_airplay calls can't interleave.
+    // Lock order (must match `cast_to_device` to avoid ABBA): cast lifecycle
+    // lock first, then airplay lifecycle lock. The cast lock both serializes
+    // any concurrent start/stop on the cast side and lets us tear down a
+    // live cast session as part of the mutual-exclusion guarantee — only one
+    // external receiver may hold the upstream slot at a time.
+    let _cast_lifecycle = state.cast_lifecycle_lock.lock().await;
     let _lifecycle = state.airplay_lifecycle_lock.lock().await;
 
     // Mutual exclusion with Chromecast: if a cast is live we must stop it
-    // before opening a new upstream slot. Take the lifecycle lock through
-    // the same path stop_cast uses so we don't race a concurrent cast op.
+    // before opening a new upstream slot.
     {
-        let _cast_lifecycle = state.cast_lifecycle_lock.lock().await;
         let (session, proxy) = {
             let mut guard = state.cast_state.lock().await;
             (guard.session.take(), guard.proxy.take())
@@ -86,8 +88,17 @@ pub async fn start_airplay(
 
 #[tauri::command]
 pub async fn stop_airplay(app: AppHandle) -> Result<(), AppError> {
-    let state = app.state::<Arc<AppState>>();
+    teardown_airplay(&app).await;
+    Ok(())
+}
 
+/// Idempotent teardown of any live AirPlay session and proxy. Used both by
+/// the explicit `stop_airplay` command and by the AVPlayer window delegate
+/// when the user closes the window via the title-bar button (which would
+/// otherwise leave the session "playing" in app state while the window is
+/// gone).
+pub async fn teardown_airplay(app: &AppHandle) {
+    let state = app.state::<Arc<AppState>>();
     let _lifecycle = state.airplay_lifecycle_lock.lock().await;
 
     let (session, proxy) = {
@@ -98,9 +109,8 @@ pub async fn stop_airplay(app: AppHandle) -> Result<(), AppError> {
         handle.shutdown();
     }
     if let Some(active) = session {
-        active.stop(&app).await;
+        active.stop(app).await;
     }
-    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/chromecast.rs
+++ b/src-tauri/src/commands/chromecast.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Manager};
 
-use crate::engine::cast_proxy;
 use crate::engine::chromecast;
+use crate::engine::media_proxy::{self, ReceiverProfile};
 use crate::error::AppError;
 use crate::models::chromecast::{CastMediaRequest, CastSession, ChromecastDevice};
 use crate::state::AppState;
@@ -54,10 +54,11 @@ pub async fn cast_to_device(
     };
 
     if let Some((mut active, prior_proxy)) = same_device_take {
-        match cast_proxy::start(
+        match media_proxy::start(
             app.clone(),
             request.original_url.clone(),
             request.stream_kind,
+            ReceiverProfile::Chromecast,
         )
         .await
         {
@@ -122,10 +123,11 @@ pub async fn cast_to_device(
         }
     }
 
-    let proxy_handle = cast_proxy::start(
+    let proxy_handle = media_proxy::start(
         app.clone(),
         request.original_url.clone(),
         request.stream_kind,
+        ReceiverProfile::Chromecast,
     )
     .await?;
     let cast_url = proxy_handle.url.clone();

--- a/src-tauri/src/commands/chromecast.rs
+++ b/src-tauri/src/commands/chromecast.rs
@@ -28,6 +28,25 @@ pub async fn cast_to_device(
     // cast_to_device / stop_cast calls cannot interleave and orphan a session.
     let _lifecycle = state.cast_lifecycle_lock.lock().await;
 
+    // Mutual exclusion with AirPlay (macOS only): a single upstream slot
+    // can't service both an Apple TV and a Chromecast, and the user only
+    // has eyes on one TV. Take the AirPlay lifecycle lock so we don't race
+    // a concurrent start_airplay.
+    #[cfg(target_os = "macos")]
+    {
+        let _airplay_lifecycle = state.airplay_lifecycle_lock.lock().await;
+        let (airplay_session, airplay_proxy) = {
+            let mut guard = state.airplay_state.lock().await;
+            (guard.session.take(), guard.proxy.take())
+        };
+        if let Some(handle) = airplay_proxy {
+            handle.shutdown();
+        }
+        if let Some(active) = airplay_session {
+            active.stop_silent(&app).await;
+        }
+    }
+
     // Same-device redirect? Try a seamless media swap on the live receiver
     // session — sends a fresh LOAD on the existing MediaController so the TV
     // doesn't flash back to its launcher between channel changes.

--- a/src-tauri/src/commands/chromecast.rs
+++ b/src-tauri/src/commands/chromecast.rs
@@ -5,6 +5,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::engine::chromecast;
 use crate::engine::media_proxy::{self, ReceiverProfile};
+use crate::engine::stream_proxy;
 use crate::error::AppError;
 use crate::models::chromecast::{CastMediaRequest, CastSession, ChromecastDevice};
 use crate::state::AppState;
@@ -73,6 +74,11 @@ pub async fn cast_to_device(
     };
 
     if let Some((mut active, prior_proxy)) = same_device_take {
+        // Same as the fresh-launch path below: drop any local-player upstream
+        // fetch so single-credential IPTV portals don't reject ffmpeg's load
+        // with HTTP 458.
+        stream_proxy::cancel_active_local_streams(state.inner()).await;
+
         match media_proxy::start(
             app.clone(),
             request.original_url.clone(),
@@ -141,6 +147,10 @@ pub async fn cast_to_device(
             active.stop_silent().await;
         }
     }
+
+    // Release the upstream slot before ffmpeg connects (HTTP 458 mitigation
+    // on single-credential IPTV portals — see comment in `start_airplay`).
+    stream_proxy::cancel_active_local_streams(state.inner()).await;
 
     let proxy_handle = media_proxy::start(
         app.clone(),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "macos")]
+pub mod airplay;
 pub mod chromecast;
 pub mod export;
 pub mod history;

--- a/src-tauri/src/engine/airplay.rs
+++ b/src-tauri/src/engine/airplay.rs
@@ -1,0 +1,219 @@
+//! macOS-only AirPlay sender bridge built on AVKit.
+//!
+//! Hands the proxy URL to AVKit and lets Apple's frameworks handle discovery,
+//! pairing, and the AirPlay protocol. The receiver (Apple TV / AirPlay 2 audio
+//! device) is selected by the user from the AVPlayerView's HUD route picker.
+//!
+//! Why we still need the media proxy on this path:
+//! - Apple TV in URL-mode AirPlay does NOT forward `AVURLAsset` HTTP headers
+//!   to the receiver-side fetcher. It opens its own request with its own
+//!   `AppleCoreMedia/...` UA, so IPTV portals that filter on UA fail.
+//! - Single-credential IPTV servers can't service both the local AVPlayer and
+//!   the Apple TV simultaneously without contention. The proxy fan-out keeps
+//!   one upstream connection for both.
+//!
+//! Threading: every AVFoundation/AppKit call MUST run on the AppKit main
+//! thread. We dispatch to it via [`tauri::AppHandle::run_on_main_thread`] and
+//! wrap the resulting `Retained<...>` handles in [`MainOnly`] so the session
+//! struct can live in `AppState` (which is shared across tokio workers).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use objc2::rc::Retained;
+use objc2::MainThreadMarker;
+use objc2_app_kit::{NSBackingStoreType, NSWindow, NSWindowStyleMask};
+use objc2_av_foundation::{AVPlayer, AVPlayerItem, AVURLAsset};
+use objc2_av_kit::{AVPlayerView, AVPlayerViewControlsStyle};
+use objc2_foundation::{NSPoint, NSRect, NSSize, NSString, NSURL};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::oneshot;
+
+use crate::error::AppError;
+use crate::models::airplay::{AirPlayMediaRequest, AirPlaySession, AirPlaySessionState};
+
+pub const AIRPLAY_STATUS_EVENT: &str = "airplay://status";
+
+/// `Retained<NSObject>` is `!Send + !Sync` because Cocoa objects must be
+/// touched from the thread that created them. We uphold that invariant by
+/// dispatching every access through `AppHandle::run_on_main_thread` — never
+/// dereferencing the inner field on a worker thread.
+struct MainOnly<T>(T);
+
+unsafe impl<T> Send for MainOnly<T> {}
+unsafe impl<T> Sync for MainOnly<T> {}
+
+pub struct ActiveAirPlaySession {
+    snapshot: AirPlaySession,
+    window: MainOnly<Retained<NSWindow>>,
+    player: MainOnly<Retained<AVPlayer>>,
+    stopped: Arc<AtomicBool>,
+}
+
+impl ActiveAirPlaySession {
+    pub fn snapshot(&self) -> AirPlaySession {
+        self.snapshot.clone()
+    }
+
+    /// Tear down the session: pause the player, close the window, drop the
+    /// strong refs (which deallocates on the main thread). Idempotent — a
+    /// second call after the user closes the window is a no-op.
+    pub async fn stop(self, app: &AppHandle) {
+        self.stop_with_state(app, AirPlaySessionState::Stopped).await;
+    }
+
+    /// Same as `stop` but doesn't emit a status event. Used when a fresh
+    /// session is starting immediately on top of this one — the new
+    /// `Playing` event is the source of truth and a stale `Stopped` would
+    /// flicker the UI.
+    pub async fn stop_silent(self, app: &AppHandle) {
+        self.stop_inner(app, None).await;
+    }
+
+    async fn stop_with_state(self, app: &AppHandle, terminal: AirPlaySessionState) {
+        self.stop_inner(app, Some(terminal)).await;
+    }
+
+    async fn stop_inner(self, app: &AppHandle, terminal: Option<AirPlaySessionState>) {
+        if self.stopped.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let ActiveAirPlaySession {
+            snapshot,
+            window,
+            player,
+            stopped: _,
+        } = self;
+        let _ = app.run_on_main_thread(move || {
+            // Move both into the closure so the Retained<...> handles drop
+            // here (on the main thread) after pause/close.
+            let player = player;
+            let window = window;
+            unsafe { player.0.pause() };
+            window.0.close();
+            // refs drop at end-of-scope on the main thread
+        });
+        if let Some(state) = terminal {
+            let mut final_snapshot = snapshot;
+            final_snapshot.state = state;
+            let _ = app.emit(AIRPLAY_STATUS_EVENT, final_snapshot);
+        }
+    }
+}
+
+/// Start a new AirPlay session. Builds an `AVPlayer` over the LAN-bound proxy
+/// URL and presents it in a fresh `AVPlayerView` inside an `NSWindow`. The
+/// view's HUD includes the AirPlay route picker so the user can pick an
+/// Apple TV (or any AirPlay-capable receiver). Local playback runs in the
+/// window until the user routes to a receiver, after which AVPlayer
+/// transparently swaps to "external playback" mode and the local view goes
+/// quiet.
+///
+/// All UI is created on the AppKit main thread. The returned handle holds
+/// strong refs to the window and player so they survive past this call;
+/// dropping the handle (or calling `stop`) tears the session down.
+pub async fn start_session(
+    app: AppHandle,
+    request: AirPlayMediaRequest,
+    proxy_url: String,
+) -> Result<ActiveAirPlaySession, AppError> {
+    let (tx, rx) = oneshot::channel::<
+        Result<(MainOnly<Retained<NSWindow>>, MainOnly<Retained<AVPlayer>>), String>,
+    >();
+
+    let proxy_url_for_setup = proxy_url.clone();
+    let title = request
+        .channel_name
+        .clone()
+        .unwrap_or_else(|| "AirPlay".to_string());
+
+    app.run_on_main_thread(move || {
+        let _ = tx.send(build_session_on_main_thread(&proxy_url_for_setup, &title));
+    })
+    .map_err(|err| {
+        AppError::Other(format!(
+            "Failed to dispatch AirPlay setup to main thread: {err}"
+        ))
+    })?;
+
+    let (window, player) = rx
+        .await
+        .map_err(|_| {
+            AppError::Other("AirPlay main-thread setup channel closed unexpectedly".to_string())
+        })?
+        .map_err(AppError::Other)?;
+
+    let snapshot = AirPlaySession {
+        state: AirPlaySessionState::Playing,
+        stream_url: proxy_url,
+        channel_name: request.channel_name,
+        channel_logo: request.channel_logo,
+        error_message: None,
+        external_playback_active: false,
+    };
+    let _ = app.emit(AIRPLAY_STATUS_EVENT, snapshot.clone());
+
+    Ok(ActiveAirPlaySession {
+        snapshot,
+        window,
+        player,
+        stopped: Arc::new(AtomicBool::new(false)),
+    })
+}
+
+/// Construct the AVKit object graph (NSURL → AVURLAsset → AVPlayerItem →
+/// AVPlayer → AVPlayerView → NSWindow), present the window, and start
+/// playback. Returns the `Retained<...>` window and player so the caller
+/// can keep them alive and tear them down on stop.
+fn build_session_on_main_thread(
+    url: &str,
+    title: &str,
+) -> Result<(MainOnly<Retained<NSWindow>>, MainOnly<Retained<AVPlayer>>), String> {
+    let mtm = MainThreadMarker::new()
+        .ok_or_else(|| "build_session_on_main_thread must run on the main thread".to_string())?;
+
+    unsafe {
+        let url_ns = NSString::from_str(url);
+        let nsurl =
+            NSURL::URLWithString(&url_ns).ok_or_else(|| format!("Invalid AirPlay URL: {url}"))?;
+
+        let asset = AVURLAsset::assetWithURL(&nsurl);
+        let item = AVPlayerItem::playerItemWithAsset(&asset, mtm);
+        let player = AVPlayer::playerWithPlayerItem(Some(&item), mtm);
+        // Default is YES, but we set explicitly so future contributors can see
+        // the route picker is intentional rather than default fallout.
+        player.setAllowsExternalPlayback(true);
+
+        let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(800.0, 450.0));
+        let view: Retained<AVPlayerView> =
+            AVPlayerView::initWithFrame(mtm.alloc::<AVPlayerView>(), frame);
+        view.setPlayer(Some(&player));
+        view.setControlsStyle(AVPlayerViewControlsStyle::Floating);
+
+        let style_mask = NSWindowStyleMask::Titled
+            | NSWindowStyleMask::Closable
+            | NSWindowStyleMask::Resizable
+            | NSWindowStyleMask::Miniaturizable;
+        let window: Retained<NSWindow> = NSWindow::initWithContentRect_styleMask_backing_defer(
+            mtm.alloc::<NSWindow>(),
+            frame,
+            style_mask,
+            NSBackingStoreType::Buffered,
+            false,
+        );
+        // Don't auto-release on close — we keep our own strong ref and want
+        // explicit teardown control. Without this, closing the window from
+        // the title bar would deallocate a window we still hold a Retained
+        // to, leading to a use-after-free when stop() runs.
+        window.setReleasedWhenClosed(false);
+        let title_ns = NSString::from_str(title);
+        window.setTitle(&title_ns);
+        window.setContentView(Some(&view));
+        window.center();
+        window.makeKeyAndOrderFront(None);
+
+        player.play();
+
+        Ok((MainOnly(window), MainOnly(player)))
+    }
+}

--- a/src-tauri/src/engine/airplay.rs
+++ b/src-tauri/src/engine/airplay.rs
@@ -17,15 +17,19 @@
 //! wrap the resulting `Retained<...>` handles in [`MainOnly`] so the session
 //! struct can live in `AppState` (which is shared across tokio workers).
 
+use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use objc2::rc::Retained;
-use objc2::MainThreadMarker;
-use objc2_app_kit::{NSBackingStoreType, NSWindow, NSWindowStyleMask};
+use objc2::runtime::ProtocolObject;
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{NSBackingStoreType, NSWindow, NSWindowDelegate, NSWindowStyleMask};
 use objc2_av_foundation::{AVPlayer, AVPlayerItem, AVURLAsset};
 use objc2_av_kit::{AVPlayerView, AVPlayerViewControlsStyle};
-use objc2_foundation::{NSPoint, NSRect, NSSize, NSString, NSURL};
+use objc2_foundation::{
+    NSNotification, NSObject, NSObjectProtocol, NSPoint, NSRect, NSSize, NSString, NSURL,
+};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::oneshot;
 
@@ -47,6 +51,10 @@ pub struct ActiveAirPlaySession {
     snapshot: AirPlaySession,
     window: MainOnly<Retained<NSWindow>>,
     player: MainOnly<Retained<AVPlayer>>,
+    /// Strong ref to the window delegate. `NSWindow.setDelegate` holds a
+    /// weak reference, so dropping this would leave the window with a
+    /// dangling delegate pointer the moment the user closes the window.
+    _delegate: MainOnly<Retained<AirPlayWindowDelegate>>,
     stopped: Arc<AtomicBool>,
 }
 
@@ -82,22 +90,87 @@ impl ActiveAirPlaySession {
             snapshot,
             window,
             player,
+            _delegate,
             stopped: _,
         } = self;
-        let _ = app.run_on_main_thread(move || {
-            // Move both into the closure so the Retained<...> handles drop
-            // here (on the main thread) after pause/close.
-            let player = player;
-            let window = window;
-            unsafe { player.0.pause() };
-            window.0.close();
-            // refs drop at end-of-scope on the main thread
-        });
+        // Wrap in ManuallyDrop so a `run_on_main_thread` failure (e.g. event
+        // loop already shutting down) doesn't drop the `Retained<...>`
+        // handles on this tokio worker — the ObjC release MUST run on the
+        // main thread per the `MainOnly` invariant.
+        let player = ManuallyDrop::new(player);
+        let window = ManuallyDrop::new(window);
+        let delegate = ManuallyDrop::new(_delegate);
+        if app
+            .run_on_main_thread(move || {
+                // Take ownership back so the handles drop here, on the main
+                // thread, after pause/close.
+                let player = ManuallyDrop::into_inner(player);
+                let window = ManuallyDrop::into_inner(window);
+                let _delegate = ManuallyDrop::into_inner(delegate);
+                unsafe { player.0.pause() };
+                window.0.close();
+            })
+            .is_err()
+        {
+            // Event loop is gone. Releasing the handles off-thread would
+            // violate the MainOnly contract; intentionally leak them and let
+            // the OS reclaim memory at process exit.
+            log::warn!(
+                "[AirPlay] run_on_main_thread failed during teardown; leaking Cocoa handles"
+            );
+        }
         if let Some(state) = terminal {
             let mut final_snapshot = snapshot;
             final_snapshot.state = state;
             let _ = app.emit(AIRPLAY_STATUS_EVENT, final_snapshot);
         }
+    }
+}
+
+/// Ivars for the window delegate: an `AppHandle` so we can spawn the
+/// async teardown when the user closes the window, plus a one-shot guard
+/// so a rapid close → re-close (or our own programmatic close from
+/// `stop_inner`) doesn't double-fire the teardown.
+struct AirPlayWindowDelegateIvars {
+    app: AppHandle,
+    fired: AtomicBool,
+}
+
+define_class!(
+    #[unsafe(super = NSObject)]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = AirPlayWindowDelegateIvars]
+    struct AirPlayWindowDelegate;
+
+    unsafe impl NSObjectProtocol for AirPlayWindowDelegate {}
+
+    unsafe impl NSWindowDelegate for AirPlayWindowDelegate {
+        // Fires on the main thread when the user clicks the title-bar
+        // close button (or any other path that closes the NSWindow). We
+        // spawn the same teardown the explicit `stop_airplay` command
+        // runs so the proxy is shut down and AppState is cleared — without
+        // this the session would stay "playing" in app state after the
+        // window vanished.
+        #[unsafe(method(windowWillClose:))]
+        fn window_will_close(&self, _notification: &NSNotification) {
+            if self.ivars().fired.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            let app = self.ivars().app.clone();
+            tauri::async_runtime::spawn(async move {
+                crate::commands::airplay::teardown_airplay(&app).await;
+            });
+        }
+    }
+);
+
+impl AirPlayWindowDelegate {
+    fn new(mtm: MainThreadMarker, app: AppHandle) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(AirPlayWindowDelegateIvars {
+            app,
+            fired: AtomicBool::new(false),
+        });
+        unsafe { msg_send![super(this), init] }
     }
 }
 
@@ -117,18 +190,29 @@ pub async fn start_session(
     request: AirPlayMediaRequest,
     proxy_url: String,
 ) -> Result<ActiveAirPlaySession, AppError> {
-    let (tx, rx) = oneshot::channel::<
-        Result<(MainOnly<Retained<NSWindow>>, MainOnly<Retained<AVPlayer>>), String>,
-    >();
+    type SetupResult = Result<
+        (
+            MainOnly<Retained<NSWindow>>,
+            MainOnly<Retained<AVPlayer>>,
+            MainOnly<Retained<AirPlayWindowDelegate>>,
+        ),
+        String,
+    >;
+    let (tx, rx) = oneshot::channel::<SetupResult>();
 
     let proxy_url_for_setup = proxy_url.clone();
     let title = request
         .channel_name
         .clone()
         .unwrap_or_else(|| "AirPlay".to_string());
+    let app_for_setup = app.clone();
 
     app.run_on_main_thread(move || {
-        let _ = tx.send(build_session_on_main_thread(&proxy_url_for_setup, &title));
+        let _ = tx.send(build_session_on_main_thread(
+            app_for_setup,
+            &proxy_url_for_setup,
+            &title,
+        ));
     })
     .map_err(|err| {
         AppError::Other(format!(
@@ -136,7 +220,7 @@ pub async fn start_session(
         ))
     })?;
 
-    let (window, player) = rx
+    let (window, player, delegate) = rx
         .await
         .map_err(|_| {
             AppError::Other("AirPlay main-thread setup channel closed unexpectedly".to_string())
@@ -157,6 +241,7 @@ pub async fn start_session(
         snapshot,
         window,
         player,
+        _delegate: delegate,
         stopped: Arc::new(AtomicBool::new(false)),
     })
 }
@@ -166,9 +251,17 @@ pub async fn start_session(
 /// playback. Returns the `Retained<...>` window and player so the caller
 /// can keep them alive and tear them down on stop.
 fn build_session_on_main_thread(
+    app: AppHandle,
     url: &str,
     title: &str,
-) -> Result<(MainOnly<Retained<NSWindow>>, MainOnly<Retained<AVPlayer>>), String> {
+) -> Result<
+    (
+        MainOnly<Retained<NSWindow>>,
+        MainOnly<Retained<AVPlayer>>,
+        MainOnly<Retained<AirPlayWindowDelegate>>,
+    ),
+    String,
+> {
     let mtm = MainThreadMarker::new()
         .ok_or_else(|| "build_session_on_main_thread must run on the main thread".to_string())?;
 
@@ -210,10 +303,21 @@ fn build_session_on_main_thread(
         window.setTitle(&title_ns);
         window.setContentView(Some(&view));
         window.center();
+
+        // Attach a window delegate so user-driven closes (title-bar "×")
+        // route through the same teardown path as the explicit stop button,
+        // tearing down the proxy and clearing AppState. NSWindow's delegate
+        // ref is weak — the strong ref we return below keeps it alive for
+        // the lifetime of the session.
+        let delegate = AirPlayWindowDelegate::new(mtm, app);
+        let delegate_proto: &ProtocolObject<dyn NSWindowDelegate> =
+            ProtocolObject::from_ref(&*delegate);
+        window.setDelegate(Some(delegate_proto));
+
         window.makeKeyAndOrderFront(None);
 
         player.play();
 
-        Ok((MainOnly(window), MainOnly(player)))
+        Ok((MainOnly(window), MainOnly(player), MainOnly(delegate)))
     }
 }

--- a/src-tauri/src/engine/media_proxy.rs
+++ b/src-tauri/src/engine/media_proxy.rs
@@ -679,7 +679,7 @@ async fn wait_for_manifest(
         }
         if cancel.is_cancelled() {
             return Err(AppError::Other(
-                "Cast remux was cancelled before manifest became ready".to_string(),
+                "Receiver remux was cancelled before manifest became ready".to_string(),
             ));
         }
         if tokio::time::Instant::now() >= deadline {

--- a/src-tauri/src/engine/media_proxy.rs
+++ b/src-tauri/src/engine/media_proxy.rs
@@ -1,7 +1,8 @@
-//! LAN-bound HTTP proxy used to stream upstream IPTV content to a Chromecast.
+//! LAN-bound HTTP proxy used to stream upstream IPTV content to a media
+//! receiver (Chromecast or AirPlay).
 //!
 //! Unlike the in-app `stream_proxy` (which binds to 127.0.0.1 for the
-//! webview), the cast proxy binds to `0.0.0.0` so the Chromecast on the LAN
+//! webview), the media proxy binds to `0.0.0.0` so receivers on the LAN
 //! can reach it. Each session generates a fresh random token; only requests
 //! whose path starts with `/cast/<token>/` are served, so this short-lived,
 //! per-session listener does not become an open relay.
@@ -14,12 +15,12 @@
 //! - **Remux** (`/cast/<token>/hls/<manifest>` + sibling segment files):
 //!   used when the upstream is MPEG-TS. ffmpeg is spawned in copy mode to
 //!   produce a sliding-window manifest in a temp directory, which is then
-//!   served from disk. H.264 streams produce HLS+TS (`playlist.m3u8` + .ts);
-//!   HEVC streams produce DASH+fMP4 (`manifest.mpd` + .m4s) because CAFv3's
-//!   default HLS player (MPL) can't render fMP4 segments — DASH on the same
-//!   receiver uses Shaka, which handles fMP4 + HEVC natively.
+//!   served from disk. The container choice depends on the [`ReceiverProfile`]:
+//!   Chromecast renders H.264 as HLS+TS but needs DASH+fMP4 for HEVC (CAFv3's
+//!   MPL can't render fMP4 in HLS); AirPlay's AVPlayer takes HLS+fMP4+HEVC
+//!   natively, so HEVC stays on HLS but with fMP4 segments.
 //!
-//! Lifecycle: [`start`] returns a [`CastProxyHandle`] containing the bound
+//! Lifecycle: [`start`] returns a [`MediaProxyHandle`] containing the bound
 //! address and a cancel guard; dropping the handle (or calling `shutdown`)
 //! tears the listener down, aborts in-flight forwarders, kills ffmpeg, and
 //! removes the temp directory.
@@ -57,7 +58,26 @@ const REMUX_PLAYLIST_POLL_INTERVAL: Duration = Duration::from_millis(150);
 /// stream) cannot OOM the proxy.
 const MAX_MANIFEST_BYTES: u64 = 2 * 1024 * 1024;
 
-pub struct CastProxyHandle {
+/// Which receiver this proxy is feeding. The receivers diverge on:
+/// - **CORS preflight**: CAFv3 receivers issue an `OPTIONS` before fetching;
+///   AVPlayer is native and doesn't.
+/// - **HEVC remux container**: Chromecast's MPL can't render fMP4 in HLS, so
+///   HEVC must be served as DASH+fMP4 to dispatch to Shaka. Apple TV's HLS
+///   engine takes fMP4+HEVC natively, so HEVC stays on HLS but with fMP4
+///   segments (avoiding the DASH muxer's stricter timestamp rules).
+/// - **HEVC sample-entry tag**: Chromecast/Shaka rejects `hev1`; both Cast
+///   and Apple TV accept `hvc1`. We rewrite to `hvc1` for Cast; Apple TV
+///   tolerates either, so we leave the default for AirPlay.
+/// - **Audio passthrough set**: CAF MPL emits LoadFailed on EAC3/AC3/MP2-in-TS,
+///   so Cast transcodes anything not AAC. Apple TV's HLS spec accepts AAC,
+///   AC3, EAC3, and MP3 natively; only MP2 still needs a transcode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiverProfile {
+    Chromecast,
+    AirPlay,
+}
+
+pub struct MediaProxyHandle {
     pub url: String,
     pub host: IpAddr,
     pub port: u16,
@@ -71,13 +91,13 @@ pub struct CastProxyHandle {
     remux: Arc<Mutex<Option<RemuxState>>>,
 }
 
-impl CastProxyHandle {
+impl MediaProxyHandle {
     pub fn shutdown(&self) {
         self.cancel.cancel();
     }
 }
 
-impl Drop for CastProxyHandle {
+impl Drop for MediaProxyHandle {
     fn drop(&mut self) {
         self.cancel.cancel();
         // Best-effort sync cleanup: try to lock without awaiting and clean up
@@ -137,7 +157,7 @@ pub fn detect_lan_ip() -> Option<IpAddr> {
             // Fall through to interface scan.
         }
         Err(err) => {
-            log::debug!("[CastProxy] local_ip() returned error: {err}");
+            log::debug!("[MediaProxy] local_ip() returned error: {err}");
         }
     }
     match local_ip_address::list_afinet_netifas() {
@@ -149,11 +169,11 @@ pub fn detect_lan_ip() -> Option<IpAddr> {
                     }
                 }
             }
-            log::warn!("[CastProxy] No usable IPv4 interface found");
+            log::warn!("[MediaProxy] No usable IPv4 interface found");
             None
         }
         Err(err) => {
-            log::warn!("[CastProxy] Failed to enumerate network interfaces: {err}");
+            log::warn!("[MediaProxy] Failed to enumerate network interfaces: {err}");
             None
         }
     }
@@ -161,12 +181,14 @@ pub fn detect_lan_ip() -> Option<IpAddr> {
 
 /// Bind a fresh LAN-facing listener and serve upstream content for a single
 /// cast URL until cancelled. For MPEG-TS sources, spawns ffmpeg to remux into
-/// HLS so Chromecast can consume the stream.
+/// a manifest the receiver can consume — the container choice is profile-driven
+/// (see [`ReceiverProfile`]).
 pub async fn start(
     app: AppHandle,
     upstream_url: String,
     stream_kind: CastStreamKind,
-) -> Result<CastProxyHandle, AppError> {
+    profile: ReceiverProfile,
+) -> Result<MediaProxyHandle, AppError> {
     let token = generate_token();
     let lan_ip = detect_lan_ip()
         .ok_or_else(|| AppError::Other("Could not determine LAN IP for cast proxy".to_string()))?;
@@ -211,6 +233,7 @@ pub async fn start(
             cancel.clone(),
             remux_state.clone(),
             client.clone(),
+            profile,
         )
         .await?;
         (
@@ -225,9 +248,10 @@ pub async fn start(
     };
 
     log::info!(
-        "[CastProxy] Listening on 0.0.0.0:{port} (advertising {lan_ip}:{port}) for {} (mode={:?})",
+        "[MediaProxy] Listening on 0.0.0.0:{port} (advertising {lan_ip}:{port}) for {} (mode={:?}, profile={:?})",
         redact_url(&upstream_url),
-        stream_kind
+        stream_kind,
+        profile
     );
 
     let cancel_for_loop = cancel.clone();
@@ -242,7 +266,7 @@ pub async fn start(
         loop {
             tokio::select! {
                 _ = cancel_for_loop.cancelled() => {
-                    log::info!("[CastProxy] Listener on port {port} cancelled");
+                    log::info!("[MediaProxy] Listener on port {port} cancelled");
                     // Clean up remux state if any
                     let mut guard = remux_for_loop.lock().await;
                     if let Some(state) = guard.take() {
@@ -254,7 +278,7 @@ pub async fn start(
                     let (socket, peer) = match accept {
                         Ok(pair) => pair,
                         Err(err) => {
-                            log::warn!("[CastProxy] Accept error: {err}");
+                            log::warn!("[MediaProxy] Accept error: {err}");
                             continue;
                         }
                     };
@@ -276,10 +300,11 @@ pub async fn start(
                             client_for_conn,
                             user_agent_for_conn,
                             resolved_origin_for_conn,
+                            profile,
                         )
                         .await
                         {
-                            log::debug!("[CastProxy] Connection from {peer} ended: {err}");
+                            log::debug!("[MediaProxy] Connection from {peer} ended: {err}");
                         }
                     });
                 }
@@ -287,7 +312,7 @@ pub async fn start(
         }
     });
 
-    Ok(CastProxyHandle {
+    Ok(MediaProxyHandle {
         url: cast_url,
         host: lan_ip,
         port,
@@ -303,9 +328,10 @@ struct RemuxStartInfo {
     is_dash: bool,
 }
 
-/// Spawn ffmpeg to remux the upstream MPEG-TS into a sliding-window HLS
-/// playlist on disk. Waits for the playlist file to appear (so the Cast
-/// device's first GET doesn't 404) before returning.
+/// Spawn ffmpeg to remux the upstream MPEG-TS into a sliding-window manifest
+/// on disk. Waits for the manifest file to appear (so the receiver's first GET
+/// doesn't 404) before returning. Container choice depends on `profile` and
+/// the upstream codec — see [`ReceiverProfile`].
 async fn start_remux(
     app: AppHandle,
     upstream_url: String,
@@ -313,6 +339,7 @@ async fn start_remux(
     cancel: CancellationToken,
     remux_state: Arc<Mutex<Option<RemuxState>>>,
     client: Arc<reqwest::Client>,
+    profile: ReceiverProfile,
 ) -> Result<RemuxStartInfo, AppError> {
     let tmpdir = std::env::temp_dir().join(format!("iptv-cast-{token}"));
     std::fs::create_dir_all(&tmpdir).map_err(AppError::Io)?;
@@ -349,15 +376,24 @@ async fn start_remux(
         .as_deref()
         .map(|c| matches!(c, "hevc" | "h265"))
         .unwrap_or(false);
-    // AAC is the only TS audio codec MPL plays reliably; transcode anything
-    // else (EAC3, AC3, MP2, MP3, Opus, …) to AAC. When the probe is empty we
-    // assume copy is fine — the H.264+AAC default. HEVC/DASH always
-    // transcodes regardless of this flag (mp4 muxer needs `mp4a`).
-    let audio_needs_transcode = audio_codec
-        .as_deref()
-        .map(|c| !matches!(c, "aac"))
-        .unwrap_or(false);
-    let manifest_path = if is_hevc {
+    // Profile-driven audio gate. Cast's MPL emits LoadFailed on
+    // EAC3/AC3/MP2-in-TS, so the Cast set is "AAC only". Apple HLS spec
+    // accepts AAC/AC3/EAC3/MP3 natively; only MP2 still needs transcoding.
+    // Empty probe falls through to "copy" — correct for the well-tested
+    // H.264+AAC default. HEVC always transcodes (see HEVC branch below).
+    let audio_passthrough = match (profile, audio_codec.as_deref()) {
+        (_, None) => true,
+        (ReceiverProfile::Chromecast, Some(c)) => matches!(c, "aac"),
+        (ReceiverProfile::AirPlay, Some(c)) => matches!(c, "aac" | "ac3" | "eac3" | "mp3"),
+    };
+    let audio_needs_transcode = !audio_passthrough;
+    // For HEVC: Chromecast must use DASH+fMP4 (CAFv3 MPL can't render fMP4
+    // in HLS — Shaka picks up DASH and renders it fine). Apple TV's HLS
+    // engine is the reference HEVC-fMP4-in-HLS platform, so AirPlay stays
+    // on HLS but with fMP4 segments instead of MPEG-TS.
+    let use_dash = is_hevc && profile == ReceiverProfile::Chromecast;
+    let use_fmp4_hls = is_hevc && profile == ReceiverProfile::AirPlay;
+    let manifest_path = if use_dash {
         tmpdir.join("manifest.mpd")
     } else {
         tmpdir.join("playlist.m3u8")
@@ -398,11 +434,13 @@ async fn start_remux(
         cmd.arg("-i").arg(&upstream_url);
     }
     if is_hevc {
-        // Video: copy HEVC; rewrite the fMP4 sample-entry codec tag so the
-        // receiver's codec sniffer sees `hvc1` (Cast/Apple-standard) rather
-        // than `hev1` (ffmpeg-default; Shaka and Cast reject it).
+        // Video: copy HEVC. Cast/Shaka rejects `hev1`, so override the fMP4
+        // sample-entry codec tag to `hvc1`. Apple TV accepts both, so we
+        // leave ffmpeg's default for AirPlay.
         cmd.arg("-c:v").arg("copy");
-        cmd.arg("-tag:v").arg("hvc1");
+        if profile == ReceiverProfile::Chromecast {
+            cmd.arg("-tag:v").arg("hvc1");
+        }
         // Audio: transcode to clean AAC. Copy-into-mp4 fails on MPEG-TS
         // sources because the TS audio codec_tag (0x0F = MPEG-2 AAC OTI)
         // is incompatible with the mp4 muxer's expected `mp4a`, and many
@@ -416,8 +454,8 @@ async fn start_remux(
         // reconnects (single-conn IPTV servers kick ffmpeg every few mins;
         // each reconnect introduces a timestamp jump) don't drop the AAC
         // encoder. `async=1000` permits up to 1s of compensation per
-        // segment; without this the encoder flushes and the DASH muxer
-        // aborts the run with "Application provided invalid, non monotonically
+        // segment; without this the encoder flushes and the muxer aborts
+        // the run with "Application provided invalid, non monotonically
         // increasing dts".
         cmd.arg("-af").arg("aresample=async=1000");
         // Make negative timestamps after a TS reconnect zero-anchored
@@ -425,26 +463,41 @@ async fn start_remux(
         // which the muxer rejects.
         cmd.arg("-avoid_negative_ts").arg("make_zero");
 
-        // DASH muxer: sliding-window live profile, fMP4 segments under
-        // SegmentTemplate so Shaka can index by $Number$. `remove_at_exit`
-        // pairs with `extra_window_size` so segments stay on disk a couple
-        // of windows past the manifest tail (covers receiver reconnects).
-        cmd.arg("-f").arg("dash");
-        cmd.arg("-seg_duration").arg("4");
-        cmd.arg("-window_size").arg("6");
-        cmd.arg("-extra_window_size").arg("2");
-        cmd.arg("-remove_at_exit").arg("1");
-        cmd.arg("-use_template").arg("1");
-        cmd.arg("-use_timeline").arg("1");
-        cmd.arg("-init_seg_name")
-            .arg("init-stream$RepresentationID$.m4s");
-        cmd.arg("-media_seg_name")
-            .arg("chunk-stream$RepresentationID$-$Number%05d$.m4s");
+        if use_dash {
+            // DASH muxer: sliding-window live profile, fMP4 segments under
+            // SegmentTemplate so Shaka can index by $Number$. `remove_at_exit`
+            // pairs with `extra_window_size` so segments stay on disk a couple
+            // of windows past the manifest tail (covers receiver reconnects).
+            cmd.arg("-f").arg("dash");
+            cmd.arg("-seg_duration").arg("4");
+            cmd.arg("-window_size").arg("6");
+            cmd.arg("-extra_window_size").arg("2");
+            cmd.arg("-remove_at_exit").arg("1");
+            cmd.arg("-use_template").arg("1");
+            cmd.arg("-use_timeline").arg("1");
+            cmd.arg("-init_seg_name")
+                .arg("init-stream$RepresentationID$.m4s");
+            cmd.arg("-media_seg_name")
+                .arg("chunk-stream$RepresentationID$-$Number%05d$.m4s");
+        } else if use_fmp4_hls {
+            // HLS+fMP4: Apple HLS spec since v6. Apple TV's HLS engine takes
+            // fMP4+HEVC natively, so we keep the simpler HLS framing instead
+            // of dispatching through DASH/Shaka.
+            let init_filename = tmpdir.join("init.mp4");
+            let segment_pattern = tmpdir.join("seg_%05d.m4s");
+            cmd.arg("-f").arg("hls");
+            cmd.arg("-hls_segment_type").arg("fmp4");
+            cmd.arg("-hls_time").arg("4");
+            cmd.arg("-hls_list_size").arg("6");
+            cmd.arg("-hls_flags")
+                .arg("delete_segments+omit_endlist+independent_segments");
+            cmd.arg("-hls_fmp4_init_filename").arg(&init_filename);
+            cmd.arg("-hls_segment_filename").arg(&segment_pattern);
+        }
     } else {
         // H.264 + TS. Video is always copy. Audio is copy when the upstream
-        // ships AAC (MPL native), otherwise transcoded to AAC — Default
-        // Media Receiver MPL emits LoadFailed on EAC3/AC3-in-TS even though
-        // the muxer accepts those codec_tags.
+        // codec is in the profile's passthrough set, otherwise transcoded
+        // to AAC.
         cmd.arg("-c:v").arg("copy");
         if audio_needs_transcode {
             cmd.arg("-c:a").arg("aac");
@@ -464,9 +517,13 @@ async fn start_remux(
     }
     cmd.arg(&manifest_path);
 
+    let pipeline_label = match (is_hevc, use_dash) {
+        (true, true) => "DASH/HEVC",
+        (true, false) => "HLS-fMP4/HEVC",
+        (false, _) => "HLS-TS/H.264",
+    };
     log::info!(
-        "[CastProxy] Spawning ffmpeg remux ({}) for {} → {}",
-        if is_hevc { "DASH/HEVC" } else { "HLS/H.264" },
+        "[MediaProxy] Spawning ffmpeg remux ({pipeline_label}) for {} → {}",
         redact_url(&upstream_url),
         manifest_path.display()
     );
@@ -511,7 +568,7 @@ async fn start_remux(
             use tokio::io::{AsyncBufReadExt, BufReader};
             let mut lines = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                log::debug!("[CastProxy/ffmpeg] {line}");
+                log::debug!("[MediaProxy/ffmpeg] {line}");
                 let mut t = tail.lock().await;
                 if t.len() >= 32 {
                     t.pop_front();
@@ -533,23 +590,23 @@ async fn start_remux(
                 match status {
                     Ok(s) if s.success() => {
                         log::info!(
-                            "[CastProxy/ffmpeg] Exited cleanly for {}",
+                            "[MediaProxy/ffmpeg] Exited cleanly for {}",
                             redact_url(&upstream_for_worker)
                         );
                     }
                     Ok(s) => {
                         log::warn!(
-                            "[CastProxy/ffmpeg] Exited with status {:?} for {}",
+                            "[MediaProxy/ffmpeg] Exited with status {:?} for {}",
                             s.code(),
                             redact_url(&upstream_for_worker)
                         );
                         let tail = stderr_tail_for_worker.lock().await;
                         for line in tail.iter() {
-                            log::warn!("[CastProxy/ffmpeg/stderr] {line}");
+                            log::warn!("[MediaProxy/ffmpeg/stderr] {line}");
                         }
                     }
                     Err(err) => {
-                        log::warn!("[CastProxy/ffmpeg] wait() failed: {err}");
+                        log::warn!("[MediaProxy/ffmpeg] wait() failed: {err}");
                     }
                 }
                 // ffmpeg ended on its own — also cancel the listener so the
@@ -561,18 +618,18 @@ async fn start_remux(
                 }
             }
             _ = cancel_for_worker.cancelled() => {
-                log::info!("[CastProxy/ffmpeg] Cancellation received, terminating");
+                log::info!("[MediaProxy/ffmpeg] Cancellation received, terminating");
                 graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
                 let _ = std::fs::remove_dir_all(&tmpdir_for_worker);
             }
         }
     });
 
-    // Wait for the manifest to actually be written so the Cast device's first
+    // Wait for the manifest to actually be written so the receiver's first
     // GET doesn't 404. On failure, trip the cancel so the spawned ffmpeg
     // worker terminates and removes the temp dir.
     if let Err(err) =
-        wait_for_manifest(&manifest_path, is_hevc, REMUX_PLAYLIST_READY_TIMEOUT, &cancel).await
+        wait_for_manifest(&manifest_path, use_dash, REMUX_PLAYLIST_READY_TIMEOUT, &cancel).await
     {
         cancel.cancel();
         return Err(err);
@@ -587,12 +644,12 @@ async fn start_remux(
     }
 
     Ok(RemuxStartInfo {
-        manifest_filename: if is_hevc {
+        manifest_filename: if use_dash {
             "manifest.mpd".to_string()
         } else {
             "playlist.m3u8".to_string()
         },
-        is_dash: is_hevc,
+        is_dash: use_dash,
     })
 }
 
@@ -677,7 +734,7 @@ fn spawn_upstream_pump(
                 format!("reconnect #{reconnects}")
             };
             log::info!(
-                "[CastProxy/pump] {label} for {}",
+                "[MediaProxy/pump] {label} for {}",
                 redact_url(&upstream_url)
             );
 
@@ -698,7 +755,7 @@ fn spawn_upstream_pump(
                 Ok(r) if r.status().is_success() => r,
                 Ok(r) => {
                     log::warn!(
-                        "[CastProxy/pump] Upstream returned {} ({label})",
+                        "[MediaProxy/pump] Upstream returned {} ({label})",
                         r.status()
                     );
                     tokio::select! {
@@ -709,7 +766,7 @@ fn spawn_upstream_pump(
                     continue;
                 }
                 Err(err) => {
-                    log::warn!("[CastProxy/pump] Upstream connect failed ({label}): {err}");
+                    log::warn!("[MediaProxy/pump] Upstream connect failed ({label}): {err}");
                     tokio::select! {
                         _ = cancel.cancelled() => break 'session,
                         _ = tokio::time::sleep(RECONNECT_BACKOFF) => {}
@@ -731,20 +788,20 @@ fn spawn_upstream_pump(
                                     // Nothing more we can do — exit the pump
                                     // and let the worker task observe the exit.
                                     log::info!(
-                                        "[CastProxy/pump] ffmpeg stdin closed ({err}); pump exiting"
+                                        "[MediaProxy/pump] ffmpeg stdin closed ({err}); pump exiting"
                                     );
                                     break 'session;
                                 }
                             }
                             Some(Err(err)) => {
                                 log::info!(
-                                    "[CastProxy/pump] Upstream read error ({label}): {err}; reconnecting"
+                                    "[MediaProxy/pump] Upstream read error ({label}): {err}; reconnecting"
                                 );
                                 break;
                             }
                             None => {
                                 log::info!(
-                                    "[CastProxy/pump] Upstream EOF ({label}); reconnecting"
+                                    "[MediaProxy/pump] Upstream EOF ({label}); reconnecting"
                                 );
                                 break;
                             }
@@ -763,7 +820,7 @@ fn spawn_upstream_pump(
         // Best-effort flush + close so ffmpeg sees EOF promptly when we exit.
         let _ = stdin.shutdown().await;
         log::info!(
-            "[CastProxy/pump] Pump terminated for {} after {} reconnect(s)",
+            "[MediaProxy/pump] Pump terminated for {} after {} reconnect(s)",
             redact_url(&upstream_url),
             reconnects
         );
@@ -812,14 +869,14 @@ async fn probe_codecs(
                 Ok(Ok(out)) => out,
                 Ok(Err(err)) => {
                     log::warn!(
-                        "[CastProxy] ffprobe spawn failed for {} ({stream_selector}): {err}",
+                        "[MediaProxy] ffprobe spawn failed for {} ({stream_selector}): {err}",
                         redact_url(&upstream_url)
                     );
                     return None;
                 }
                 Err(_) => {
                     log::warn!(
-                        "[CastProxy] ffprobe codec probe timed out for {} ({stream_selector})",
+                        "[MediaProxy] ffprobe codec probe timed out for {} ({stream_selector})",
                         redact_url(&upstream_url)
                     );
                     return None;
@@ -827,7 +884,7 @@ async fn probe_codecs(
             };
             if !output.status.success() {
                 log::debug!(
-                    "[CastProxy] ffprobe codec probe exited non-zero for {} ({stream_selector}, status {:?})",
+                    "[MediaProxy] ffprobe codec probe exited non-zero for {} ({stream_selector}, status {:?})",
                     redact_url(&upstream_url),
                     output.status.code()
                 );
@@ -848,7 +905,7 @@ async fn probe_codecs(
 
     let (video, audio) = tokio::join!(run("v:0"), run("a:0"));
     log::info!(
-        "[CastProxy] Probed codecs video={} audio={} for {}",
+        "[MediaProxy] Probed codecs video={} audio={} for {}",
         video.as_deref().unwrap_or("?"),
         audio.as_deref().unwrap_or("?"),
         redact_url(upstream_url)
@@ -866,6 +923,7 @@ async fn handle_connection(
     client: Arc<reqwest::Client>,
     user_agent: String,
     resolved_origin: Arc<Mutex<Option<Url>>>,
+    profile: ReceiverProfile,
 ) -> std::io::Result<()> {
     let mut buf = vec![0u8; 8192];
     let n = socket.read(&mut buf).await?;
@@ -888,7 +946,7 @@ async fn handle_connection(
     };
     let range_header = parse_request_header(&request, "range").map(|s| s.to_string());
     log::info!(
-        "[CastProxy] {method} {redacted}{range_suffix} from {peer}",
+        "[MediaProxy] {method} {redacted}{range_suffix} from {peer}",
         redacted = redact_cast_path(path),
         range_suffix = range_header
             .as_deref()
@@ -898,8 +956,10 @@ async fn handle_connection(
 
     // Chromecast CAF receivers send a CORS preflight (OPTIONS) before fetching
     // adaptive media. Answer it directly with the same allow-* headers we
-    // attach to real responses.
-    if method.eq_ignore_ascii_case("OPTIONS") {
+    // attach to real responses. AVPlayer (AirPlay) is a native client and
+    // does not preflight, so the OPTIONS handler is a Cast-only concern —
+    // for AirPlay we fall through to the 403 token-check path.
+    if profile == ReceiverProfile::Chromecast && method.eq_ignore_ascii_case("OPTIONS") {
         let header = "HTTP/1.1 204 No Content\r\n\
              Access-Control-Allow-Origin: *\r\n\
              Access-Control-Allow-Methods: GET, HEAD, OPTIONS\r\n\
@@ -914,7 +974,7 @@ async fn handle_connection(
 
     let allowed_prefix = format!("/cast/{token}/");
     if !path.starts_with(&allowed_prefix) {
-        log::warn!("[CastProxy] Rejecting request with bad token from {peer}");
+        log::warn!("[MediaProxy] Rejecting request with bad token from {peer}");
         let _ = write_simple(&mut socket, 403, "text/plain", b"Forbidden").await;
         return Ok(());
     }
@@ -985,7 +1045,7 @@ async fn handle_connection(
                 .map(|u| u.as_str().to_string())
                 .unwrap_or_default();
             log::warn!(
-                "[CastProxy] Rejected out-of-origin segment fetch for {} (base {})",
+                "[MediaProxy] Rejected out-of-origin segment fetch for {} (base {})",
                 redact_url(decoded_url.as_str()),
                 redact_url(&base_label)
             );
@@ -1039,7 +1099,7 @@ async fn serve_remux_file(
             return Ok(());
         }
         Err(err) => {
-            log::warn!("[CastProxy] Failed to read remux file {file_path:?}: {err}");
+            log::warn!("[MediaProxy] Failed to read remux file {file_path:?}: {err}");
             let _ = write_simple(socket, 500, "text/plain", b"Read error").await;
             return Ok(());
         }
@@ -1151,14 +1211,14 @@ async fn serve_upstream(
         Ok(Ok(resp)) => resp,
         Ok(Err(err)) => {
             log::warn!(
-                "[CastProxy] Upstream fetch failed for {}: {err}",
+                "[MediaProxy] Upstream fetch failed for {}: {err}",
                 redact_url(&upstream_url)
             );
             return write_simple(socket, 502, "text/plain", b"Upstream failed").await;
         }
         Err(_) => {
             log::warn!(
-                "[CastProxy] Upstream fetch timed out for {}",
+                "[MediaProxy] Upstream fetch timed out for {}",
                 redact_url(&upstream_url)
             );
             return write_simple(socket, 504, "text/plain", b"Upstream timed out").await;
@@ -1191,7 +1251,7 @@ async fn serve_upstream(
         if let Some(len) = response.content_length() {
             if len > MAX_MANIFEST_BYTES {
                 log::warn!(
-                    "[CastProxy] Manifest content-length {len} exceeds cap; refusing to rewrite"
+                    "[MediaProxy] Manifest content-length {len} exceeds cap; refusing to rewrite"
                 );
                 return write_simple(socket, 502, "text/plain", b"Manifest too large").await;
             }
@@ -1200,12 +1260,12 @@ async fn serve_upstream(
             Ok(bytes) => bytes,
             Err(ReadCappedError::TooLarge) => {
                 log::warn!(
-                    "[CastProxy] Manifest exceeded {MAX_MANIFEST_BYTES} bytes; refusing to rewrite"
+                    "[MediaProxy] Manifest exceeded {MAX_MANIFEST_BYTES} bytes; refusing to rewrite"
                 );
                 return write_simple(socket, 502, "text/plain", b"Manifest too large").await;
             }
             Err(ReadCappedError::Read(err)) => {
-                log::warn!("[CastProxy] Failed to read manifest: {err}");
+                log::warn!("[MediaProxy] Failed to read manifest: {err}");
                 return write_simple(socket, 502, "text/plain", b"Manifest read failed").await;
             }
         };
@@ -1303,7 +1363,7 @@ async fn serve_upstream(
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
-                log::debug!("[CastProxy] Forward cancelled mid-stream");
+                log::debug!("[MediaProxy] Forward cancelled mid-stream");
                 break;
             }
             chunk = stream.next() => {
@@ -1326,7 +1386,7 @@ async fn serve_upstream(
                         }
                     }
                     Err(err) => {
-                        log::warn!("[CastProxy] Upstream stream error: {err}");
+                        log::warn!("[MediaProxy] Upstream stream error: {err}");
                         break;
                     }
                 }
@@ -1567,7 +1627,7 @@ fn rewrite_manifest(body: &str, base_url: &str, token: &str) -> String {
             }
             Ok(rejected) => {
                 log::warn!(
-                    "[CastProxy] Refusing to proxy out-of-origin segment {} (base {})",
+                    "[MediaProxy] Refusing to proxy out-of-origin segment {} (base {})",
                     redact_url(rejected.as_str()),
                     redact_url(base.as_str())
                 );
@@ -1605,7 +1665,7 @@ fn rewrite_tag_uri(line: &str, base: &Url, token: &str) -> String {
         Ok(u) if is_target_allowed(base, &u) => u,
         Ok(rejected) => {
             log::warn!(
-                "[CastProxy] Refusing to proxy out-of-origin tag URI {} (base {})",
+                "[MediaProxy] Refusing to proxy out-of-origin tag URI {} (base {})",
                 redact_url(rejected.as_str()),
                 redact_url(base.as_str())
             );

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,6 +1,8 @@
 pub mod media_proxy;
 pub mod checker;
 pub mod chromecast;
+#[cfg(target_os = "macos")]
+pub mod airplay;
 pub mod connectivity;
 pub mod disk;
 pub mod ffmpeg;

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,4 +1,4 @@
-pub mod cast_proxy;
+pub mod media_proxy;
 pub mod checker;
 pub mod chromecast;
 pub mod connectivity;

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -4,6 +4,7 @@ use reqwest::header::{HeaderValue, CONTENT_TYPE, RANGE, USER_AGENT};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::Manager;
+use tokio_util::sync::CancellationToken;
 use url::{Host, Url};
 
 use crate::state::AppState;
@@ -18,6 +19,39 @@ const PROXY_BUFFERED_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration
 /// Per-read inactivity timeout — resets on every successful read, so it does NOT
 /// cap total stream duration. Only kills truly dead/stalled connections.
 const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Time to wait after cancelling local connections so the upstream server
+/// has a chance to release the single-credential slot (TCP FIN → server-side
+/// session cleanup) before the receiver path opens its own. 250ms is enough
+/// for well-behaved IPTV portals; tail providers may need more, but the
+/// receiver fetch will still typically succeed because we've at least closed
+/// our socket.
+const LOCAL_STREAM_CANCEL_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Cancel all in-flight local streaming-proxy connections and wait briefly for
+/// the upstream slot to be released. Receiver paths (Chromecast / AirPlay)
+/// must call this before starting their own upstream fetch — single-credential
+/// IPTV providers reject the receiver with HTTP 458 ("too many connections")
+/// if the local player still holds the slot.
+///
+/// The token is replaced with a fresh one before being cancelled, so future
+/// local-player connections after the receiver tears down still work.
+pub async fn cancel_active_local_streams(state: &AppState) {
+    let old = {
+        let mut guard = state.local_stream_cancel.lock().await;
+        std::mem::replace(&mut *guard, CancellationToken::new())
+    };
+    old.cancel();
+    log::info!(
+        "[StreamProxy] Released upstream slot (waiting {}ms for server cleanup)",
+        LOCAL_STREAM_CANCEL_GRACE.as_millis()
+    );
+    tokio::time::sleep(LOCAL_STREAM_CANCEL_GRACE).await;
+}
+
+async fn current_local_stream_cancel(state: &AppState) -> CancellationToken {
+    state.local_stream_cancel.lock().await.clone()
+}
 
 /// Base64url-encode an original stream URL for the proxy scheme.
 pub fn encode_proxy_url(original: &str) -> String {
@@ -531,7 +565,6 @@ where
 /// Start a localhost HTTP proxy that streams upstream responses.
 /// Returns the port the server is listening on.
 pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -543,7 +576,7 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
 
     tokio::spawn(async move {
         loop {
-            let (mut socket, _addr) = match listener.accept().await {
+            let (socket, _addr) = match listener.accept().await {
                 Ok(conn) => conn,
                 Err(err) => {
                     log::warn!("[StreamProxy] Accept error: {}", err);
@@ -552,135 +585,158 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
             };
 
             let app_handle = app.clone();
+            // Snapshot the current cancel token so this connection dies if a
+            // receiver path (Chromecast / AirPlay) calls
+            // `cancel_active_local_streams` before we start its own upstream
+            // fetch. Future connections accepted after that grab the
+            // already-replaced fresh token, so they're unaffected.
+            let cancel = current_local_stream_cancel(
+                app_handle.state::<Arc<AppState>>().inner(),
+            )
+            .await;
             tokio::spawn(async move {
-                // Read the HTTP request line to extract the URL
-                let mut buf = vec![0u8; 8192];
-                let n = match socket.read(&mut buf).await {
-                    Ok(0) => return,
-                    Ok(n) => n,
-                    Err(_) => return,
-                };
-                let request_str = String::from_utf8_lossy(&buf[..n]);
-
-                // Parse GET /stream?url=ENCODED_URL HTTP/1.1
-                let url = match parse_stream_request(&request_str) {
-                    Some(url) => url,
-                    None => {
-                        let response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
-                        let _ = socket.write_all(response.as_bytes()).await;
-                        return;
-                    }
-                };
-
-                if !is_safe_upstream_url(&url).await {
-                    log::warn!("[StreamProxy] Blocked request to private/local target");
-                    let response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 22\r\n\r\nTarget URL not allowed";
-                    let _ = socket.write_all(response.as_bytes()).await;
-                    return;
-                }
-
-                log::info!("[StreamProxy] Streaming {}", redact_url(&url));
-
-                // Fetch upstream with streaming body using settings-aware client
-                let state = app_handle.state::<Arc<AppState>>();
-                let (user_agent, accept_invalid_certs) = {
-                    let settings = state.settings.lock().await;
-                    (settings.user_agent.clone(), settings.accept_invalid_certs)
-                };
-
-                let client = get_or_create_proxy_client(state.inner(), accept_invalid_certs).await;
-
-                let response = match client
-                    .get(&url)
-                    .header(
-                        USER_AGENT,
-                        HeaderValue::from_str(&user_agent).unwrap_or_else(|_| {
-                            HeaderValue::from_static("TiviMate/5.1.6 (Android 12)")
-                        }),
-                    )
-                    .send()
-                    .await
-                {
-                    Ok(resp) => resp,
-                    Err(err) => {
-                        log::warn!(
-                            "[StreamProxy] Upstream request failed for {} ({})",
-                            redact_url(&url),
-                            reqwest_error_kind(&err)
-                        );
-                        let (status_line, body) = if err.is_timeout() {
-                            ("HTTP/1.1 504 Gateway Timeout", "Upstream request timed out")
-                        } else {
-                            ("HTTP/1.1 502 Bad Gateway", "Upstream request failed")
-                        };
-                        let response = format!(
-                            "{status_line}\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
-                        let _ = socket.write_all(response.as_bytes()).await;
-                        return;
-                    }
-                };
-
-                let status = response.status();
-                let content_type = response
-                    .headers()
-                    .get(CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("application/octet-stream")
-                    .to_string();
-
-                // Write HTTP response headers
-                let status_line = match status.canonical_reason() {
-                    Some(reason) => format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason),
-                    None => format!("HTTP/1.1 {}\r\n", status.as_u16()),
-                };
-                let header = format!(
-                    "{}Content-Type: {}\r\n\
-                     Access-Control-Allow-Origin: *\r\n\
-                     Transfer-Encoding: chunked\r\n\
-                     Cache-Control: no-cache\r\n\
-                     Connection: close\r\n\
-                     \r\n",
-                    status_line, content_type
-                );
-                if socket.write_all(header.as_bytes()).await.is_err() {
-                    return;
-                }
-
-                match forward_response_as_chunked_stream(&mut socket, response).await {
-                    StreamForwardOutcome::Completed => {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
                         log::debug!(
-                            "[StreamProxy] Upstream stream ended normally for {}",
-                            redact_url(&url)
+                            "[StreamProxy] Connection cancelled (receiver took the upstream slot)"
                         );
                     }
-                    StreamForwardOutcome::UpstreamReadTimeout => {
-                        log::warn!(
-                            "[StreamProxy] Upstream stream stalled/timed out for {}",
-                            redact_url(&url)
-                        );
-                    }
-                    StreamForwardOutcome::UpstreamReadError(kind) => {
-                        log::warn!(
-                            "[StreamProxy] Upstream stream terminated for {} ({})",
-                            redact_url(&url),
-                            kind
-                        );
-                    }
-                    StreamForwardOutcome::DownstreamClosed => {
-                        log::debug!(
-                            "[StreamProxy] Downstream disconnected while streaming {}",
-                            redact_url(&url)
-                        );
-                    }
+                    _ = handle_streaming_connection(socket, app_handle) => {}
                 }
             });
         }
     });
 
     Ok(port)
+}
+
+async fn handle_streaming_connection(mut socket: tokio::net::TcpStream, app_handle: tauri::AppHandle) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Read the HTTP request line to extract the URL
+    let mut buf = vec![0u8; 8192];
+    let n = match socket.read(&mut buf).await {
+        Ok(0) => return,
+        Ok(n) => n,
+        Err(_) => return,
+    };
+    let request_str = String::from_utf8_lossy(&buf[..n]);
+
+    // Parse GET /stream?url=ENCODED_URL HTTP/1.1
+    let url = match parse_stream_request(&request_str) {
+        Some(url) => url,
+        None => {
+            let response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
+            let _ = socket.write_all(response.as_bytes()).await;
+            return;
+        }
+    };
+
+    if !is_safe_upstream_url(&url).await {
+        log::warn!("[StreamProxy] Blocked request to private/local target");
+        let response =
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 22\r\n\r\nTarget URL not allowed";
+        let _ = socket.write_all(response.as_bytes()).await;
+        return;
+    }
+
+    log::info!("[StreamProxy] Streaming {}", redact_url(&url));
+
+    // Fetch upstream with streaming body using settings-aware client
+    let state = app_handle.state::<Arc<AppState>>();
+    let (user_agent, accept_invalid_certs) = {
+        let settings = state.settings.lock().await;
+        (settings.user_agent.clone(), settings.accept_invalid_certs)
+    };
+
+    let client = get_or_create_proxy_client(state.inner(), accept_invalid_certs).await;
+
+    let response = match client
+        .get(&url)
+        .header(
+            USER_AGENT,
+            HeaderValue::from_str(&user_agent)
+                .unwrap_or_else(|_| HeaderValue::from_static("TiviMate/5.1.6 (Android 12)")),
+        )
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(err) => {
+            log::warn!(
+                "[StreamProxy] Upstream request failed for {} ({})",
+                redact_url(&url),
+                reqwest_error_kind(&err)
+            );
+            let (status_line, body) = if err.is_timeout() {
+                ("HTTP/1.1 504 Gateway Timeout", "Upstream request timed out")
+            } else {
+                ("HTTP/1.1 502 Bad Gateway", "Upstream request failed")
+            };
+            let response = format!(
+                "{status_line}\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            return;
+        }
+    };
+
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    // Write HTTP response headers
+    let status_line = match status.canonical_reason() {
+        Some(reason) => format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason),
+        None => format!("HTTP/1.1 {}\r\n", status.as_u16()),
+    };
+    let header = format!(
+        "{}Content-Type: {}\r\n\
+             Access-Control-Allow-Origin: *\r\n\
+             Transfer-Encoding: chunked\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             \r\n",
+        status_line, content_type
+    );
+    if socket.write_all(header.as_bytes()).await.is_err() {
+        return;
+    }
+
+    match forward_response_as_chunked_stream(&mut socket, response).await {
+        StreamForwardOutcome::Completed => {
+            log::debug!(
+                "[StreamProxy] Upstream stream ended normally for {}",
+                redact_url(&url)
+            );
+        }
+        StreamForwardOutcome::UpstreamReadTimeout => {
+            log::warn!(
+                "[StreamProxy] Upstream stream stalled/timed out for {}",
+                redact_url(&url)
+            );
+        }
+        StreamForwardOutcome::UpstreamReadError(kind) => {
+            log::warn!(
+                "[StreamProxy] Upstream stream terminated for {} ({})",
+                redact_url(&url),
+                kind
+            );
+        }
+        StreamForwardOutcome::DownstreamClosed => {
+            log::debug!(
+                "[StreamProxy] Downstream disconnected while streaming {}",
+                redact_url(&url)
+            );
+        }
+    }
 }
 
 fn parse_stream_request(request: &str) -> Option<String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1127,6 +1127,12 @@ pub fn run() {
             commands::chromecast::cast_to_device,
             commands::chromecast::stop_cast,
             commands::chromecast::get_cast_status,
+            #[cfg(target_os = "macos")]
+            commands::airplay::start_airplay,
+            #[cfg(target_os = "macos")]
+            commands::airplay::stop_airplay,
+            #[cfg(target_os = "macos")]
+            commands::airplay::get_airplay_status,
             commands::scan::start_scan,
             commands::scan::pause_scan,
             commands::scan::resume_scan,

--- a/src-tauri/src/models/airplay.rs
+++ b/src-tauri/src/models/airplay.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+use crate::models::chromecast::CastStreamKind;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AirPlaySessionState {
+    Connecting,
+    Playing,
+    Paused,
+    Stopped,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirPlaySession {
+    pub state: AirPlaySessionState,
+    pub stream_url: String,
+    pub channel_name: Option<String>,
+    pub channel_logo: Option<String>,
+    pub error_message: Option<String>,
+    pub external_playback_active: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AirPlayMediaRequest {
+    pub original_url: String,
+    pub channel_name: Option<String>,
+    pub channel_logo: Option<String>,
+    pub stream_kind: CastStreamKind,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod airplay;
 pub mod backend_perf;
 pub mod channel;
 pub mod chromecast;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
-use crate::engine::cast_proxy::CastProxyHandle;
+use crate::engine::media_proxy::MediaProxyHandle;
 use crate::engine::chromecast::ActiveCastSession;
 use crate::models::backend_perf::BackendPerfSample;
 use crate::models::playlist::PlaylistPreview;
@@ -62,7 +62,7 @@ impl Default for WindowScanState {
 
 pub struct CastState {
     pub session: Option<ActiveCastSession>,
-    pub proxy: Option<CastProxyHandle>,
+    pub proxy: Option<MediaProxyHandle>,
 }
 
 impl Default for CastState {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,6 +6,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::engine::media_proxy::MediaProxyHandle;
 use crate::engine::chromecast::ActiveCastSession;
+#[cfg(target_os = "macos")]
+use crate::engine::airplay::ActiveAirPlaySession;
 use crate::models::backend_perf::BackendPerfSample;
 use crate::models::playlist::PlaylistPreview;
 use crate::models::scan_log::ScanDebugLog;
@@ -74,6 +76,22 @@ impl Default for CastState {
     }
 }
 
+#[cfg(target_os = "macos")]
+pub struct AirPlayState {
+    pub session: Option<ActiveAirPlaySession>,
+    pub proxy: Option<MediaProxyHandle>,
+}
+
+#[cfg(target_os = "macos")]
+impl Default for AirPlayState {
+    fn default() -> Self {
+        Self {
+            session: None,
+            proxy: None,
+        }
+    }
+}
+
 pub struct AppState {
     pub settings: Mutex<AppSettings>,
     pub proxy_client: Mutex<Option<(reqwest::Client, bool)>>,
@@ -84,6 +102,13 @@ pub struct AppState {
     /// `cast_to_device` / `stop_cast` calls cannot interleave and corrupt
     /// the stored session.
     pub cast_lifecycle_lock: Mutex<()>,
+    #[cfg(target_os = "macos")]
+    pub airplay_state: Mutex<AirPlayState>,
+    /// AirPlay analog of `cast_lifecycle_lock`. Same rationale: serialize
+    /// concurrent `start_airplay` / `stop_airplay` so they can't orphan a
+    /// session or proxy.
+    #[cfg(target_os = "macos")]
+    pub airplay_lifecycle_lock: Mutex<()>,
     window_scan_states: Mutex<HashMap<String, WindowScanState>>,
     backend_perf_samples: Mutex<VecDeque<BackendPerfSample>>,
     playlist_preview_cache: Mutex<HashMap<String, CachedPlaylistPreview>>,
@@ -98,6 +123,10 @@ impl AppState {
             streaming_proxy_start_lock: Mutex::new(()),
             cast_state: Mutex::new(CastState::default()),
             cast_lifecycle_lock: Mutex::new(()),
+            #[cfg(target_os = "macos")]
+            airplay_state: Mutex::new(AirPlayState::default()),
+            #[cfg(target_os = "macos")]
+            airplay_lifecycle_lock: Mutex::new(()),
             window_scan_states: Mutex::new(HashMap::new()),
             backend_perf_samples: Mutex::new(VecDeque::new()),
             playlist_preview_cache: Mutex::new(HashMap::new()),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -97,6 +97,12 @@ pub struct AppState {
     pub proxy_client: Mutex<Option<(reqwest::Client, bool)>>,
     pub streaming_proxy_port: std::sync::atomic::AtomicU16,
     pub streaming_proxy_start_lock: Mutex<()>,
+    /// Shared cancel for in-flight local streaming-proxy connections.
+    /// Receiver paths (Chromecast / AirPlay) cancel + replace this so the
+    /// upstream slot is released before they start their own fetch — single-
+    /// credential IPTV providers reject the receiver with HTTP 458 if the
+    /// local player still holds the slot. See `stream_proxy::cancel_active_local_streams`.
+    pub local_stream_cancel: Mutex<CancellationToken>,
     pub cast_state: Mutex<CastState>,
     /// Held for the entire start/stop cast lifecycle so concurrent
     /// `cast_to_device` / `stop_cast` calls cannot interleave and corrupt
@@ -121,6 +127,7 @@ impl AppState {
             proxy_client: Mutex::new(None),
             streaming_proxy_port: std::sync::atomic::AtomicU16::new(0),
             streaming_proxy_start_lock: Mutex::new(()),
+            local_stream_cancel: Mutex::new(CancellationToken::new()),
             cast_state: Mutex::new(CastState::default()),
             cast_lifecycle_lock: Mutex::new(()),
             #[cfg(target_os = "macos")]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2524,7 +2524,10 @@ export default function App() {
             ? lastCastDeviceRef.current
             : null);
         if (device) {
-          void chromecast.cast(device, buildCastRequest(result));
+          // Fire-and-forget — the hook already mirrors any rejection into
+          // `chromecast.error` which renders in CastMenu. Swallow the
+          // rejection here so it doesn't surface as an unhandled promise.
+          void chromecast.cast(device, buildCastRequest(result)).catch(() => {});
           return;
         }
         // Fall through to local play if we can't resolve the device — better
@@ -2535,7 +2538,9 @@ export default function App() {
       // ffmpeg fan-out and cause receiver dropouts. Restart the AirPlay
       // session against the new channel instead.
       if (isAirPlaySessionActive(airplay.session)) {
-        void airplay.start(buildAirPlayRequest(result));
+        // Same pattern as the cast branch above — the hook records the
+        // error in `airplay.error`; swallow the rejection here.
+        void airplay.start(buildAirPlayRequest(result)).catch(() => {});
         return;
       }
       getStore().setPlayIntentActive(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,9 +55,15 @@ import {
 } from "./lib/tauri";
 import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
+import { useAirPlay, type UseAirPlayResult } from "./hooks/useAirPlay";
 import { useChromecast, type UseChromecastResult } from "./hooks/useChromecast";
 import { useStreamPlayer } from "./hooks/useStreamPlayer";
-import { buildCastRequest, isCastSessionActive } from "./lib/cast";
+import {
+  buildAirPlayRequest,
+  buildCastRequest,
+  isAirPlaySessionActive,
+  isCastSessionActive,
+} from "./lib/cast";
 import type { ChromecastDevice } from "./lib/types";
 import { useAppStore } from "./store";
 import type { AppStore, OpenSourceDialogState, UpdateNotice } from "./store/types";
@@ -436,6 +442,7 @@ function SelectedChannelSidebar({
   onResizeStart,
   streamPlayer,
   chromecast,
+  airplay,
   onPlayChannel,
   onScanChannel,
   onStopPlayer,
@@ -446,6 +453,7 @@ function SelectedChannelSidebar({
   onResizeStart: (event: React.MouseEvent) => void;
   streamPlayer: StreamPlayerController;
   chromecast: UseChromecastResult;
+  airplay: UseAirPlayResult;
   onPlayChannel: (result: ChannelResult) => void;
   onScanChannel: (indices: number[]) => void;
   onStopPlayer: () => void;
@@ -536,6 +544,7 @@ function SelectedChannelSidebar({
         onPlayChannel={onPlayChannel}
         onScanChannel={onScanChannel}
         chromecast={chromecast}
+        airplay={airplay}
         isPlaying={streamPlayer.playerState !== "idle"}
         playerState={streamPlayer.playerState}
         errorMessage={streamPlayer.errorMessage}
@@ -869,8 +878,11 @@ export default function App() {
     () => ({ ...baseChromecast, cast: wrappedCast }),
     [baseChromecast, wrappedCast],
   );
+  const airplay = useAirPlay();
   const castSession = chromecast.session;
+  const airplaySession = airplay.session;
   const isCasting = isCastSessionActive(castSession);
+  const isAirPlaying = isAirPlaySessionActive(airplaySession);
 
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
   const settingsRef = useRef(settings);
@@ -2518,10 +2530,18 @@ export default function App() {
         // Fall through to local play if we can't resolve the device — better
         // than silently doing nothing.
       }
+      // Same rationale for AirPlay: AVPlayer holds the proxy URL on the live
+      // upstream slot, so starting a competing local stream would kick the
+      // ffmpeg fan-out and cause receiver dropouts. Restart the AirPlay
+      // session against the new channel instead.
+      if (isAirPlaySessionActive(airplay.session)) {
+        void airplay.start(buildAirPlayRequest(result));
+        return;
+      }
       getStore().setPlayIntentActive(true);
       streamPlayer.play(result);
     },
-    [chromecast, streamPlayer],
+    [airplay, chromecast, streamPlayer],
   );
 
   const handleStopPlayer = useCallback(() => {
@@ -2639,7 +2659,7 @@ export default function App() {
       onOpenChannel={handlePlayInApp}
       onOpenExternal={handleOpenExternal}
       onScanSelected={handleScanSelected}
-      isCasting={isCasting}
+      isReceiverActive={isCasting || isAirPlaying}
       headerPortalRef={isMac ? headerPortalRef : undefined}
       toolbarHeight={toolbarHeight}
     />
@@ -2828,6 +2848,7 @@ export default function App() {
               onResizeStart={handleSidebarDragStart}
               streamPlayer={streamPlayer}
               chromecast={chromecast}
+              airplay={airplay}
               onPlayChannel={handlePlayInApp}
               onScanChannel={handleScanSelected}
               onStopPlayer={handleStopPlayer}

--- a/src/components/CastMenu.tsx
+++ b/src/components/CastMenu.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Cast, ChevronDown, RefreshCw, Square } from "lucide-react";
+import { AirVent, Cast, ChevronDown, RefreshCw, Square } from "lucide-react";
 import type {
+  AirPlayMediaRequest,
+  AirPlaySession,
   CastMediaRequest,
   CastSession,
   ChromecastDevice,
 } from "../lib/types";
-import { isCastSessionActive } from "../lib/cast";
+import { isAirPlaySessionActive, isCastSessionActive } from "../lib/cast";
 
 interface UseChromecastShape {
   devices: ChromecastDevice[];
@@ -17,12 +19,30 @@ interface UseChromecastShape {
   stop: () => Promise<void>;
 }
 
+interface UseAirPlayShape {
+  available: boolean;
+  session: AirPlaySession | null;
+  error: string | null;
+  start: (request: AirPlayMediaRequest) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
 interface CastMenuProps {
   chromecast: UseChromecastShape;
   castRequest: CastMediaRequest;
   mode: "popover" | "inline";
+  /**
+   * Optional AirPlay hook. When provided AND `airplay.available` is true
+   * (macOS), an AirPlay control appears above the cast section. The
+   * route-picker UI lives in the AVPlayerView HUD that opens when AirPlay
+   * starts, so we just need a "Start AirPlay" / "Stop" affordance here.
+   */
+  airplay?: UseAirPlayShape;
+  airplayRequest?: AirPlayMediaRequest;
   /** Fired after a cast successfully starts — e.g. to pause the local player. */
   onCastStart?: () => void;
+  /** Fired after AirPlay successfully starts. Same purpose as onCastStart. */
+  onAirPlayStart?: () => void;
   /**
    * Popover-mode only: fired when the menu opens or closes so the parent can
    * suppress auto-hide of surrounding chrome while the picker is visible.
@@ -34,7 +54,10 @@ export function CastMenu({
   chromecast,
   castRequest,
   mode,
+  airplay,
+  airplayRequest,
   onCastStart,
+  onAirPlayStart,
   onOpenChange,
 }: CastMenuProps) {
   if (mode === "popover") {
@@ -42,7 +65,10 @@ export function CastMenu({
       <CastMenuPopover
         chromecast={chromecast}
         castRequest={castRequest}
+        airplay={airplay}
+        airplayRequest={airplayRequest}
         onCastStart={onCastStart}
+        onAirPlayStart={onAirPlayStart}
         onOpenChange={onOpenChange}
       />
     );
@@ -51,7 +77,10 @@ export function CastMenu({
     <CastMenuInline
       chromecast={chromecast}
       castRequest={castRequest}
+      airplay={airplay}
+      airplayRequest={airplayRequest}
       onCastStart={onCastStart}
+      onAirPlayStart={onAirPlayStart}
     />
   );
 }
@@ -61,13 +90,19 @@ export function CastMenu({
 function CastMenuPopover({
   chromecast,
   castRequest,
+  airplay,
+  airplayRequest,
   onCastStart,
+  onAirPlayStart,
   onOpenChange,
 }: Omit<CastMenuProps, "mode">) {
   const [open, setOpenState] = useState(false);
   const [starting, setStarting] = useState(false);
+  const [airplayStarting, setAirplayStarting] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const isCasting = isCastSessionActive(chromecast.session);
+  const isAirPlaying = isAirPlaySessionActive(airplay?.session ?? null);
+  const airplayAvailable = !!airplay?.available && !!airplayRequest;
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -121,20 +156,85 @@ function CastMenuPopover({
     }
   }, [chromecast]);
 
+  const handleStartAirPlay = useCallback(async () => {
+    if (!airplay || !airplayRequest) return;
+    setAirplayStarting(true);
+    onAirPlayStart?.();
+    try {
+      await airplay.start(airplayRequest);
+      setOpen(false);
+    } catch {
+      // error surfaces via airplay.error; keep menu open
+    } finally {
+      setAirplayStarting(false);
+    }
+  }, [airplay, airplayRequest, onAirPlayStart, setOpen]);
+
+  const handleStopAirPlay = useCallback(async () => {
+    if (!airplay) return;
+    try {
+      await airplay.stop();
+    } finally {
+      setOpen(false);
+    }
+  }, [airplay, setOpen]);
+
+  const isReceiverActive = isCasting || isAirPlaying;
+  const buttonTitle = isCasting
+    ? `Casting to ${chromecast.session?.deviceName ?? "device"}`
+    : isAirPlaying
+    ? "AirPlay session active"
+    : "Cast or AirPlay";
+
   return (
     <div ref={ref} className="relative ml-1">
       <button
         type="button"
         onClick={() => (open ? setOpen(false) : openMenu())}
         className={`p-1 transition-colors ${
-          isCasting ? "text-blue-300 hover:text-blue-200" : "text-white hover:text-white/80"
+          isReceiverActive ? "text-blue-300 hover:text-blue-200" : "text-white hover:text-white/80"
         }`}
-        title={isCasting ? `Casting to ${chromecast.session?.deviceName ?? "device"}` : "Cast"}
+        title={buttonTitle}
       >
         <Cast className="w-4 h-4" />
       </button>
       {open && (
         <div className="absolute bottom-full right-0 mb-2 w-64 rounded-md border border-white/10 bg-black/90 backdrop-blur-sm shadow-xl text-white text-[12px] z-10">
+          {airplayAvailable && (
+            <div className="px-3 py-2 border-b border-white/10">
+              <div className="flex items-center gap-2">
+                <AirVent className="w-3.5 h-3.5 shrink-0 text-white/70" />
+                <span className="flex-1 font-medium">AirPlay</span>
+              </div>
+              {isAirPlaying && airplay?.session ? (
+                <>
+                  <div className="mt-1 text-[11px] text-white/55 capitalize">
+                    {airplay.session.state}
+                    {airplay.session.externalPlaybackActive ? " · external" : ""}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleStopAirPlay()}
+                    className="mt-2 w-full px-2 py-1 text-[11px] font-medium rounded bg-red-600/80 hover:bg-red-600 transition-colors"
+                  >
+                    Stop AirPlay
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void handleStartAirPlay()}
+                  disabled={airplayStarting}
+                  className="mt-2 w-full px-2 py-1 text-[11px] font-medium rounded bg-white/10 hover:bg-white/15 disabled:opacity-50 transition-colors"
+                >
+                  {airplayStarting ? "Starting…" : "Open AirPlay window"}
+                </button>
+              )}
+              {airplay?.error && (
+                <div className="mt-2 text-[11px] text-red-300 break-words">{airplay.error}</div>
+              )}
+            </div>
+          )}
           <div className="flex items-center justify-between px-3 py-2 border-b border-white/10">
             <span className="font-medium">{isCasting ? "Casting" : "Cast to device"}</span>
             <button
@@ -205,11 +305,17 @@ function CastMenuPopover({
 function CastMenuInline({
   chromecast,
   castRequest,
+  airplay,
+  airplayRequest,
   onCastStart,
+  onAirPlayStart,
 }: Omit<CastMenuProps, "mode">) {
   const [expanded, setExpanded] = useState(false);
   const [starting, setStarting] = useState(false);
+  const [airplayStarting, setAirplayStarting] = useState(false);
   const isCasting = isCastSessionActive(chromecast.session);
+  const isAirPlaying = isAirPlaySessionActive(airplay?.session ?? null);
+  const airplayAvailable = !!airplay?.available && !!airplayRequest;
 
   // Auto-expand when casting so the active session is always visible without
   // an extra click; collapse back when it ends.
@@ -247,8 +353,75 @@ function CastMenuInline({
     void chromecast.stop();
   }, [chromecast]);
 
+  const handleStartAirPlay = useCallback(async () => {
+    if (!airplay || !airplayRequest) return;
+    setAirplayStarting(true);
+    onAirPlayStart?.();
+    try {
+      await airplay.start(airplayRequest);
+    } catch {
+      // error surfaces via airplay.error
+    } finally {
+      setAirplayStarting(false);
+    }
+  }, [airplay, airplayRequest, onAirPlayStart]);
+
+  const handleStopAirPlay = useCallback(() => {
+    if (!airplay) return;
+    void airplay.stop();
+  }, [airplay]);
+
+  const airplayRow = airplayAvailable ? (
+    <div className="flex flex-col gap-2 px-3 py-2.5">
+      {isAirPlaying && airplay?.session ? (
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75 animate-ping" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+          </span>
+          <AirVent className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-medium text-text-primary truncate">
+              {airplay.session.externalPlaybackActive
+                ? "AirPlaying to receiver"
+                : "AirPlay window open"}
+            </div>
+            <div className="text-[11px] text-text-tertiary capitalize">
+              {airplay.session.state}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleStopAirPlay}
+            className="flex items-center gap-1 px-2 py-1 text-[11px] font-medium rounded bg-red-600 hover:bg-red-500 text-white transition-colors shrink-0"
+            title="Stop AirPlay"
+          >
+            <Square className="w-3 h-3" />
+            Stop
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void handleStartAirPlay()}
+          disabled={airplayStarting}
+          className="flex w-full items-center gap-2 text-left transition-colors hover:opacity-80 disabled:opacity-50"
+        >
+          <AirVent className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
+          <span className="flex-1 text-[12px] font-medium text-text-primary">
+            {airplayStarting ? "Opening AirPlay…" : "Open AirPlay window"}
+          </span>
+        </button>
+      )}
+      {airplay?.error && (
+        <div className="text-[11px] text-red-500 break-words">{airplay.error}</div>
+      )}
+    </div>
+  ) : null;
+
   return (
-    <div className="rounded-md border border-border-subtle bg-panel-subtle">
+    <div className="rounded-md border border-border-subtle bg-panel-subtle divide-y divide-border-subtle">
+      {airplayRow}
       {isCasting && chromecast.session ? (
         <div className="flex flex-col gap-2 px-3 py-2.5">
           <div className="flex items-center gap-2 min-w-0">

--- a/src/components/CastMenu.tsx
+++ b/src/components/CastMenu.tsx
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AirVent, Cast, ChevronDown, RefreshCw, Square } from "lucide-react";
 import type {
   AirPlayMediaRequest,
-  AirPlaySession,
   CastMediaRequest,
   CastSession,
   ChromecastDevice,
 } from "../lib/types";
 import { isAirPlaySessionActive, isCastSessionActive } from "../lib/cast";
+import type { UseAirPlayResult } from "../hooks/useAirPlay";
 
 interface UseChromecastShape {
   devices: ChromecastDevice[];
@@ -16,14 +16,6 @@ interface UseChromecastShape {
   error: string | null;
   refreshDevices: () => Promise<void>;
   cast: (device: ChromecastDevice, request: CastMediaRequest) => Promise<void>;
-  stop: () => Promise<void>;
-}
-
-interface UseAirPlayShape {
-  available: boolean;
-  session: AirPlaySession | null;
-  error: string | null;
-  start: (request: AirPlayMediaRequest) => Promise<void>;
   stop: () => Promise<void>;
 }
 
@@ -37,7 +29,7 @@ interface CastMenuProps {
    * route-picker UI lives in the AVPlayerView HUD that opens when AirPlay
    * starts, so we just need a "Start AirPlay" / "Stop" affordance here.
    */
-  airplay?: UseAirPlayShape;
+  airplay?: UseAirPlayResult;
   airplayRequest?: AirPlayMediaRequest;
   /** Fired after a cast successfully starts — e.g. to pause the local player. */
   onCastStart?: () => void;

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -34,11 +34,11 @@ interface ChannelTableProps {
   onOpenExternal?: (result: ChannelResult) => void;
   onScanSelected?: (selectedIndices: number[]) => void;
   /**
-   * True when a Chromecast session is active. Enables arrow-key auto-open as
-   * a "channel-surfing" redirect of the cast (debounced) even when no local
-   * playback is in progress.
+   * True when an external receiver session (Chromecast or AirPlay) is active.
+   * Enables arrow-key auto-open as a "channel-surfing" redirect to that
+   * receiver (debounced) even when no local playback is in progress.
    */
-  isCasting?: boolean;
+  isReceiverActive?: boolean;
   headerPortalRef?: RefObject<HTMLDivElement | null>;
   toolbarHeight: number;
 }
@@ -130,7 +130,7 @@ export function ChannelTable({
   onOpenChannel,
   onOpenExternal,
   onScanSelected,
-  isCasting = false,
+  isReceiverActive = false,
   headerPortalRef,
   toolbarHeight,
 }: ChannelTableProps) {
@@ -690,8 +690,8 @@ export function ChannelTable({
           emitSelection(selected);
           setSelectionAnchor(result.index);
           onSelectChannel(result);
-          if ((isPlaying || isCasting) && !isScanActive(scanState)) {
-            if (isCasting) {
+          if ((isPlaying || isReceiverActive) && !isScanActive(scanState)) {
+            if (isReceiverActive) {
               // Coalesce key bursts so each press doesn't fire a full cast
               // re-handshake (~300ms backend round-trip).
               if (castRedirectTimerRef.current) {
@@ -718,7 +718,7 @@ export function ChannelTable({
       onSelectChannel,
       onOpenChannel,
       isPlaying,
-      isCasting,
+      isReceiverActive,
       scanState,
       virtualizer,
     ],
@@ -806,7 +806,7 @@ export function ChannelTable({
       // Plain row click while casting → redirect the cast (same debounce as
       // arrow-key channel surfing so a click burst doesn't fan out into
       // multiple cast_to_device calls).
-      if (isCasting && !isScanActive(scanState)) {
+      if (isReceiverActive && !isScanActive(scanState)) {
         if (castRedirectTimerRef.current) {
           clearTimeout(castRedirectTimerRef.current);
         }
@@ -824,7 +824,7 @@ export function ChannelTable({
       onOpenChannel,
       clearSelection,
       selectSingle,
-      isCasting,
+      isReceiverActive,
       scanState,
     ],
   );

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -11,9 +11,10 @@ import {
   Volume2,
   VolumeX,
 } from "lucide-react";
+import type { UseAirPlayResult } from "../hooks/useAirPlay";
 import type { UseChromecastResult } from "../hooks/useChromecast";
-import type { CastMediaRequest } from "../lib/types";
-import { isCastSessionActive } from "../lib/cast";
+import type { AirPlayMediaRequest, CastMediaRequest } from "../lib/types";
+import { isAirPlaySessionActive, isCastSessionActive } from "../lib/cast";
 import { CastMenu } from "./CastMenu";
 
 interface StreamPlayerProps {
@@ -39,6 +40,12 @@ interface StreamPlayerProps {
    * UI is shown regardless of `castRequest`.
    */
   chromecast?: UseChromecastResult;
+  /**
+   * Optional shared AirPlay hook (macOS only). When provided and `available`
+   * is true, the in-overlay menu also offers an AirPlay button.
+   */
+  airplay?: UseAirPlayResult;
+  airplayRequest?: AirPlayMediaRequest;
   onTogglePause: () => void;
   onStop: () => void;
   onSetVolume: (v: number) => void;
@@ -62,6 +69,8 @@ export function StreamPlayer({
   castRequest,
   compact = false,
   chromecast,
+  airplay,
+  airplayRequest,
   onTogglePause,
   onStop,
   onSetVolume,
@@ -77,6 +86,7 @@ export function StreamPlayer({
 
   const showCastUi = !compact && !!castRequest && !!chromecast;
   const isCasting = isCastSessionActive(chromecast?.session ?? null);
+  const isAirPlaying = isAirPlaySessionActive(airplay?.session ?? null);
 
   const scheduleHide = useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
@@ -137,6 +147,16 @@ export function StreamPlayer({
           <Cast className="w-3 h-3" />
           <span className="truncate max-w-[180px]">
             Casting to {chromecast.session.deviceName}
+          </span>
+        </div>
+      )}
+      {showCastUi && !isCasting && isAirPlaying && (
+        <div className="absolute top-2 left-2 flex items-center gap-1.5 px-2 py-1 rounded-md bg-blue-600/85 text-white text-[11px] font-medium shadow-md backdrop-blur-sm">
+          <Cast className="w-3 h-3" />
+          <span className="truncate max-w-[180px]">
+            {airplay?.session?.externalPlaybackActive
+              ? "AirPlaying to receiver"
+              : "AirPlay window open"}
           </span>
         </div>
       )}
@@ -236,8 +256,11 @@ export function StreamPlayer({
             <CastMenu
               chromecast={chromecast}
               castRequest={castRequest}
+              airplay={airplay}
+              airplayRequest={airplayRequest}
               mode="popover"
               onCastStart={handleCastStart}
+              onAirPlayStart={handleCastStart}
               onOpenChange={setCastMenuPinned}
             />
           )}

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -3,11 +3,17 @@ import { createPortal } from "react-dom";
 import { CircleHelp, ExternalLink, Fullscreen, ImageOff, LoaderCircle, Play, RotateCw, Shrink, Square, X } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ChannelResult } from "../lib/types";
-import { buildCastRequest, isCastSessionActive } from "../lib/cast";
+import {
+  buildAirPlayRequest,
+  buildCastRequest,
+  isAirPlaySessionActive,
+  isCastSessionActive,
+} from "../lib/cast";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { formatAudioInfo, formatVideoInfo, statusLabel } from "../lib/format";
 import { isScanActive, type ScanState } from "../lib/scanState";
 import { getThumbnailDisplayState } from "../lib/thumbnailState";
+import type { UseAirPlayResult } from "../hooks/useAirPlay";
 import type { UseChromecastResult } from "../hooks/useChromecast";
 import { CastMenu } from "./CastMenu";
 import { StatusBadge } from "./StatusBadge";
@@ -30,6 +36,11 @@ interface ThumbnailPanelProps {
    * a competing local stream.
    */
   chromecast: UseChromecastResult;
+  /**
+   * Optional AirPlay hook (macOS only). When provided and `available`, the
+   * inline CastMenu renders an AirPlay control above the cast section.
+   */
+  airplay?: UseAirPlayResult;
   // Stream player props
   isPlaying?: boolean;
   playerState?: "idle" | "loading" | "playing" | "error";
@@ -62,6 +73,7 @@ export function ThumbnailPanel({
   onPlayChannel,
   onScanChannel,
   chromecast,
+  airplay,
   isPlaying,
   playerState = "idle",
   errorMessage: playerErrorMessage,
@@ -206,6 +218,7 @@ export function ThumbnailPanel({
   // useEffect downstream of `castRequest` would tear down and re-fire on every
   // parent re-render even when none of its inputs actually changed.
   const castRequest = useMemo(() => buildCastRequest(result), [result]);
+  const airplayRequest = useMemo(() => buildAirPlayRequest(result), [result]);
   const mediaFrameClass = "relative w-full aspect-video overflow-hidden rounded-lg border border-border-app";
   const lightboxPlaceholderClass =
     "w-[400px] max-w-[88vw] aspect-video rounded-xl border border-white/15 bg-black/60 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]";
@@ -262,6 +275,8 @@ export function ThumbnailPanel({
           castRequest={castRequest}
           compact
           chromecast={chromecast}
+          airplay={airplay}
+          airplayRequest={airplayRequest}
         />
       ) : screenshotUrl ? (
         <button
@@ -383,22 +398,27 @@ export function ThumbnailPanel({
       )}
 
       {(() => {
-        // Keep the row visible while a session is active so the user can
-        // still hit Stop after we've torn down the local player. The
+        // Keep the row visible while a receiver session is active so the user
+        // can still hit Stop after we've torn down the local player. The
         // lightbox-open carve-out matters for casts started from the
         // lightbox: starting a cast unmounts the lightbox StreamPlayer
         // (onStopPlayer fires), and without this fallback the user would
         // have to manually close the lightbox to find a way to stop or
         // retarget the cast.
         const hasCastSession = isCastSessionActive(chromecast.session);
-        if (!isPlaying && !hasCastSession) return null;
-        if (lightboxOpen && !hasCastSession) return null;
+        const hasAirPlaySession = isAirPlaySessionActive(airplay?.session ?? null);
+        const hasReceiverSession = hasCastSession || hasAirPlaySession;
+        if (!isPlaying && !hasReceiverSession) return null;
+        if (lightboxOpen && !hasReceiverSession) return null;
         return (
           <CastMenu
             chromecast={chromecast}
             castRequest={castRequest}
+            airplay={airplay}
+            airplayRequest={airplayRequest}
             mode="inline"
             onCastStart={() => onStopPlayer?.()}
+            onAirPlayStart={() => onStopPlayer?.()}
           />
         );
       })()}
@@ -564,6 +584,8 @@ export function ThumbnailPanel({
                   onPip={onPip ? () => { onPip(); closeLightbox(); } : undefined}
                   castRequest={castRequest}
                   chromecast={chromecast}
+                  airplay={airplay}
+                  airplayRequest={airplayRequest}
                 />
                 <button
                   type="button"

--- a/src/hooks/useAirPlay.ts
+++ b/src/hooks/useAirPlay.ts
@@ -63,8 +63,10 @@ export function useAirPlay(): UseAirPlayResult {
 
     (async () => {
       // Gate everything on macOS — start_airplay isn't even registered as a
-      // command on Windows/Linux, so calling it would reject anyway.
-      const platform = await detectPlatform();
+      // command on Windows/Linux, so calling it would reject anyway. A
+      // rejection here (e.g. tauri-plugin-os not yet ready) just means we
+      // stay un-`available` rather than crashing the effect.
+      const platform = await detectPlatform().catch(() => null);
       if (!mounted || cancelledRef.current) return;
       if (platform !== "macos") return;
       setAvailable(true);

--- a/src/hooks/useAirPlay.ts
+++ b/src/hooks/useAirPlay.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  getAirplayStatus,
+  startAirplay,
+  stopAirplay,
+} from "../lib/tauri";
+import { detectPlatform } from "../lib/platform";
+import type { AirPlayMediaRequest, AirPlaySession } from "../lib/types";
+
+export interface UseAirPlayResult {
+  available: boolean;
+  session: AirPlaySession | null;
+  error: string | null;
+  start: (request: AirPlayMediaRequest) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+export function useAirPlay(): UseAirPlayResult {
+  const [available, setAvailable] = useState(false);
+  const [session, setSession] = useState<AirPlaySession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const start = useCallback(
+    async (request: AirPlayMediaRequest) => {
+      setError(null);
+      try {
+        const next = await startAirplay(request);
+        if (!cancelledRef.current) setSession(next);
+      } catch (err) {
+        if (!cancelledRef.current) {
+          setError(String(err));
+          setSession(null);
+        }
+        throw err;
+      }
+    },
+    [],
+  );
+
+  const stop = useCallback(async () => {
+    try {
+      await stopAirplay();
+      // Symmetric to useChromecast.stop: only clear locally on a successful
+      // backend stop. If the call rejects (window already torn down, etc.)
+      // the receiver may still be playing — clearing here would lie to the
+      // rest of the UI and break cast-redirect gates.
+      if (!cancelledRef.current) {
+        setError(null);
+        setSession(null);
+      }
+    } catch (err) {
+      if (!cancelledRef.current) setError(String(err));
+      throw err;
+    }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    let unlisten: UnlistenFn | null = null;
+    let mounted = true;
+
+    (async () => {
+      // Gate everything on macOS — start_airplay isn't even registered as a
+      // command on Windows/Linux, so calling it would reject anyway.
+      const platform = await detectPlatform();
+      if (!mounted || cancelledRef.current) return;
+      if (platform !== "macos") return;
+      setAvailable(true);
+
+      try {
+        const initial = await getAirplayStatus();
+        if (mounted && !cancelledRef.current) setSession(initial);
+      } catch {
+        // ignore — no active session is the norm
+      }
+
+      try {
+        unlisten = await listen<AirPlaySession>("airplay://status", (event) => {
+          if (!mounted || cancelledRef.current) return;
+          const next = event.payload;
+          if (next.state === "stopped") {
+            setSession(null);
+            setError(null);
+            return;
+          }
+          setSession(next);
+          if (next.state === "error") {
+            setError(next.errorMessage ?? "AirPlay session error");
+          } else {
+            setError(null);
+          }
+        });
+      } catch (err) {
+        if (mounted && !cancelledRef.current) setError(String(err));
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      cancelledRef.current = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  return { available, session, error, start, stop };
+}

--- a/src/lib/cast.ts
+++ b/src/lib/cast.ts
@@ -1,4 +1,6 @@
 import type {
+  AirPlayMediaRequest,
+  AirPlaySession,
   CastMediaRequest,
   CastSession,
   CastStreamKind,
@@ -36,5 +38,21 @@ export function buildCastRequest(channel: ChannelResult): CastMediaRequest {
 export function isCastSessionActive(
   session: CastSession | null,
 ): session is CastSession {
+  return !!session && session.state !== "stopped" && session.state !== "error";
+}
+
+export function buildAirPlayRequest(channel: ChannelResult): AirPlayMediaRequest {
+  const url = channel.stream_url?.trim() || channel.url;
+  return {
+    originalUrl: url,
+    channelName: channel.name || null,
+    channelLogo: channel.tvg_logo || null,
+    streamKind: detectStreamKind(url),
+  };
+}
+
+export function isAirPlaySessionActive(
+  session: AirPlaySession | null,
+): session is AirPlaySession {
   return !!session && session.state !== "stopped" && session.state !== "error";
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { inferPlatformFromNavigator } from "./platform";
 import type {
   AirPlayMediaRequest,
   AirPlaySession,
@@ -310,16 +311,32 @@ export async function getCastStatus(): Promise<CastSession | null> {
   return invoke("get_cast_status");
 }
 
+// AirPlay commands are only registered on macOS (gated by
+// `#[cfg(target_os = "macos")]` in lib.rs). Calling `invoke` on a
+// non-existent command surfaces as a generic "command X not found" error
+// from the webview — we'd rather throw a clearly-named error from the
+// wrapper layer so any accidental non-mac call paths fail fast with a
+// useful message. `inferPlatformFromNavigator` is synchronous and good
+// enough for the Mac/non-Mac split (we only need to skip on Win/Linux).
+function ensureAirPlaySupported(): void {
+  if (inferPlatformFromNavigator() !== "macos") {
+    throw new Error("AirPlay is only available on macOS");
+  }
+}
+
 export async function startAirplay(
   request: AirPlayMediaRequest,
 ): Promise<AirPlaySession> {
+  ensureAirPlaySupported();
   return invoke("start_airplay", { request });
 }
 
 export async function stopAirplay(): Promise<void> {
+  if (inferPlatformFromNavigator() !== "macos") return;
   return invoke("stop_airplay");
 }
 
 export async function getAirplayStatus(): Promise<AirPlaySession | null> {
+  if (inferPlatformFromNavigator() !== "macos") return null;
   return invoke("get_airplay_status");
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  AirPlayMediaRequest,
+  AirPlaySession,
   AppSettings,
   CastMediaRequest,
   CastSession,
@@ -306,4 +308,18 @@ export async function stopCast(): Promise<void> {
 
 export async function getCastStatus(): Promise<CastSession | null> {
   return invoke("get_cast_status");
+}
+
+export async function startAirplay(
+  request: AirPlayMediaRequest,
+): Promise<AirPlaySession> {
+  return invoke("start_airplay", { request });
+}
+
+export async function stopAirplay(): Promise<void> {
+  return invoke("stop_airplay");
+}
+
+export async function getAirplayStatus(): Promise<AirPlaySession | null> {
+  return invoke("get_airplay_status");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -458,3 +458,26 @@ export interface CastMediaRequest {
   channelLogo: string | null;
   streamKind: CastStreamKind;
 }
+
+export type AirPlaySessionState =
+  | "connecting"
+  | "playing"
+  | "paused"
+  | "stopped"
+  | "error";
+
+export interface AirPlaySession {
+  state: AirPlaySessionState;
+  streamUrl: string;
+  channelName: string | null;
+  channelLogo: string | null;
+  errorMessage: string | null;
+  externalPlaybackActive: boolean;
+}
+
+export interface AirPlayMediaRequest {
+  originalUrl: string;
+  channelName: string | null;
+  channelLogo: string | null;
+  streamKind: CastStreamKind;
+}


### PR DESCRIPTION
## Summary

Adds **macOS-only** AirPlay support so users can stream IPTV channels to an Apple TV. Cross-platform AirPlay 2 is blocked by needing to port Pair-Setup/Pair-Verify crypto to Rust (~9–13 days, ongoing maintenance burden — no maintained Rust AirPlay 2 sender crate exists). This PR delegates pairing/encryption/discovery to Apple's `AVKit` framework, which ships natively on macOS.

> [!IMPORTANT]
> **Stacked on #192 (Chromecast support).** Will rebase onto `main` after #192 lands. Review against the chromecast branch base.

## Why this is more than a thin AVKit wrapper

The chromecast PR surfaced a long tail of IPTV-specific problems that apply identically to AirPlay:

- **Apple TV in URL-mode AirPlay does NOT forward `AVURLAssetHTTPHeaderFieldsKey` headers.** ATV sends its own `AppleCoreMedia/...` UA. IPTV portals that filter by UA fail without going through the LAN proxy.
- **Single-credential contention is identical** — ATV opens its own upstream connection; without proxy fan-out the local Mac AVPlayer and ATV race for the one slot.
- **HEAD + Range probing** is required by Apple's HLS engine for fMP4 init segments.

So the cast proxy at \`engine/cast_proxy.rs\` is shared, parameterized on a \`ReceiverProfile\` enum that gates CORS / DASH+fMP4 / AAC-transcode / hvc1-tag — these are Chromecast-specific behaviors that AirPlay drops.

## Scope

### New files
- \`src-tauri/src/models/airplay.rs\` — \`AirPlayMediaRequest\`, \`AirPlaySession\`, state enum
- \`src-tauri/src/engine/airplay.rs\` — AVKit bridge (\`AVPlayer\` + \`AVPlayerView\` + \`NSWindow\`, KVO → \`airplay://status\` events)
- \`src-tauri/src/commands/airplay.rs\` — \`start_airplay\`, \`stop_airplay\`, \`get_airplay_status\`
- \`src/hooks/useAirPlay.ts\` — mirrors \`useChromecast\` (no devices)

### Modified
- \`src-tauri/src/engine/cast_proxy.rs\` → renamed \`media_proxy.rs\` with \`ReceiverProfile\` enum
- \`src-tauri/src/engine/chromecast.rs\` — passes \`ReceiverProfile::Chromecast\`
- \`src-tauri/Cargo.toml\` — macOS-only \`objc2-foundation\`, \`objc2-app-kit\`, \`objc2-av-kit\`, \`objc2-av-foundation\`, \`block2\`
- \`src-tauri/src/lib.rs\`, \`src-tauri/src/state.rs\` — register commands behind \`cfg(target_os = \"macos\")\`
- \`src/components/CastMenu.tsx\` — AirPlay row above device list (gated on macOS)
- \`src/components/StreamPlayer.tsx\`, \`ChannelTable.tsx\`, \`useStreamPlayer.ts\` — extend \`4e1ff42\` redirect pattern to AirPlay sessions
- \`src/lib/{tauri,cast,types,platform}.ts\` — invoke wrappers, helper, types, isMacOS gate

## Implementation checklist

- [x] Add \`AirPlayMediaRequest\` / \`AirPlaySession\` (Rust + TS)
- [ ] Add macOS-only Cargo deps for AVKit FFI
- [ ] Generalize \`cast_proxy.rs\` → \`media_proxy.rs\` with \`ReceiverProfile\` enum
- [ ] Build \`engine/airplay.rs\` (AVKit bridge)
- [ ] Build \`commands/airplay.rs\`
- [ ] Wire \`state.rs\` and \`lib.rs\` registration
- [ ] Build \`useAirPlay\` hook + \`buildAirPlayRequest\` helper
- [ ] Modify \`CastMenu.tsx\` and extend cast-active redirect to cover AirPlay
- [ ] Real-device testing on Apple TV 4K

## Test plan

Requires Apple TV 4K on the same LAN, single-credential IPTV provider:

- [ ] Click AirPlay on HLS+AVC channel → AVPlayerView window opens, route picker shows ATV, video appears on TV
- [ ] Confirm local Mac player paused (no double-fetch on upstream)
- [ ] Repeat with HLS+HEVC, MPEG-TS+AVC, MPEG-TS+HEVC, EAC3-audio
- [ ] Channel-switch mid-AirPlay via arrow keys → seamless or graceful re-load
- [ ] Stop AirPlay → window closes, status emits \`stopped\`, can resume local play
- [ ] Mutually-exclusive receivers: starting AirPlay tears down active Chromecast cleanly
- [ ] \`bun tauri build\` (notarized) — verify proxy listener and AVKit work in production build
- [ ] \`bun run typecheck\` and \`cargo test\` pass

## Risks

| Risk | Mitigation |
|---|---|
| macOS App Sandbox blocks 0.0.0.0 LAN listener for notarized builds | Verify against hardened-runtime on chromecast first, since same listener |
| ATV-specific HLS strictness silently fails (EXT-X-VERSION < 6 for fMP4, codec string mismatch) | Real-device test matrix on every IPTV format |
| \`replaceCurrentItem\` mid-AirPlay channel-switch causes ATV to bounce to launcher | Pre-buffer next item before swap, mirror chromecast's \`bdba784\` polish |

## Out of scope

- Linux/Windows AirPlay sender (would need Pair-Verify crypto port)
- Inline \`AVRoutePickerView\` overlay inside Tauri webview (z-order complexity)
- HDR metadata pass-through verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS AirPlay support: start/stop AirPlay, session status, and AirPlay routing integrated into player UI and cast menus.

* **Refactor**
  * Unified media proxy to support both Chromecast and AirPlay with profile-aware streaming and manifest handling.

* **Bug Fixes**
  * Improved local-stream cancellation to reduce leftover connections and smoother receiver handoffs.

* **Chores**
  * CI install step adjusted to improve fuzz job reliability; macOS dependency additions for AirPlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->