### PR TITLE
Parse xtream m3u urls into separate credentials

### DIFF
--- a/scripts/download-ffmpeg.sh
+++ b/scripts/download-ffmpeg.sh
@@ -125,9 +125,7 @@ download_macos_evermeet() {
 
 download_btbn() {
     local platform="$1"
-    local btbn_tag
-    btbn_tag="$(curl -sI "https://github.com/BtbN/FFmpeg-Builds/releases/latest" | grep -i location | sed 's|.*/tag/||;s/\r//')"
-    local base="https://github.com/BtbN/FFmpeg-Builds/releases/download/${btbn_tag}"
+    local base="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest"
     local archive="ffmpeg-master-latest-${platform}-gpl"
 
     local ext_archive=".tar.xz"

--- a/src/components/OpenSourceDialog.tsx
+++ b/src/components/OpenSourceDialog.tsx
@@ -378,6 +378,27 @@ export default function OpenSourceDialog({
     return () => window.removeEventListener("keydown", handler);
   }, [handleClose, showServerTest]);
 
+  const parseXtreamM3ULink = (link: string) => {
+    try {
+      const url = new URL(link);
+      const u = url.searchParams.get("username");
+      const p = url.searchParams.get("password");
+
+      if (u && p) {
+        setXtreamServer(`${url.protocol}//${url.host}`);
+        setXtreamUsername(u);
+        setXtreamPassword(p);
+
+
+        // exit if we already set credentials
+        return;
+      }
+    } catch (_) {}
+
+    // fallback to setting the link as is
+    setXtreamServer(link);
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (submitting) return;
@@ -575,7 +596,7 @@ export default function OpenSourceDialog({
                     type="text"
                     autoFocus
                     value={xtreamServer}
-                    onChange={(event) => setXtreamServer(event.target.value)}
+                    onChange={(event) => parseXtreamM3ULink(event.target.value)}
                     placeholder="https://example.com:8080"
                     className="w-full rounded-md border border-border-app bg-input px-3 py-2 text-[14px] text-text-primary placeholder:text-text-muted focus:border-blue-500 focus:outline-none"
                   />

--- a/src/lib/channelResults.ts
+++ b/src/lib/channelResults.ts
@@ -23,6 +23,7 @@ function pendingScanFields() {
     stream_url: null,
     retry_count: null,
     error_reason: null,
+    last_error_reason: null,
     drm_system: null,
   };
 }
@@ -42,9 +43,9 @@ export function getChannelIdFromUrl(url: string): string {
 }
 
 export function getChannelErrorReason(
-  result: Pick<ChannelResult, "error_reason">,
+  result: Pick<ChannelResult, "error_reason" | "last_error_reason">,
 ): string | null {
-  return result.error_reason?.trim() || null;
+  return result.error_reason?.trim() || result.last_error_reason?.trim() || null;
 }
 
 export function getScreenshotErrorReason(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface ChannelResult {
   stream_url: string | null;
   retry_count?: number | null;
   error_reason?: string | null;
+  last_error_reason?: string | null;
   drm_system?: string | null;
 }
 


### PR DESCRIPTION
## Summary
Parse Xtream M3U-style URLs entered into the server field and auto-fill Xtream server, username, and password fields when credentials are present in the query string

## Changes
- Added `parseXtreamM3ULink(link: string)` helper.
  - Attempts to parse the input as a URL
  - If `username` and `password` query params exist, sets:
    - `xtreamServer` to the URL origin (protocol + host)
    - `xtreamUsername` and `xtreamPassword` to the extracted values
  - Fallback to setting `xtreamServer` to the raw input when parsing fails or credentials are not present.

## Reason
Many Xtream providers give credentials as M3U URLs. Parsing these automatically saves time from manually copying username/password and reduces friction when testing multiple streams

## Example
Input:
http://hostname:8080/get.php?username=foo&password=bar&type=m3u_plus
Result:
- Server: https://hostname:8080 (preserves protocol and host)
- Username: foo
- Password: bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Xtream input now auto-extracts server, username, and password when a full link is pasted.
* **Bug Fixes**
  * Scan/channel results now surface a “last error” value so error messages are more accurate.
* **Chores**
  * Updated how bundled media tools are downloaded to use a simpler releases URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->