### PR TITLE
Stabilize long-running IPTV playback

### DIFF
--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -343,7 +343,7 @@ fn stderr_excerpt(stderr: &str) -> String {
     truncate_stderr_summary(&tail)
 }
 
-fn sanitize_ffmpeg_stderr_line(line: &str) -> String {
+pub(crate) fn sanitize_ffmpeg_stderr_line(line: &str) -> String {
     let trimmed = strip_ffmpeg_log_prefix(line);
     if trimmed.contains("Input #") {
         if let Some((prefix, remainder)) = trimmed.split_once(" from '") {

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -19,6 +19,11 @@ const PROXY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// proxy. These responses are finite and should stay bounded.
 const PROXY_BUFFERED_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Buffered HLS manifests and segments can legitimately remain idle while an
+/// upstream finishes producing the next segment. Keep their per-read timeout
+/// aligned with the bounded response timeout.
+const PROXY_BUFFERED_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Per-read inactivity timeout — resets on every successful read, so it does NOT
 /// cap total stream duration. Only kills truly dead/stalled connections.
 const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
@@ -535,7 +540,7 @@ async fn get_or_create_proxy_client(
     let client = build_proxy_client(
         accept_invalid_certs,
         PROXY_CONNECT_TIMEOUT,
-        PROXY_READ_TIMEOUT,
+        PROXY_BUFFERED_READ_TIMEOUT,
     );
 
     *guard = Some((client.clone(), accept_invalid_certs));
@@ -1100,7 +1105,15 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                     (settings.user_agent.clone(), settings.accept_invalid_certs)
                 };
 
-                let client = get_or_create_proxy_client(state.inner(), accept_invalid_certs).await;
+                // Infinite live bodies need a much shorter inactivity timeout
+                // than buffered HLS responses so reconnects happen promptly.
+                // Keep this client local to the downstream playback session so
+                // its cookie jar is retained across upstream reconnects.
+                let client = build_proxy_client(
+                    accept_invalid_certs,
+                    PROXY_CONNECT_TIMEOUT,
+                    PROXY_READ_TIMEOUT,
+                );
 
                 let user_agent = HeaderValue::from_str(&user_agent)
                     .unwrap_or_else(|_| HeaderValue::from_static("TiviMate/5.1.6 (Android 12)"));

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -7,7 +7,8 @@ use tauri::Manager;
 use url::{Host, Url};
 
 use crate::engine::ffmpeg::{
-    configure_background_process, graceful_kill, resolve_binary, GRACEFUL_KILL_TIMEOUT,
+    configure_background_process, graceful_kill, resolve_binary, sanitize_ffmpeg_stderr_line,
+    GRACEFUL_KILL_TIMEOUT,
 };
 use crate::state::AppState;
 
@@ -34,7 +35,7 @@ const STREAM_PACER_MAX_LEAD: std::time::Duration = std::time::Duration::from_sec
 /// A reqwest body chunk is small enough that it cannot legitimately span more
 /// than a few seconds of broadcast time. Larger PCR steps usually mean the
 /// provider switched clocks/PIDs or sent a corrupt timestamp.
-const STREAM_PACER_MAX_PCR_STEP: std::time::Duration = std::time::Duration::from_millis(250);
+const STREAM_PACER_MAX_PCR_STEP: std::time::Duration = std::time::Duration::from_secs(5);
 /// Never let a suspect transport clock put the proxy to sleep long enough for
 /// the browser's starvation watchdog to fire. Normal pacing delays stay well
 /// below this because the proxy sleeps after every body chunk.
@@ -754,7 +755,11 @@ where
         tokio::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                log::debug!("[StreamProxy/remux] {}", line.replace(&original, &redacted));
+                let sanitized = sanitize_ffmpeg_stderr_line(&line);
+                log::debug!(
+                    "[StreamProxy/remux] {}",
+                    sanitized.replace(&original, &redacted)
+                );
             }
         });
     }
@@ -764,9 +769,10 @@ where
     let reader = tokio::spawn(async move {
         loop {
             let mut chunk = vec![0u8; 64 * 1024];
-            match stdout.read(&mut chunk).await {
-                Ok(0) => return StreamForwardOutcome::Completed,
-                Ok(read) => {
+            match tokio::time::timeout(PROXY_READ_TIMEOUT, stdout.read(&mut chunk)).await {
+                Err(_) => return StreamForwardOutcome::UpstreamReadTimeout,
+                Ok(Ok(0)) => return StreamForwardOutcome::Completed,
+                Ok(Ok(read)) => {
                     chunk.truncate(read);
                     let permits = read.min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
                     let permit = match budget.clone().acquire_many_owned(permits).await {
@@ -777,7 +783,9 @@ where
                         return StreamForwardOutcome::DownstreamClosed;
                     }
                 }
-                Err(_) => return StreamForwardOutcome::UpstreamReadError("ffmpeg stdout failed"),
+                Ok(Err(_)) => {
+                    return StreamForwardOutcome::UpstreamReadError("ffmpeg stdout failed")
+                }
             }
         }
     });

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -6,6 +6,9 @@ use std::sync::Arc;
 use tauri::Manager;
 use url::{Host, Url};
 
+use crate::engine::ffmpeg::{
+    configure_background_process, graceful_kill, resolve_binary, GRACEFUL_KILL_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// Fail fast if upstream's TCP/TLS handshake stalls.
@@ -17,13 +20,35 @@ const PROXY_BUFFERED_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration
 
 /// Per-read inactivity timeout — resets on every successful read, so it does NOT
 /// cap total stream duration. Only kills truly dead/stalled connections.
-const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// Short retry delay for a live MPEG-TS source that drops its upstream socket.
 /// The downstream connection stays open while the proxy reconnects, so the
 /// browser player can keep its MediaSource and buffered video intact.
 const STREAM_RECONNECT_BASE_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 const STREAM_RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+const MPEG_TS_PACKET_SIZE: usize = 188;
+const MPEG_TS_PCR_TICKS_PER_SECOND: u64 = 27_000_000;
+const MPEG_TS_PCR_WRAP_TICKS: u64 = (1u64 << 33) * 300;
+const STREAM_PACER_MAX_LEAD: std::time::Duration = std::time::Duration::from_secs(90);
+/// A reqwest body chunk is small enough that it cannot legitimately span more
+/// than a few seconds of broadcast time. Larger PCR steps usually mean the
+/// provider switched clocks/PIDs or sent a corrupt timestamp.
+const STREAM_PACER_MAX_PCR_STEP: std::time::Duration = std::time::Duration::from_millis(250);
+/// Never let a suspect transport clock put the proxy to sleep long enough for
+/// the browser's starvation watchdog to fire. Normal pacing delays stay well
+/// below this because the proxy sleeps after every body chunk.
+const STREAM_PACER_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+/// Read live providers eagerly into a bounded queue so downstream pacing does
+/// not apply TCP backpressure to bursty servers and make them skip TS packets.
+const STREAM_PROXY_READ_AHEAD_BYTES: usize = 64 * 1024 * 1024;
+const STREAM_PROXY_READ_AHEAD_CHUNKS: usize = 4_096;
+const REMUX_PACER_MAX_LEAD: std::time::Duration = std::time::Duration::from_secs(12);
+/// Rebuild a monotonic packet clock from each encoded stream's packet
+/// durations. This preserves video composition offsets (PTS-DTS), including
+/// B-frames, while removing every provider timestamp hole without decoding.
+const CONTIGUOUS_VIDEO_TIMESTAMPS: &str = "setts=dts=if(eq(N\\,0)\\,0\\,PREV_OUTDTS+if(gt(PREV_OUTDURATION\\,0)\\,PREV_OUTDURATION\\,if(gt(DURATION\\,0)\\,DURATION\\,1))):pts=if(eq(N\\,0)\\,PTS-STARTDTS\\,PREV_OUTDTS+if(gt(PREV_OUTDURATION\\,0)\\,PREV_OUTDURATION\\,if(gt(DURATION\\,0)\\,DURATION\\,1))+PTS-DTS)";
+const CONTIGUOUS_AUDIO_TIMESTAMPS: &str = "setts=ts=if(eq(N\\,0)\\,0\\,PREV_OUTDTS+if(gt(PREV_OUTDURATION\\,0)\\,PREV_OUTDURATION\\,if(gt(DURATION\\,0)\\,DURATION\\,1)))";
 
 /// Base64url-encode an original stream URL for the proxy scheme.
 pub fn encode_proxy_url(original: &str) -> String {
@@ -219,6 +244,46 @@ pub(crate) fn redact_url(url: &str) -> String {
             if !parsed.username().is_empty() || parsed.password().is_some() {
                 let _ = parsed.set_username("***");
                 let _ = parsed.set_password(None);
+            }
+            // Xtream credentials live in path segments rather than URL userinfo:
+            // /live/{username}/{password}/{stream-id}.ts. Those URLs are the
+            // most common source of playback diagnostics, so query/userinfo
+            // redaction alone would still leak both credentials.
+            let segments = parsed
+                .path_segments()
+                .map(|segments| segments.map(str::to_string).collect::<Vec<_>>())
+                .unwrap_or_default();
+            let credential_start = if segments.len() >= 4
+                && matches!(
+                    segments[0].to_ascii_lowercase().as_str(),
+                    "live" | "movie" | "series"
+                ) {
+                Some(1)
+            } else if segments.len() == 3
+                && segments[2]
+                    .split('.')
+                    .next()
+                    .is_some_and(|id| !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()))
+            {
+                Some(0)
+            } else {
+                None
+            };
+            if let Some(start) = credential_start {
+                let redacted_segments = segments
+                    .iter()
+                    .enumerate()
+                    .map(|(index, segment)| {
+                        if index == start || index == start + 1 {
+                            "***"
+                        } else {
+                            segment.as_str()
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                if let Ok(mut path) = parsed.path_segments_mut() {
+                    path.clear().extend(redacted_segments);
+                }
             }
             parsed.to_string()
         }
@@ -490,9 +555,368 @@ struct StreamForwardResult {
     bytes_forwarded: u64,
 }
 
+struct TransportStreamPacer {
+    scan_tail: Vec<u8>,
+    pcr_pid: Option<u16>,
+    last_pcr: Option<u64>,
+    media_elapsed_ticks: u64,
+    wall_anchor: Option<std::time::Instant>,
+    announced: bool,
+    reanchor_count: u32,
+    max_lead: std::time::Duration,
+}
+
+impl TransportStreamPacer {
+    fn new() -> Self {
+        Self::with_max_lead(STREAM_PACER_MAX_LEAD)
+    }
+
+    fn with_max_lead(max_lead: std::time::Duration) -> Self {
+        Self {
+            scan_tail: Vec::with_capacity(MPEG_TS_PACKET_SIZE * 4),
+            pcr_pid: None,
+            last_pcr: None,
+            media_elapsed_ticks: 0,
+            wall_anchor: None,
+            announced: false,
+            reanchor_count: 0,
+            max_lead,
+        }
+    }
+
+    fn delay_for_payload(&mut self, payload: &[u8]) -> std::time::Duration {
+        let mut scan = Vec::with_capacity(self.scan_tail.len() + payload.len());
+        scan.extend_from_slice(&self.scan_tail);
+        scan.extend_from_slice(payload);
+
+        let latest_pcr = latest_transport_stream_pcr(&scan, self.pcr_pid);
+        let tail_start = scan.len().saturating_sub(MPEG_TS_PACKET_SIZE * 4);
+        self.scan_tail.clear();
+        self.scan_tail.extend_from_slice(&scan[tail_start..]);
+
+        let Some((pcr_pid, pcr)) = latest_pcr else {
+            return std::time::Duration::ZERO;
+        };
+        self.pcr_pid.get_or_insert(pcr_pid);
+
+        let Some(previous_pcr) = self.last_pcr else {
+            self.last_pcr = Some(pcr);
+            self.wall_anchor = Some(std::time::Instant::now());
+            return std::time::Duration::ZERO;
+        };
+
+        let delta = if pcr >= previous_pcr {
+            pcr - previous_pcr
+        } else {
+            MPEG_TS_PCR_WRAP_TICKS - previous_pcr + pcr
+        };
+        let discontinuity_ticks = duration_to_pcr_ticks(STREAM_PACER_MAX_PCR_STEP);
+        if delta > discontinuity_ticks {
+            self.last_pcr = Some(pcr);
+            // The broadcaster may reset or jump its PCR at a program boundary.
+            // Keep the accumulated wall-clock budget so each discontinuity
+            // cannot grant another full forward-buffer allowance.
+            return std::time::Duration::ZERO;
+        }
+
+        self.last_pcr = Some(pcr);
+        self.media_elapsed_ticks = self.media_elapsed_ticks.saturating_add(delta);
+        let media_elapsed = duration_from_pcr_ticks(self.media_elapsed_ticks);
+        let target_wall_elapsed = media_elapsed.saturating_sub(self.max_lead);
+        let wall_elapsed = self
+            .wall_anchor
+            .map(|anchor| anchor.elapsed())
+            .unwrap_or_default();
+        let delay = target_wall_elapsed.saturating_sub(wall_elapsed);
+        if delay > STREAM_PACER_MAX_DELAY {
+            // A bad-but-plausible PCR series can otherwise accumulate into one
+            // very long sleep. Re-anchor at real-time pacing without granting
+            // another forward-buffer allowance; the browser keeps the buffer
+            // it already has and the next payload is paced normally.
+            self.media_elapsed_ticks = duration_to_pcr_ticks(self.max_lead);
+            self.wall_anchor = Some(std::time::Instant::now());
+            self.reanchor_count = self.reanchor_count.saturating_add(1);
+            log::warn!(
+                "[StreamProxy] Re-anchored transport clock after an implausible pacing delay"
+            );
+            return std::time::Duration::ZERO;
+        }
+        delay
+    }
+}
+
+fn spawn_playback_remux(
+    app: &tauri::AppHandle,
+    upstream_url: &str,
+    user_agent: &str,
+    accept_invalid_certs: bool,
+) -> std::io::Result<tokio::process::Child> {
+    let ffmpeg = resolve_binary(app, "ffmpeg");
+    let mut command = tokio::process::Command::new(&ffmpeg);
+    configure_background_process(&mut command);
+    command
+        .kill_on_drop(true)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .arg("-hide_banner")
+        .arg("-nostdin")
+        .arg("-loglevel")
+        .arg("warning")
+        .arg("-fflags")
+        .arg("+genpts+discardcorrupt")
+        // MPEG-TS is marked as timestamp-discontinuous, so ffmpeg can remove
+        // jumps by shifting subsequent DTS/PTS. Its 10-second default misses
+        // the 2-5 second holes that repeatedly freeze WebView's MediaSource.
+        .arg("-dts_delta_threshold")
+        .arg("0.5")
+        .arg("-thread_queue_size")
+        .arg("4096")
+        .arg("-user_agent")
+        .arg(user_agent);
+
+    if accept_invalid_certs && upstream_url.to_ascii_lowercase().starts_with("https://") {
+        command.arg("-tls_verify").arg("0");
+    }
+
+    command
+        .arg("-reconnect")
+        .arg("1")
+        .arg("-reconnect_at_eof")
+        .arg("1")
+        .arg("-reconnect_streamed")
+        .arg("1")
+        .arg("-reconnect_delay_max")
+        .arg("5")
+        .arg("-i")
+        .arg(upstream_url)
+        .arg("-map")
+        .arg("0:v:0?")
+        .arg("-map")
+        .arg("0:a:0?")
+        .arg("-sn")
+        .arg("-dn")
+        .arg("-c")
+        .arg("copy")
+        // Some providers reconnect in short finite bursts whose timestamps
+        // have small holes. Even ffmpeg's discontinuity correction can leave
+        // those holes at the MSE boundary. setts is a bitstream filter, so it
+        // repairs the packet clock without the CPU/quality cost of transcoding.
+        .arg("-bsf:v")
+        .arg(CONTIGUOUS_VIDEO_TIMESTAMPS)
+        .arg("-bsf:a")
+        .arg(CONTIGUOUS_AUDIO_TIMESTAMPS)
+        .arg("-avoid_negative_ts")
+        .arg("make_zero")
+        .arg("-max_interleave_delta")
+        .arg("1000000")
+        .arg("-muxdelay")
+        .arg("0")
+        .arg("-muxpreload")
+        .arg("0")
+        .arg("-mpegts_flags")
+        .arg("+resend_headers+initial_discontinuity")
+        .arg("-flush_packets")
+        .arg("1")
+        .arg("-f")
+        .arg("mpegts")
+        .arg("pipe:1");
+
+    command.spawn().map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!("failed to start playback remux with {ffmpeg}: {error}"),
+        )
+    })
+}
+
+async fn forward_playback_remux_as_chunked_stream<W>(
+    writer: &mut W,
+    mut child: tokio::process::Child,
+    upstream_url: &str,
+) -> StreamForwardResult
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+    let Some(mut stdout) = child.stdout.take() else {
+        graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
+        return StreamForwardResult {
+            outcome: StreamForwardOutcome::UpstreamReadError("ffmpeg stdout unavailable"),
+            bytes_forwarded: 0,
+        };
+    };
+
+    if let Some(stderr) = child.stderr.take() {
+        let redacted = redact_url(upstream_url);
+        let original = upstream_url.to_string();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                log::debug!("[StreamProxy/remux] {}", line.replace(&original, &redacted));
+            }
+        });
+    }
+
+    let budget = Arc::new(tokio::sync::Semaphore::new(STREAM_PROXY_READ_AHEAD_BYTES));
+    let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel(STREAM_PROXY_READ_AHEAD_CHUNKS);
+    let reader = tokio::spawn(async move {
+        loop {
+            let mut chunk = vec![0u8; 64 * 1024];
+            match stdout.read(&mut chunk).await {
+                Ok(0) => return StreamForwardOutcome::Completed,
+                Ok(read) => {
+                    chunk.truncate(read);
+                    let permits = read.min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
+                    let permit = match budget.clone().acquire_many_owned(permits).await {
+                        Ok(permit) => permit,
+                        Err(_) => return StreamForwardOutcome::DownstreamClosed,
+                    };
+                    if chunk_tx.send((chunk, permit)).await.is_err() {
+                        return StreamForwardOutcome::DownstreamClosed;
+                    }
+                }
+                Err(_) => return StreamForwardOutcome::UpstreamReadError("ffmpeg stdout failed"),
+            }
+        }
+    });
+
+    let mut bytes_forwarded = 0u64;
+    let mut pacer = TransportStreamPacer::with_max_lead(REMUX_PACER_MAX_LEAD);
+    while let Some((chunk, _budget_permit)) = chunk_rx.recv().await {
+        let delay = pacer.delay_for_payload(&chunk);
+        if !pacer.announced && pacer.wall_anchor.is_some() {
+            pacer.announced = true;
+            log::info!("[StreamProxy/remux] Enabled normalized transport-clock pacing");
+        }
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+
+        let size_line = format!("{:x}\r\n", chunk.len());
+        if writer.write_all(size_line.as_bytes()).await.is_err()
+            || writer.write_all(&chunk).await.is_err()
+            || writer.write_all(b"\r\n").await.is_err()
+        {
+            reader.abort();
+            graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
+            return StreamForwardResult {
+                outcome: StreamForwardOutcome::DownstreamClosed,
+                bytes_forwarded,
+            };
+        }
+        bytes_forwarded = bytes_forwarded.saturating_add(chunk.len() as u64);
+    }
+
+    let outcome = match reader.await {
+        Ok(outcome) => outcome,
+        Err(_) => StreamForwardOutcome::UpstreamReadError("ffmpeg reader task failed"),
+    };
+    let status = match tokio::time::timeout(GRACEFUL_KILL_TIMEOUT, child.wait()).await {
+        Ok(Ok(status)) => Some(status),
+        _ => {
+            graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
+            None
+        }
+    };
+    if status.is_some_and(|status| !status.success()) {
+        log::warn!(
+            "[StreamProxy/remux] ffmpeg stopped while streaming {}",
+            redact_url(upstream_url)
+        );
+    }
+
+    StreamForwardResult {
+        outcome,
+        bytes_forwarded,
+    }
+}
+
+fn duration_to_pcr_ticks(duration: std::time::Duration) -> u64 {
+    duration
+        .as_secs()
+        .saturating_mul(MPEG_TS_PCR_TICKS_PER_SECOND)
+        .saturating_add(
+            u64::from(duration.subsec_nanos()).saturating_mul(MPEG_TS_PCR_TICKS_PER_SECOND)
+                / 1_000_000_000,
+        )
+}
+
+fn duration_from_pcr_ticks(ticks: u64) -> std::time::Duration {
+    let seconds = ticks / MPEG_TS_PCR_TICKS_PER_SECOND;
+    let remainder = ticks % MPEG_TS_PCR_TICKS_PER_SECOND;
+    let nanos = remainder.saturating_mul(1_000_000_000) / MPEG_TS_PCR_TICKS_PER_SECOND;
+    std::time::Duration::new(seconds, nanos as u32)
+}
+
+fn latest_transport_stream_pcr(data: &[u8], preferred_pid: Option<u16>) -> Option<(u16, u64)> {
+    if data.len() < MPEG_TS_PACKET_SIZE * 3 {
+        return None;
+    }
+
+    // Lock onto one packet boundary using three sync bytes. Scanning every
+    // 0x47 byte can mistake H.264 payload data for a TS header and feed bogus
+    // PCR jumps into the pacer.
+    let max_offset = MPEG_TS_PACKET_SIZE.min(data.len() - MPEG_TS_PACKET_SIZE * 2);
+    let sync_offset = (0..max_offset).find(|offset| {
+        data[*offset] == 0x47
+            && data[*offset + MPEG_TS_PACKET_SIZE] == 0x47
+            && data[*offset + MPEG_TS_PACKET_SIZE * 2] == 0x47
+    })?;
+
+    let mut latest = None;
+    let mut offset = sync_offset;
+    while offset + MPEG_TS_PACKET_SIZE <= data.len() {
+        let packet = &data[offset..offset + MPEG_TS_PACKET_SIZE];
+        if let Some(pid) = transport_stream_packet_pid(packet) {
+            if preferred_pid.map_or(true, |preferred| preferred == pid) {
+                if let Some(pcr) = transport_stream_packet_pcr(packet) {
+                    latest = Some((pid, pcr));
+                }
+            }
+        }
+        offset += MPEG_TS_PACKET_SIZE;
+    }
+    latest
+}
+
+fn transport_stream_packet_pid(packet: &[u8]) -> Option<u16> {
+    if packet.len() < MPEG_TS_PACKET_SIZE || packet[0] != 0x47 {
+        return None;
+    }
+    Some((u16::from(packet[1] & 0x1f) << 8) | u16::from(packet[2]))
+}
+
+fn transport_stream_packet_pcr(packet: &[u8]) -> Option<u64> {
+    if packet.len() < MPEG_TS_PACKET_SIZE || packet[0] != 0x47 {
+        return None;
+    }
+    let adaptation_control = (packet[3] >> 4) & 0x03;
+    if adaptation_control != 0x02 && adaptation_control != 0x03 {
+        return None;
+    }
+    let adaptation_length = packet[4] as usize;
+    if adaptation_length < 7 || 5 + adaptation_length > MPEG_TS_PACKET_SIZE {
+        return None;
+    }
+    if packet[5] & 0x10 == 0 {
+        return None;
+    }
+
+    let pcr_base = (u64::from(packet[6]) << 25)
+        | (u64::from(packet[7]) << 17)
+        | (u64::from(packet[8]) << 9)
+        | (u64::from(packet[9]) << 1)
+        | (u64::from(packet[10]) >> 7);
+    let pcr_extension = (u64::from(packet[10] & 0x01) << 8) | u64::from(packet[11]);
+    Some(pcr_base * 300 + pcr_extension)
+}
+
 async fn forward_response_as_chunked_stream<W>(
     writer: &mut W,
     response: reqwest::Response,
+    mut pacer: Option<&mut TransportStreamPacer>,
 ) -> StreamForwardResult
 where
     W: tokio::io::AsyncWrite + Unpin,
@@ -500,43 +924,67 @@ where
     use futures::StreamExt;
     use tokio::io::AsyncWriteExt;
 
-    let mut outcome = StreamForwardOutcome::Completed;
     let mut bytes_forwarded = 0u64;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk_result) = stream.next().await {
-        match chunk_result {
-            Ok(chunk) => {
-                let size_line = format!("{:x}\r\n", chunk.len());
-                if writer.write_all(size_line.as_bytes()).await.is_err() {
-                    return StreamForwardResult {
-                        outcome: StreamForwardOutcome::DownstreamClosed,
-                        bytes_forwarded,
+    let budget = Arc::new(tokio::sync::Semaphore::new(STREAM_PROXY_READ_AHEAD_BYTES));
+    let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel(STREAM_PROXY_READ_AHEAD_CHUNKS);
+    let reader = tokio::spawn(async move {
+        let mut stream = response.bytes_stream();
+        while let Some(chunk_result) = stream.next().await {
+            match chunk_result {
+                Ok(chunk) => {
+                    if chunk.is_empty() {
+                        continue;
+                    }
+                    let permits = chunk.len().min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
+                    let permit = match budget.clone().acquire_many_owned(permits).await {
+                        Ok(permit) => permit,
+                        Err(_) => return StreamForwardOutcome::DownstreamClosed,
+                    };
+                    if chunk_tx.send((chunk, permit)).await.is_err() {
+                        return StreamForwardOutcome::DownstreamClosed;
+                    }
+                }
+                Err(err) => {
+                    return if err.is_timeout() {
+                        StreamForwardOutcome::UpstreamReadTimeout
+                    } else {
+                        StreamForwardOutcome::UpstreamReadError(reqwest_error_kind(&err))
                     };
                 }
-                if writer.write_all(&chunk).await.is_err() {
-                    return StreamForwardResult {
-                        outcome: StreamForwardOutcome::DownstreamClosed,
-                        bytes_forwarded,
-                    };
-                }
-                if writer.write_all(b"\r\n").await.is_err() {
-                    return StreamForwardResult {
-                        outcome: StreamForwardOutcome::DownstreamClosed,
-                        bytes_forwarded,
-                    };
-                }
-                bytes_forwarded = bytes_forwarded.saturating_add(chunk.len() as u64);
-            }
-            Err(err) => {
-                outcome = if err.is_timeout() {
-                    StreamForwardOutcome::UpstreamReadTimeout
-                } else {
-                    StreamForwardOutcome::UpstreamReadError(reqwest_error_kind(&err))
-                };
-                break;
             }
         }
+        StreamForwardOutcome::Completed
+    });
+
+    while let Some((chunk, _budget_permit)) = chunk_rx.recv().await {
+        if let Some(pacer) = pacer.as_deref_mut() {
+            let delay = pacer.delay_for_payload(&chunk);
+            if !pacer.announced && pacer.wall_anchor.is_some() {
+                pacer.announced = true;
+                log::info!("[StreamProxy] Enabled transport-clock pacing for bursty live stream");
+            }
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+        }
+        let size_line = format!("{:x}\r\n", chunk.len());
+        if writer.write_all(size_line.as_bytes()).await.is_err()
+            || writer.write_all(&chunk).await.is_err()
+            || writer.write_all(b"\r\n").await.is_err()
+        {
+            reader.abort();
+            return StreamForwardResult {
+                outcome: StreamForwardOutcome::DownstreamClosed,
+                bytes_forwarded,
+            };
+        }
+        bytes_forwarded = bytes_forwarded.saturating_add(chunk.len() as u64);
     }
+
+    let outcome = match reader.await {
+        Ok(outcome) => outcome,
+        Err(_) => StreamForwardOutcome::UpstreamReadError("reader task failed"),
+    };
 
     StreamForwardResult {
         outcome,
@@ -617,7 +1065,7 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                 let request_str = String::from_utf8_lossy(&buf[..n]);
 
                 // Parse GET /stream?url=ENCODED_URL HTTP/1.1
-                let (url, reconnect) = match parse_stream_request(&request_str) {
+                let request = match parse_stream_request(&request_str) {
                     Some(request) => request,
                     None => {
                         let response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
@@ -625,6 +1073,8 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                         return;
                     }
                 };
+                let url = request.url;
+                let reconnect = request.reconnect;
 
                 if !is_safe_upstream_url(&url).await {
                     log::warn!("[StreamProxy] Blocked request to private/local target");
@@ -646,6 +1096,60 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
 
                 let user_agent = HeaderValue::from_str(&user_agent)
                     .unwrap_or_else(|_| HeaderValue::from_static("TiviMate/5.1.6 (Android 12)"));
+
+                if request.remux {
+                    let user_agent_text =
+                        user_agent.to_str().unwrap_or("TiviMate/5.1.6 (Android 12)");
+                    let child = match spawn_playback_remux(
+                        &app_handle,
+                        &url,
+                        user_agent_text,
+                        accept_invalid_certs,
+                    ) {
+                        Ok(child) => child,
+                        Err(error) => {
+                            log::warn!(
+                                "[StreamProxy/remux] Could not start for {}: {}",
+                                redact_url(&url),
+                                error
+                            );
+                            let body = "Playback remux unavailable";
+                            let response = format!(
+                                "HTTP/1.1 502 Bad Gateway\r\nContent-Length: {}\r\n\r\n{}",
+                                body.len(),
+                                body
+                            );
+                            let _ = socket.write_all(response.as_bytes()).await;
+                            return;
+                        }
+                    };
+
+                    let header = concat!(
+                        "HTTP/1.1 200 OK\r\n",
+                        "Content-Type: video/mp2t\r\n",
+                        "Access-Control-Allow-Origin: *\r\n",
+                        "Transfer-Encoding: chunked\r\n",
+                        "Cache-Control: no-cache\r\n",
+                        "Connection: close\r\n",
+                        "\r\n"
+                    );
+                    if socket.write_all(header.as_bytes()).await.is_err() {
+                        let mut child = child;
+                        graceful_kill(&mut child, GRACEFUL_KILL_TIMEOUT).await;
+                        return;
+                    }
+
+                    log::info!(
+                        "[StreamProxy/remux] Normalizing live MPEG-TS timestamps for {}",
+                        redact_url(&url)
+                    );
+                    let forward =
+                        forward_playback_remux_as_chunked_stream(&mut socket, child, &url).await;
+                    if forward.outcome != StreamForwardOutcome::DownstreamClosed {
+                        let _ = finish_chunked_stream(&mut socket).await;
+                    }
+                    return;
+                }
 
                 let response = match client
                     .get(&url)
@@ -705,17 +1209,20 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                 // Only successful live bodies are safe to concatenate after an
                 // upstream reconnect.
                 if !reconnect || !status.is_success() {
-                    let _ = forward_response_as_chunked_stream(&mut socket, response).await;
+                    let _ = forward_response_as_chunked_stream(&mut socket, response, None).await;
                     let _ = finish_chunked_stream(&mut socket).await;
                     return;
                 }
 
                 let mut response = response;
+                let mut pacer = TransportStreamPacer::new();
                 let mut reconnects = 0u32;
                 let mut consecutive_empty_attempts = 0u32;
 
                 loop {
-                    let forward = forward_response_as_chunked_stream(&mut socket, response).await;
+                    let forward =
+                        forward_response_as_chunked_stream(&mut socket, response, Some(&mut pacer))
+                            .await;
                     if forward.outcome == StreamForwardOutcome::DownstreamClosed {
                         log::debug!(
                             "[StreamProxy] Downstream disconnected while streaming {}",
@@ -799,21 +1306,34 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
     Ok(port)
 }
 
-fn parse_stream_request(request: &str) -> Option<(String, bool)> {
+#[derive(Debug, PartialEq, Eq)]
+struct StreamRequest {
+    url: String,
+    reconnect: bool,
+    remux: bool,
+}
+
+fn parse_stream_request(request: &str) -> Option<StreamRequest> {
     let first_line = request.lines().next()?;
     // GET /stream?url=ENCODED HTTP/1.1
     let path = first_line.split_whitespace().nth(1)?;
     let url = Url::parse(&format!("http://localhost{path}")).ok()?;
     let mut upstream_url = None;
     let mut reconnect = false;
+    let mut remux = false;
     for (key, value) in url.query_pairs() {
         match key.as_ref() {
             "url" => upstream_url = Some(value.into_owned()),
             "reconnect" => reconnect = value == "1" || value.eq_ignore_ascii_case("true"),
+            "remux" => remux = value == "1" || value.eq_ignore_ascii_case("true"),
             _ => {}
         }
     }
-    upstream_url.map(|url| (url, reconnect))
+    upstream_url.map(|url| StreamRequest {
+        url,
+        reconnect,
+        remux,
+    })
 }
 
 #[cfg(test)]
@@ -903,6 +1423,18 @@ mod tests {
     #[test]
     fn decode_invalid_base64_returns_none() {
         assert!(decode_proxy_url("!!!invalid!!!").is_none());
+    }
+
+    #[test]
+    fn redact_url_hides_xtream_path_credentials() {
+        assert_eq!(
+            redact_url("http://provider.example/live/user-name/pass-word/12345.ts"),
+            "http://provider.example/live/***/***/12345.ts"
+        );
+        assert_eq!(
+            redact_url("https://provider.example/user/pass/67890?token=secret"),
+            "https://provider.example/***/***/67890?***"
+        );
     }
 
     #[test]
@@ -1075,7 +1607,11 @@ segment.ts
             "GET /stream?url=https%3A%2F%2Fexample.com%2Fstr%C3%B8m%3Ftoken%3Dabc%2B123 HTTP/1.1\r\nHost: localhost\r\n\r\n";
         assert_eq!(
             parse_stream_request(request),
-            Some(("https://example.com/strøm?token=abc+123".to_string(), false))
+            Some(StreamRequest {
+                url: "https://example.com/strøm?token=abc+123".to_string(),
+                reconnect: false,
+                remux: false,
+            })
         );
     }
 
@@ -1084,7 +1620,24 @@ segment.ts
         let request = "GET /stream?url=https%3A%2F%2Fexample.com%2Flive.ts&reconnect=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
         assert_eq!(
             parse_stream_request(request),
-            Some(("https://example.com/live.ts".to_string(), true))
+            Some(StreamRequest {
+                url: "https://example.com/live.ts".to_string(),
+                reconnect: true,
+                remux: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_stream_request_enables_opt_in_remux() {
+        let request = "GET /stream?url=https%3A%2F%2Fexample.com%2Flive.ts&reconnect=1&remux=true HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        assert_eq!(
+            parse_stream_request(request),
+            Some(StreamRequest {
+                url: "https://example.com/live.ts".to_string(),
+                reconnect: true,
+                remux: true,
+            })
         );
     }
 
@@ -1116,7 +1669,7 @@ segment.ts
 
         let started = Instant::now();
         let mut sink = tokio::io::sink();
-        let result = forward_response_as_chunked_stream(&mut sink, response).await;
+        let result = forward_response_as_chunked_stream(&mut sink, response, None).await;
         let elapsed = started.elapsed();
 
         assert_eq!(result.outcome, StreamForwardOutcome::Completed);
@@ -1146,7 +1699,7 @@ segment.ts
             .expect("stream request should succeed");
 
         let mut sink = tokio::io::sink();
-        let result = forward_response_as_chunked_stream(&mut sink, response).await;
+        let result = forward_response_as_chunked_stream(&mut sink, response, None).await;
 
         assert_eq!(result.outcome, StreamForwardOutcome::UpstreamReadTimeout);
         assert_eq!(result.bytes_forwarded, 64);
@@ -1177,8 +1730,9 @@ segment.ts
         let second_response = client.get(&second_url).send().await.unwrap();
         let mut downstream = Vec::new();
 
-        let first = forward_response_as_chunked_stream(&mut downstream, first_response).await;
-        let second = forward_response_as_chunked_stream(&mut downstream, second_response).await;
+        let first = forward_response_as_chunked_stream(&mut downstream, first_response, None).await;
+        let second =
+            forward_response_as_chunked_stream(&mut downstream, second_response, None).await;
         assert!(finish_chunked_stream(&mut downstream).await);
 
         assert_eq!(first.bytes_forwarded, 2);
@@ -1199,6 +1753,152 @@ segment.ts
         assert_eq!(stream_reconnect_delay(1), Duration::from_secs(1));
         assert_eq!(stream_reconnect_delay(3), Duration::from_secs(4));
         assert_eq!(stream_reconnect_delay(8), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn parses_mpeg_ts_program_clock_reference() {
+        let pcr_base = 123_456_789u64;
+        let pcr_extension = 42u64;
+        let mut packet = vec![0xff; MPEG_TS_PACKET_SIZE];
+        packet[0] = 0x47;
+        packet[1] = 0x01;
+        packet[2] = 0x00;
+        packet[3] = 0x20;
+        packet[4] = 7;
+        packet[5] = 0x10;
+        packet[6] = (pcr_base >> 25) as u8;
+        packet[7] = (pcr_base >> 17) as u8;
+        packet[8] = (pcr_base >> 9) as u8;
+        packet[9] = (pcr_base >> 1) as u8;
+        packet[10] = (((pcr_base & 1) << 7) | 0x7e | (pcr_extension >> 8)) as u8;
+        packet[11] = pcr_extension as u8;
+
+        assert_eq!(
+            transport_stream_packet_pcr(&packet),
+            Some(pcr_base * 300 + pcr_extension)
+        );
+        assert_eq!(
+            duration_from_pcr_ticks(MPEG_TS_PCR_TICKS_PER_SECOND),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn pcr_discontinuity_preserves_accumulated_pacing_budget() {
+        let make_payload = |milliseconds: &[u64]| {
+            let mut payload = Vec::with_capacity(milliseconds.len() * MPEG_TS_PACKET_SIZE);
+            for millisecond in milliseconds {
+                let pcr_base = millisecond * 90;
+                let mut packet = vec![0xff; MPEG_TS_PACKET_SIZE];
+                packet[0] = 0x47;
+                packet[1] = 0x01;
+                packet[2] = 0x00;
+                packet[3] = 0x20;
+                packet[4] = 7;
+                packet[5] = 0x10;
+                packet[6] = (pcr_base >> 25) as u8;
+                packet[7] = (pcr_base >> 17) as u8;
+                packet[8] = (pcr_base >> 9) as u8;
+                packet[9] = (pcr_base >> 1) as u8;
+                packet[10] = (((pcr_base & 1) << 7) | 0x7e) as u8;
+                packet[11] = 0;
+                payload.extend_from_slice(&packet);
+            }
+            payload
+        };
+
+        let mut pacer = TransportStreamPacer::new();
+        assert_eq!(
+            pacer.delay_for_payload(&make_payload(&[0, 0, 0])),
+            Duration::ZERO
+        );
+        for step in 1..=360 {
+            let milliseconds = step * 250;
+            assert_eq!(
+                pacer
+                    .delay_for_payload(&make_payload(&[milliseconds, milliseconds, milliseconds,])),
+                Duration::ZERO
+            );
+        }
+        let first_delay = pacer.delay_for_payload(&make_payload(&[90_250, 90_250, 90_250]));
+        assert!(first_delay > Duration::from_millis(200));
+        pacer.wall_anchor = pacer.wall_anchor.map(|anchor| anchor - first_delay);
+
+        let second_delay = pacer.delay_for_payload(&make_payload(&[90_500, 90_500, 90_500]));
+        assert!(second_delay > Duration::from_millis(200));
+        pacer.wall_anchor = pacer.wall_anchor.map(|anchor| anchor - second_delay);
+
+        assert_eq!(
+            pacer.delay_for_payload(&make_payload(&[200_000, 200_000, 200_000])),
+            Duration::ZERO
+        );
+        assert!(
+            pacer.delay_for_payload(&make_payload(&[200_250, 200_250, 200_250]))
+                > Duration::from_millis(200)
+        );
+        assert_eq!(pacer.reanchor_count, 0);
+    }
+
+    #[test]
+    fn pcr_pacer_reanchors_instead_of_returning_a_starvation_delay() {
+        let make_payload = |milliseconds: &[u64]| {
+            let mut payload = Vec::with_capacity(milliseconds.len() * MPEG_TS_PACKET_SIZE);
+            for millisecond in milliseconds {
+                let pcr_base = millisecond * 90;
+                let mut packet = vec![0xff; MPEG_TS_PACKET_SIZE];
+                packet[0] = 0x47;
+                packet[1] = 0x01;
+                packet[2] = 0x00;
+                packet[3] = 0x20;
+                packet[4] = 7;
+                packet[5] = 0x10;
+                packet[6] = (pcr_base >> 25) as u8;
+                packet[7] = (pcr_base >> 17) as u8;
+                packet[8] = (pcr_base >> 9) as u8;
+                packet[9] = (pcr_base >> 1) as u8;
+                packet[10] = (((pcr_base & 1) << 7) | 0x7e) as u8;
+                packet[11] = 0;
+                payload.extend_from_slice(&packet);
+            }
+            payload
+        };
+
+        let mut pacer = TransportStreamPacer::new();
+        assert_eq!(
+            pacer.delay_for_payload(&make_payload(&[0, 0, 0])),
+            Duration::ZERO
+        );
+        for step in 1..=360 {
+            let milliseconds = step * 250;
+            assert_eq!(
+                pacer
+                    .delay_for_payload(&make_payload(&[milliseconds, milliseconds, milliseconds,])),
+                Duration::ZERO
+            );
+        }
+        assert!(
+            pacer.delay_for_payload(&make_payload(&[90_250, 90_250, 90_250]))
+                > Duration::from_millis(200)
+        );
+        for step in 362..=380 {
+            let milliseconds = step * 250;
+            assert!(!pacer
+                .delay_for_payload(&make_payload(&[milliseconds, milliseconds, milliseconds,]))
+                .is_zero());
+        }
+        assert_eq!(
+            pacer.delay_for_payload(&make_payload(&[95_250, 95_250, 95_250])),
+            Duration::ZERO
+        );
+        assert_eq!(pacer.reanchor_count, 1);
+        assert_eq!(
+            pacer.media_elapsed_ticks,
+            duration_to_pcr_ticks(pacer.max_lead)
+        );
+
+        let resumed_delay = pacer.delay_for_payload(&make_payload(&[95_500, 95_500, 95_500]));
+        assert!(resumed_delay > Duration::from_millis(200));
+        assert!(resumed_delay <= STREAM_PACER_MAX_DELAY);
     }
 
     #[tokio::test]

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -19,6 +19,12 @@ const PROXY_BUFFERED_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration
 /// cap total stream duration. Only kills truly dead/stalled connections.
 const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
+/// Short retry delay for a live MPEG-TS source that drops its upstream socket.
+/// The downstream connection stays open while the proxy reconnects, so the
+/// browser player can keep its MediaSource and buffered video intact.
+const STREAM_RECONNECT_BASE_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+const STREAM_RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Base64url-encode an original stream URL for the proxy scheme.
 pub fn encode_proxy_url(original: &str) -> String {
     URL_SAFE_NO_PAD.encode(original.as_bytes())
@@ -478,10 +484,16 @@ enum StreamForwardOutcome {
     DownstreamClosed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StreamForwardResult {
+    outcome: StreamForwardOutcome,
+    bytes_forwarded: u64,
+}
+
 async fn forward_response_as_chunked_stream<W>(
     writer: &mut W,
     response: reqwest::Response,
-) -> StreamForwardOutcome
+) -> StreamForwardResult
 where
     W: tokio::io::AsyncWrite + Unpin,
 {
@@ -489,20 +501,31 @@ where
     use tokio::io::AsyncWriteExt;
 
     let mut outcome = StreamForwardOutcome::Completed;
+    let mut bytes_forwarded = 0u64;
     let mut stream = response.bytes_stream();
     while let Some(chunk_result) = stream.next().await {
         match chunk_result {
             Ok(chunk) => {
                 let size_line = format!("{:x}\r\n", chunk.len());
                 if writer.write_all(size_line.as_bytes()).await.is_err() {
-                    return StreamForwardOutcome::DownstreamClosed;
+                    return StreamForwardResult {
+                        outcome: StreamForwardOutcome::DownstreamClosed,
+                        bytes_forwarded,
+                    };
                 }
                 if writer.write_all(&chunk).await.is_err() {
-                    return StreamForwardOutcome::DownstreamClosed;
+                    return StreamForwardResult {
+                        outcome: StreamForwardOutcome::DownstreamClosed,
+                        bytes_forwarded,
+                    };
                 }
                 if writer.write_all(b"\r\n").await.is_err() {
-                    return StreamForwardOutcome::DownstreamClosed;
+                    return StreamForwardResult {
+                        outcome: StreamForwardOutcome::DownstreamClosed,
+                        bytes_forwarded,
+                    };
                 }
+                bytes_forwarded = bytes_forwarded.saturating_add(chunk.len() as u64);
             }
             Err(err) => {
                 outcome = if err.is_timeout() {
@@ -515,11 +538,42 @@ where
         }
     }
 
-    if writer.write_all(b"0\r\n\r\n").await.is_err() {
-        return StreamForwardOutcome::DownstreamClosed;
+    StreamForwardResult {
+        outcome,
+        bytes_forwarded,
     }
+}
 
-    outcome
+async fn finish_chunked_stream<W>(writer: &mut W) -> bool
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+    writer.write_all(b"0\r\n\r\n").await.is_ok()
+}
+
+fn stream_reconnect_delay(consecutive_empty_attempts: u32) -> std::time::Duration {
+    let multiplier = 1u32 << consecutive_empty_attempts.min(4);
+    STREAM_RECONNECT_BASE_DELAY
+        .saturating_mul(multiplier)
+        .min(STREAM_RECONNECT_MAX_DELAY)
+}
+
+async fn wait_for_stream_reconnect(
+    socket: &mut tokio::net::TcpStream,
+    delay: std::time::Duration,
+) -> bool {
+    use tokio::io::AsyncReadExt;
+
+    let mut downstream_probe = [0u8; 1];
+    match tokio::time::timeout(delay, socket.read(&mut downstream_probe)).await {
+        Err(_) => true,
+        Ok(Ok(0)) | Ok(Err(_)) => false,
+        // The browser should not send another request on this Connection: close
+        // response, but consuming an unexpected byte is harmless and lets the
+        // reconnect proceed.
+        Ok(Ok(_)) => true,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -563,8 +617,8 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                 let request_str = String::from_utf8_lossy(&buf[..n]);
 
                 // Parse GET /stream?url=ENCODED_URL HTTP/1.1
-                let url = match parse_stream_request(&request_str) {
-                    Some(url) => url,
+                let (url, reconnect) = match parse_stream_request(&request_str) {
+                    Some(request) => request,
                     None => {
                         let response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
                         let _ = socket.write_all(response.as_bytes()).await;
@@ -590,14 +644,12 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
 
                 let client = get_or_create_proxy_client(state.inner(), accept_invalid_certs).await;
 
+                let user_agent = HeaderValue::from_str(&user_agent)
+                    .unwrap_or_else(|_| HeaderValue::from_static("TiviMate/5.1.6 (Android 12)"));
+
                 let response = match client
                     .get(&url)
-                    .header(
-                        USER_AGENT,
-                        HeaderValue::from_str(&user_agent).unwrap_or_else(|_| {
-                            HeaderValue::from_static("TiviMate/5.1.6 (Android 12)")
-                        }),
-                    )
+                    .header(USER_AGENT, user_agent.clone())
                     .send()
                     .await
                 {
@@ -649,31 +701,95 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                     return;
                 }
 
-                match forward_response_as_chunked_stream(&mut socket, response).await {
-                    StreamForwardOutcome::Completed => {
-                        log::debug!(
-                            "[StreamProxy] Upstream stream ended normally for {}",
-                            redact_url(&url)
-                        );
-                    }
-                    StreamForwardOutcome::UpstreamReadTimeout => {
-                        log::warn!(
-                            "[StreamProxy] Upstream stream stalled/timed out for {}",
-                            redact_url(&url)
-                        );
-                    }
-                    StreamForwardOutcome::UpstreamReadError(kind) => {
-                        log::warn!(
-                            "[StreamProxy] Upstream stream terminated for {} ({})",
-                            redact_url(&url),
-                            kind
-                        );
-                    }
-                    StreamForwardOutcome::DownstreamClosed => {
+                // Error responses are finite and should be delivered normally.
+                // Only successful live bodies are safe to concatenate after an
+                // upstream reconnect.
+                if !reconnect || !status.is_success() {
+                    let _ = forward_response_as_chunked_stream(&mut socket, response).await;
+                    let _ = finish_chunked_stream(&mut socket).await;
+                    return;
+                }
+
+                let mut response = response;
+                let mut reconnects = 0u32;
+                let mut consecutive_empty_attempts = 0u32;
+
+                loop {
+                    let forward = forward_response_as_chunked_stream(&mut socket, response).await;
+                    if forward.outcome == StreamForwardOutcome::DownstreamClosed {
                         log::debug!(
                             "[StreamProxy] Downstream disconnected while streaming {}",
                             redact_url(&url)
                         );
+                        return;
+                    }
+
+                    if forward.bytes_forwarded > 0 {
+                        consecutive_empty_attempts = 0;
+                    } else {
+                        consecutive_empty_attempts = consecutive_empty_attempts.saturating_add(1);
+                    }
+                    reconnects = reconnects.saturating_add(1);
+
+                    match forward.outcome {
+                        StreamForwardOutcome::Completed => log::warn!(
+                            "[StreamProxy] Upstream stream ended for {}; reconnecting (#{})",
+                            redact_url(&url),
+                            reconnects
+                        ),
+                        StreamForwardOutcome::UpstreamReadTimeout => log::warn!(
+                            "[StreamProxy] Upstream stream stalled/timed out for {}; reconnecting (#{})",
+                            redact_url(&url),
+                            reconnects
+                        ),
+                        StreamForwardOutcome::UpstreamReadError(kind) => log::warn!(
+                            "[StreamProxy] Upstream stream terminated for {} ({}); reconnecting (#{})",
+                            redact_url(&url),
+                            kind,
+                            reconnects
+                        ),
+                        StreamForwardOutcome::DownstreamClosed => unreachable!(),
+                    }
+
+                    loop {
+                        let delay = stream_reconnect_delay(consecutive_empty_attempts);
+                        if !wait_for_stream_reconnect(&mut socket, delay).await {
+                            log::debug!(
+                                "[StreamProxy] Downstream closed while reconnecting {}",
+                                redact_url(&url)
+                            );
+                            return;
+                        }
+
+                        match client
+                            .get(&url)
+                            .header(USER_AGENT, user_agent.clone())
+                            .send()
+                            .await
+                        {
+                            Ok(next_response) if next_response.status().is_success() => {
+                                response = next_response;
+                                break;
+                            }
+                            Ok(next_response) => {
+                                consecutive_empty_attempts =
+                                    consecutive_empty_attempts.saturating_add(1);
+                                log::warn!(
+                                    "[StreamProxy] Reconnect for {} returned HTTP {}; retrying",
+                                    redact_url(&url),
+                                    next_response.status()
+                                );
+                            }
+                            Err(err) => {
+                                consecutive_empty_attempts =
+                                    consecutive_empty_attempts.saturating_add(1);
+                                log::warn!(
+                                    "[StreamProxy] Reconnect failed for {} ({}); retrying",
+                                    redact_url(&url),
+                                    reqwest_error_kind(&err)
+                                );
+                            }
+                        }
                     }
                 }
             });
@@ -683,13 +799,21 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
     Ok(port)
 }
 
-fn parse_stream_request(request: &str) -> Option<String> {
+fn parse_stream_request(request: &str) -> Option<(String, bool)> {
     let first_line = request.lines().next()?;
     // GET /stream?url=ENCODED HTTP/1.1
     let path = first_line.split_whitespace().nth(1)?;
     let url = Url::parse(&format!("http://localhost{path}")).ok()?;
-    url.query_pairs()
-        .find_map(|(key, value)| (key == "url").then(|| value.into_owned()))
+    let mut upstream_url = None;
+    let mut reconnect = false;
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "url" => upstream_url = Some(value.into_owned()),
+            "reconnect" => reconnect = value == "1" || value.eq_ignore_ascii_case("true"),
+            _ => {}
+        }
+    }
+    upstream_url.map(|url| (url, reconnect))
 }
 
 #[cfg(test)]
@@ -950,8 +1074,17 @@ segment.ts
         let request =
             "GET /stream?url=https%3A%2F%2Fexample.com%2Fstr%C3%B8m%3Ftoken%3Dabc%2B123 HTTP/1.1\r\nHost: localhost\r\n\r\n";
         assert_eq!(
-            parse_stream_request(request).as_deref(),
-            Some("https://example.com/strøm?token=abc+123")
+            parse_stream_request(request),
+            Some(("https://example.com/strøm?token=abc+123".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn parse_stream_request_enables_opt_in_reconnect() {
+        let request = "GET /stream?url=https%3A%2F%2Fexample.com%2Flive.ts&reconnect=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        assert_eq!(
+            parse_stream_request(request),
+            Some(("https://example.com/live.ts".to_string(), true))
         );
     }
 
@@ -983,10 +1116,11 @@ segment.ts
 
         let started = Instant::now();
         let mut sink = tokio::io::sink();
-        let outcome = forward_response_as_chunked_stream(&mut sink, response).await;
+        let result = forward_response_as_chunked_stream(&mut sink, response).await;
         let elapsed = started.elapsed();
 
-        assert_eq!(outcome, StreamForwardOutcome::Completed);
+        assert_eq!(result.outcome, StreamForwardOutcome::Completed);
+        assert_eq!(result.bytes_forwarded, 192);
         assert!(
             elapsed > simulated_old_total_timeout,
             "stream completed too quickly to cover the old timeout window: {:?}",
@@ -1012,11 +1146,59 @@ segment.ts
             .expect("stream request should succeed");
 
         let mut sink = tokio::io::sink();
-        let outcome = forward_response_as_chunked_stream(&mut sink, response).await;
+        let result = forward_response_as_chunked_stream(&mut sink, response).await;
 
-        assert_eq!(outcome, StreamForwardOutcome::UpstreamReadTimeout);
+        assert_eq!(result.outcome, StreamForwardOutcome::UpstreamReadTimeout);
+        assert_eq!(result.bytes_forwarded, 64);
 
         server_handle.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn reconnected_upstreams_share_one_downstream_chunked_response() {
+        let (first_url, first_server) = spawn_chunked_upstream(
+            vec![TestStreamChunk {
+                body: vec![0x01, 0x02],
+                delay_after: Duration::ZERO,
+            }],
+            Duration::ZERO,
+        )
+        .await;
+        let (second_url, second_server) = spawn_chunked_upstream(
+            vec![TestStreamChunk {
+                body: vec![0x03, 0x04, 0x05],
+                delay_after: Duration::ZERO,
+            }],
+            Duration::ZERO,
+        )
+        .await;
+        let client = build_proxy_client(false, Duration::from_secs(1), Duration::from_secs(1));
+        let first_response = client.get(&first_url).send().await.unwrap();
+        let second_response = client.get(&second_url).send().await.unwrap();
+        let mut downstream = Vec::new();
+
+        let first = forward_response_as_chunked_stream(&mut downstream, first_response).await;
+        let second = forward_response_as_chunked_stream(&mut downstream, second_response).await;
+        assert!(finish_chunked_stream(&mut downstream).await);
+
+        assert_eq!(first.bytes_forwarded, 2);
+        assert_eq!(second.bytes_forwarded, 3);
+        assert_eq!(
+            downstream,
+            b"2\r\n\x01\x02\r\n3\r\n\x03\x04\x05\r\n0\r\n\r\n"
+        );
+        first_server.await.expect("first server task should finish");
+        second_server
+            .await
+            .expect("second server task should finish");
+    }
+
+    #[test]
+    fn reconnect_delay_backs_off_and_caps() {
+        assert_eq!(stream_reconnect_delay(0), Duration::from_millis(500));
+        assert_eq!(stream_reconnect_delay(1), Duration::from_secs(1));
+        assert_eq!(stream_reconnect_delay(3), Duration::from_secs(4));
+        assert_eq!(stream_reconnect_delay(8), Duration::from_secs(5));
     }
 
     #[tokio::test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,7 @@
         "hiddenTitle": true,
         "titleBarStyle": "Overlay",
         "transparent": true,
+        "additionalBrowserArgs": "--disable-features=SuspendMutedAudio --autoplay-policy=no-user-gesture-required --disable-background-media-suspend",
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -851,6 +851,12 @@ export default function App() {
   const streamPlayer = useStreamPlayer({
     onPlaybackFailed: (result) => handlePlaybackFailedRef.current?.(result),
   });
+  const {
+    activeChannelIndex: playbackChannelIndex,
+    play: playStream,
+    stop: stopStream,
+    videoElement: playbackVideoElement,
+  } = streamPlayer;
 
   const baseChromecast = useChromecast();
   // mDNS discovery is best-effort; the device list can drop a device between
@@ -869,6 +875,8 @@ export default function App() {
     () => ({ ...baseChromecast, cast: wrappedCast }),
     [baseChromecast, wrappedCast],
   );
+  const chromecastRef = useRef(chromecast);
+  chromecastRef.current = chromecast;
   const castSession = chromecast.session;
   const isCasting = isCastSessionActive(castSession);
 
@@ -2505,48 +2513,49 @@ export default function App() {
       // instead of starting a competing local stream. Single-connection IPTV
       // upstreams can only feed one consumer; starting local play would kick
       // the cast pipeline's ffmpeg off the upstream.
-      if (isCastSessionActive(chromecast.session)) {
-        const session = chromecast.session;
+      const currentChromecast = chromecastRef.current;
+      if (isCastSessionActive(currentChromecast.session)) {
+        const session = currentChromecast.session;
         const device =
-          chromecast.devices.find((d) => d.id === session.deviceId) ??
+          currentChromecast.devices.find((d) => d.id === session.deviceId) ??
           (lastCastDeviceRef.current?.id === session.deviceId
             ? lastCastDeviceRef.current
             : null);
         if (device) {
-          void chromecast.cast(device, buildCastRequest(result));
+          void currentChromecast.cast(device, buildCastRequest(result));
           return;
         }
         // Fall through to local play if we can't resolve the device — better
         // than silently doing nothing.
       }
       getStore().setPlayIntentActive(true);
-      streamPlayer.play(result);
+      playStream(result);
     },
-    [chromecast, streamPlayer],
+    [playStream],
   );
 
   const handleStopPlayer = useCallback(() => {
     getStore().setPlayIntentActive(false);
-    streamPlayer.stop();
-  }, [streamPlayer]);
+    stopStream();
+  }, [stopStream]);
 
   const handlePip = useCallback(() => {
-    const video = streamPlayer.videoElement;
+    const video = playbackVideoElement;
     if (!video) return;
     if (document.pictureInPictureElement) {
       document.exitPictureInPicture().catch(() => {});
     } else if (document.pictureInPictureEnabled) {
       video.requestPictureInPicture().catch(() => {});
     }
-  }, [streamPlayer.videoElement]);
+  }, [playbackVideoElement]);
 
   const handleProceedPlayback = useCallback(() => {
     if (!pendingPlaybackChannel) return;
     const channel = pendingPlaybackChannel;
     getStore().setPendingPlaybackChannel(null);
     getStore().setPlayIntentActive(true);
-    streamPlayer.play(channel);
-  }, [pendingPlaybackChannel, streamPlayer]);
+    playStream(channel);
+  }, [pendingPlaybackChannel, playStream]);
 
   // Merge player-derived metadata into ChannelResult for unscanned channels
   const lastMergedMetaRef = useRef<{ index: number; meta: typeof streamPlayer.streamMetadata } | null>(null);
@@ -2620,14 +2629,14 @@ export default function App() {
   );
   // Auto-stop player when selected channel changes or is deselected
   useEffect(() => {
-    if (streamPlayer.activeChannelIndex === null) return;
+    if (playbackChannelIndex === null) return;
     if (!liveSelectedChannel) {
       getStore().setPlayIntentActive(false);
-      streamPlayer.stop();
-    } else if (liveSelectedChannel.index !== streamPlayer.activeChannelIndex) {
-      streamPlayer.stop();
+      stopStream();
+    } else if (liveSelectedChannel.index !== playbackChannelIndex) {
+      stopStream();
     }
-  }, [liveSelectedChannel, streamPlayer]);
+  }, [liveSelectedChannel, playbackChannelIndex, stopStream]);
 
   const headerPortalRef = useRef<HTMLDivElement>(null);
   const [toolbarHeight, setToolbarHeight] = useState(0);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -876,7 +876,9 @@ export default function App() {
     [baseChromecast, wrappedCast],
   );
   const chromecastRef = useRef(chromecast);
-  chromecastRef.current = chromecast;
+  useEffect(() => {
+    chromecastRef.current = chromecast;
+  }, [chromecast]);
   const castSession = chromecast.session;
   const isCasting = isCastSessionActive(castSession);
 
@@ -2417,6 +2419,7 @@ export default function App() {
     const baseUrl = import.meta.env.DEV ? devUrl : window.location.origin;
     new WebviewWindow("settings", {
       url: `${baseUrl}?window=settings`,
+      ...(platform === "windows" ? { dataDirectory: "settings-webview" } : {}),
       title: "Settings",
       width: 620,
       height: 680,
@@ -2429,7 +2432,7 @@ export default function App() {
       hiddenTitle: true,
       titleBarStyle: "overlay",
     });
-  }, []);
+  }, [platform]);
   useEffect(() => {
     handleOpenSettingsRef.current = handleOpenSettings;
   }, [handleOpenSettings]);
@@ -2447,6 +2450,7 @@ export default function App() {
     const baseUrl = import.meta.env.DEV ? devUrl : window.location.origin;
     new WebviewWindow("log", {
       url: `${baseUrl}?window=log`,
+      ...(platform === "windows" ? { dataDirectory: "log-webview" } : {}),
       title: "Log",
       width: 900,
       height: 600,
@@ -2459,7 +2463,7 @@ export default function App() {
       hiddenTitle: true,
       titleBarStyle: "overlay",
     });
-  }, []);
+  }, [platform]);
   useEffect(() => {
     handleOpenLogRef.current = handleOpenLog;
   }, [handleOpenLog]);

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -12,6 +12,7 @@ import {
   VolumeX,
 } from "lucide-react";
 import type { UseChromecastResult } from "../hooks/useChromecast";
+import { MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../hooks/useStreamPlayer";
 import type { CastMediaRequest } from "../lib/types";
 import { isCastSessionActive } from "../lib/cast";
 import { CastMenu } from "./CastMenu";
@@ -156,7 +157,10 @@ export function StreamPlayer({
             <div className="flex items-center gap-1.5 text-[11px] text-amber-100/85">
               <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
               <span>
-                Trying a clean reconnect{recoveryAttempt ? ` (${recoveryAttempt}/2)` : ""}
+                Trying a clean reconnect
+                {recoveryAttempt
+                  ? ` (${recoveryAttempt}/${MAX_PLAYBACK_RECOVERY_ATTEMPTS})`
+                  : ""}
               </span>
             </div>
           )}

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -45,6 +45,25 @@ export interface StreamMetadata {
   audioOnly: boolean;
 }
 
+export function areStreamMetadataEqual(
+  left: StreamMetadata | null,
+  right: StreamMetadata | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.width === right.width &&
+    left.height === right.height &&
+    left.resolution === right.resolution &&
+    left.codec === right.codec &&
+    left.fps === right.fps &&
+    left.videoBitrate === right.videoBitrate &&
+    left.audioCodec === right.audioCodec &&
+    left.audioBitrate === right.audioBitrate &&
+    left.audioOnly === right.audioOnly
+  );
+}
+
 export interface UseStreamPlayerReturn {
   playerState: PlayerState;
   errorMessage: string | null;
@@ -126,20 +145,43 @@ export function classifyStream(url: string): StreamType {
 }
 
 /**
- * Try to convert an Xtream MPEG-TS URL to HLS format.
- * Xtream pattern: http://host:port/username/password/stream_id
- * HLS variant:    http://host:port/live/username/password/stream_id.m3u8
+ * Convert the common Xtream live URL forms to their HLS equivalent.
+ * Providers frequently return `/live/user/pass/id.ts`; treating that as a
+ * generic MPEG-TS endpoint can let a bursty response fill WebView's MSE quota.
  */
-function tryConvertToXtreamHls(url: string): string | null {
-  const match = url.match(/^(https?:\/\/[^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/);
-  if (!match) return null;
-  const [, origin, user, pass, id] = match;
-  return `${origin}/live/${user}/${pass}/${id}.m3u8`;
+export function tryConvertToXtreamHls(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  const firstSegment = segments[0]?.toLowerCase();
+  const offset = firstSegment === "live" ? 1 : 0;
+  if (segments.length - offset !== 3) return null;
+
+  const user = segments[offset];
+  const password = segments[offset + 1];
+  const streamPart = segments[offset + 2];
+  const streamMatch = streamPart?.match(/^(\d+)(?:\.(?:ts|m2ts|mpegts))?$/i);
+  if (!user || !password || !streamMatch) return null;
+
+  parsed.pathname = `/live/${user}/${password}/${streamMatch[1]}.m3u8`;
+  return parsed.toString();
 }
 
-function toStreamingProxyUrl(url: string, port: number, reconnect: boolean): string {
+function toStreamingProxyUrl(
+  url: string,
+  port: number,
+  reconnect: boolean,
+  remux: boolean,
+): string {
   const reconnectParam = reconnect ? "&reconnect=1" : "";
-  return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}${reconnectParam}`;
+  const remuxParam = remux ? "&remux=1" : "";
+  return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}${reconnectParam}${remuxParam}`;
 }
 
 export function supportsNativeHlsPlayback(
@@ -200,8 +242,117 @@ const PLAYBACK_STALL_GRACE_MS = 15_000;
 const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
 const PLAYBACK_WATCHDOG_POLL_MS = 1_000;
 const MIN_PROGRESS_DELTA_SECS = 0.05;
-const HAVE_FUTURE_DATA = 3;
 const HLS_BUFFER_STALLED_ERROR = "bufferStalledError";
+const LIVE_RESYNC_MIN_SEEK_SECS = 1;
+const LIVE_RESYNC_MAX_SEEK_SECS = 3;
+const LIVE_RESYNC_MAX_JUMP_SECS = 30;
+const LIVE_RESYNC_COOLDOWN_MS = 3_000;
+const LIVE_RESYNC_WAIT_CONFIRM_MS = 750;
+const LIVE_RESYNC_SILENT_STALL_MS = 3_000;
+const LIVE_BUFFER_SLOWDOWN_THRESHOLD_SECS = 12;
+const LIVE_BUFFER_RECOVERED_THRESHOLD_SECS = 20;
+const LIVE_BUFFER_RECOVERY_RATE = 0.97;
+const LIVE_BUFFER_CATCHUP_THRESHOLD_SECS = 30;
+const LIVE_BUFFER_CATCHUP_RATE = 1.08;
+const LIVE_BUFFER_MAX_LATENCY_SECS = 60;
+const LIVE_BUFFER_TARGET_LATENCY_SECS = 20;
+
+export interface BufferedTimeRange {
+  start: number;
+  end: number;
+}
+
+export function chooseLiveBufferPlaybackRate(
+  currentRate: number,
+  bufferedAhead: number,
+): number {
+  if (!Number.isFinite(bufferedAhead)) return 1;
+  if (currentRate < 1) {
+    return bufferedAhead < LIVE_BUFFER_RECOVERED_THRESHOLD_SECS
+      ? LIVE_BUFFER_RECOVERY_RATE
+      : 1;
+  }
+  if (currentRate > 1) {
+    return bufferedAhead > LIVE_BUFFER_RECOVERED_THRESHOLD_SECS
+      ? LIVE_BUFFER_CATCHUP_RATE
+      : 1;
+  }
+  if (bufferedAhead > LIVE_BUFFER_CATCHUP_THRESHOLD_SECS) {
+    return LIVE_BUFFER_CATCHUP_RATE;
+  }
+  return bufferedAhead < LIVE_BUFFER_SLOWDOWN_THRESHOLD_SECS
+    ? LIVE_BUFFER_RECOVERY_RATE
+    : 1;
+}
+
+function bufferedSecondsAhead(currentTime: number, ranges: BufferedTimeRange[]): number {
+  const currentRange = ranges.find(
+    (range) => currentTime >= range.start && currentTime < range.end,
+  );
+  return currentRange ? Math.max(0, currentRange.end - currentTime) : 0;
+}
+
+export function findLiveLatencyCatchUpTarget(
+  currentTime: number,
+  ranges: BufferedTimeRange[],
+  maxLatency = LIVE_BUFFER_MAX_LATENCY_SECS,
+  targetLatency = LIVE_BUFFER_TARGET_LATENCY_SECS,
+): number | null {
+  if (!Number.isFinite(currentTime)) return null;
+  const currentRange = ranges.find(
+    (range) => currentTime >= range.start && currentTime < range.end,
+  );
+  if (!currentRange || currentRange.end - currentTime <= maxLatency) {
+    return null;
+  }
+  const target = Math.max(
+    currentRange.start + MIN_PROGRESS_DELTA_SECS,
+    currentRange.end - targetLatency,
+  );
+  return target > currentTime + MIN_PROGRESS_DELTA_SECS ? target : null;
+}
+
+/**
+ * Choose a safe point already buffered by MSE when a live stream stops at a
+ * timestamp/keyframe discontinuity. Some IPTV MPEG-TS sources keep delivering
+ * data while leaving the playhead on an undecodable boundary; rebuilding the
+ * whole player loses far more video than moving to the next buffered keyframe.
+ */
+export function findLiveBufferResyncTarget(
+  currentTime: number,
+  ranges: BufferedTimeRange[],
+  maxJump = LIVE_RESYNC_MAX_JUMP_SECS,
+): number | null {
+  if (!Number.isFinite(currentTime) || ranges.length === 0) return null;
+
+  for (const range of ranges) {
+    if (!Number.isFinite(range.start) || !Number.isFinite(range.end) || range.end <= range.start) {
+      continue;
+    }
+
+    if (range.start > currentTime + MIN_PROGRESS_DELTA_SECS) {
+      const gap = range.start - currentTime;
+      if (gap > maxJump) return null;
+      return Math.min(range.end - 0.01, range.start + MIN_PROGRESS_DELTA_SECS);
+    }
+
+    if (
+      currentTime >= range.start - MIN_PROGRESS_DELTA_SECS &&
+      currentTime < range.end - MIN_PROGRESS_DELTA_SECS
+    ) {
+      const availableAdvance = range.end - currentTime - MIN_PROGRESS_DELTA_SECS;
+      const advance = Math.min(
+        LIVE_RESYNC_MAX_SEEK_SECS,
+        maxJump,
+        Math.max(LIVE_RESYNC_MIN_SEEK_SECS, availableAdvance),
+      );
+      const target = Math.min(range.end - MIN_PROGRESS_DELTA_SECS, currentTime + advance);
+      return target > currentTime + MIN_PROGRESS_DELTA_SECS ? target : null;
+    }
+  }
+
+  return null;
+}
 
 export function getHlsFatalRecoveryAction(type?: string): HlsFatalRecoveryAction {
   if (type === "networkError") return "restart_network";
@@ -436,7 +587,9 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     }
 
     if (meta.width || meta.codec || meta.audioCodec) {
-      setStreamMetadata(meta);
+      setStreamMetadata((previous) =>
+        areStreamMetadataEqual(previous, meta) ? previous : meta,
+      );
     }
   }, [videoElement]);
 
@@ -464,12 +617,10 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       };
       hlsEvents.on("hlsLevelSwitched", hlsHandler);
       hlsEvents.on("hlsManifestParsed", hlsHandler);
-      hlsEvents.on("hlsFragLoaded", hlsHandler);
       libCleanups.push(() => {
         try {
           hlsEvents.off("hlsLevelSwitched", hlsHandler);
           hlsEvents.off("hlsManifestParsed", hlsHandler);
-          hlsEvents.off("hlsFragLoaded", hlsHandler);
         } catch {}
       });
     }
@@ -478,11 +629,9 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     if (mpegts?.on && mpegts.off) {
       const mpegtsHandler = () => collectMetadata();
       mpegts.on("media_info", mpegtsHandler);
-      mpegts.on("statistics_info", mpegtsHandler);
       libCleanups.push(() => {
         try {
           mpegts.off?.("media_info", mpegtsHandler);
-          mpegts.off?.("statistics_info", mpegtsHandler);
         } catch {}
       });
     }
@@ -629,7 +778,9 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         lastProgressAt: performance.now(),
         lastCurrentTime: videoElement.currentTime,
         stallStartedAt: null as number | null,
+        lastResyncAt: Number.NEGATIVE_INFINITY,
       };
+      let resyncTimer: ReturnType<typeof setTimeout> | null = null;
 
       const handlers: Array<{ target: EventTarget; event: string; handler: EventListener }> = [];
       const addHandler = (target: EventTarget, event: string, handler: EventListener) => {
@@ -657,6 +808,105 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       };
 
+      const tryLiveBufferResync = () => {
+        if (
+          closed ||
+          !mpegtsPlayerRef.current ||
+          isPausedRef.current ||
+          videoElement.paused ||
+          performance.now() - monitor.lastResyncAt < LIVE_RESYNC_COOLDOWN_MS
+        ) {
+          return false;
+        }
+
+        const ranges: BufferedTimeRange[] = [];
+        for (let index = 0; index < videoElement.buffered.length; index += 1) {
+          ranges.push({
+            start: videoElement.buffered.start(index),
+            end: videoElement.buffered.end(index),
+          });
+        }
+        const from = videoElement.currentTime;
+        const target = findLiveBufferResyncTarget(from, ranges);
+        if (target === null || target <= from + MIN_PROGRESS_DELTA_SECS) {
+          return false;
+        }
+
+        monitor.lastResyncAt = performance.now();
+        monitor.lastCurrentTime = target;
+        monitor.lastProgressAt = monitor.lastResyncAt;
+        monitor.stallStartedAt = null;
+        logger.warn(
+          `[Player] Skipping ${(target - from).toFixed(2)}s buffered timestamp gap`,
+        );
+        videoElement.currentTime = target;
+        void videoElement.play().catch(() => {});
+        return true;
+      };
+
+      const adjustLiveBufferPlaybackRate = () => {
+        if (!mpegtsPlayerRef.current) return;
+        const ranges: BufferedTimeRange[] = [];
+        for (let index = 0; index < videoElement.buffered.length; index += 1) {
+          ranges.push({
+            start: videoElement.buffered.start(index),
+            end: videoElement.buffered.end(index),
+          });
+        }
+        const bufferedAhead = bufferedSecondsAhead(videoElement.currentTime, ranges);
+        const nextRate = chooseLiveBufferPlaybackRate(videoElement.playbackRate, bufferedAhead);
+        if (Math.abs(videoElement.playbackRate - nextRate) < 0.001) return;
+        videoElement.playbackRate = nextRate;
+        logger.info(
+          nextRate < 1
+            ? `[Player] Slowing live playback to ${nextRate.toFixed(2)}x to rebuild buffer`
+            : nextRate > 1
+              ? `[Player] Increasing live playback to ${nextRate.toFixed(2)}x to reduce latency`
+            : "[Player] Restored live playback to 1.00x",
+        );
+      };
+
+      const trimExcessiveLiveLatency = () => {
+        if (!mpegtsPlayerRef.current || videoElement.buffered.length === 0) return false;
+        const ranges: BufferedTimeRange[] = [];
+        for (let index = 0; index < videoElement.buffered.length; index += 1) {
+          ranges.push({
+            start: videoElement.buffered.start(index),
+            end: videoElement.buffered.end(index),
+          });
+        }
+        const from = videoElement.currentTime;
+        const target = findLiveLatencyCatchUpTarget(from, ranges);
+        if (target === null) return false;
+
+        const now = performance.now();
+        monitor.lastResyncAt = now;
+        monitor.lastCurrentTime = target;
+        monitor.lastProgressAt = now;
+        monitor.stallStartedAt = null;
+        logger.warn(
+          `[Player] Trimming ${(target - from).toFixed(1)}s accumulated live latency`,
+        );
+        videoElement.currentTime = target;
+        void videoElement.play().catch(() => {});
+        return true;
+      };
+
+      const clearResyncTimer = () => {
+        if (!resyncTimer) return;
+        clearTimeout(resyncTimer);
+        resyncTimer = null;
+      };
+
+      const scheduleLiveBufferResync = () => {
+        markPotentialStall();
+        if (resyncTimer) return;
+        resyncTimer = setTimeout(() => {
+          resyncTimer = null;
+          tryLiveBufferResync();
+        }, LIVE_RESYNC_WAIT_CONFIRM_MS);
+      };
+
       const triggerRuntimeIssue = (
         issue: PlaybackRecoveryIssue,
         reason: string,
@@ -669,6 +919,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       };
 
       addHandler(videoElement, "playing", () => {
+        clearResyncTimer();
         monitor.lastProgressAt = performance.now();
         monitor.lastCurrentTime = videoElement.currentTime;
         monitor.stallStartedAt = null;
@@ -677,14 +928,29 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         markProgress();
       });
       addHandler(videoElement, "canplay", () => {
+        clearResyncTimer();
         markProgress();
         monitor.stallStartedAt = null;
       });
       addHandler(videoElement, "waiting", () => {
-        markPotentialStall();
+        scheduleLiveBufferResync();
       });
       addHandler(videoElement, "stalled", () => {
-        markPotentialStall();
+        scheduleLiveBufferResync();
+      });
+      addHandler(videoElement, "pause", () => {
+        if (closed || isPausedRef.current || videoElement.ended) return;
+        logger.warn("[Player] Resuming an unexpected media pause");
+        window.setTimeout(() => {
+          if (
+            !closed &&
+            !isPausedRef.current &&
+            videoElement.paused &&
+            !videoElement.ended
+          ) {
+            void videoElement.play().catch(() => {});
+          }
+        }, 100);
       });
       addHandler(videoElement, "error", () => {
         const reason = readMediaErrorMessage(videoElement.error) ?? "Media error during playback";
@@ -777,13 +1043,16 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           isPausedRef.current ||
           videoElement.paused ||
           videoElement.seeking ||
-          videoElement.ended ||
-          document.visibilityState === "hidden"
+          videoElement.ended
         ) {
           return;
         }
 
         const now = performance.now();
+        if (trimExcessiveLiveLatency()) {
+          return;
+        }
+        adjustLiveBufferPlaybackRate();
         const currentTime = videoElement.currentTime;
         if (currentTime > monitor.lastCurrentTime + MIN_PROGRESS_DELTA_SECS) {
           monitor.lastCurrentTime = currentTime;
@@ -793,16 +1062,27 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
 
         if (monitor.stallStartedAt !== null) {
+          if (
+            now - monitor.stallStartedAt >= LIVE_RESYNC_WAIT_CONFIRM_MS &&
+            tryLiveBufferResync()
+          ) {
+            return;
+          }
           if (now - monitor.stallStartedAt >= PLAYBACK_STALL_GRACE_MS) {
             triggerRuntimeIssue("watchdog_stall", "Stream stalled during playback");
           }
           return;
         }
 
+        const noProgressDuration = now - monitor.lastProgressAt;
         if (
-          videoElement.readyState < HAVE_FUTURE_DATA &&
-          now - monitor.lastProgressAt >= PLAYBACK_NO_PROGRESS_STALL_MS
+          noProgressDuration >= LIVE_RESYNC_SILENT_STALL_MS &&
+          tryLiveBufferResync()
         ) {
+          return;
+        }
+
+        if (noProgressDuration >= PLAYBACK_NO_PROGRESS_STALL_MS) {
           triggerRuntimeIssue("watchdog_stall", "Playback stopped progressing");
         }
       }, PLAYBACK_WATCHDOG_POLL_MS);
@@ -810,6 +1090,8 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       runtimeMonitorCleanupRef.current = () => {
         closed = true;
         clearInterval(watchdog);
+        clearResyncTimer();
+        videoElement.playbackRate = 1;
         for (const h of handlers) {
           h.target.removeEventListener(h.event, h.handler);
         }
@@ -952,6 +1234,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           {
             // Trade a small amount of live latency for enough network cushion
             // to ride out the jitter common on IPTV provider connections.
+            enableWorker: true,
             enableStashBuffer: true,
             stashInitialSize: 1024 * 1024,
             lazyLoad: false,
@@ -1147,7 +1430,12 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           logger.warn("[Player] Could not get streaming proxy port");
         }
         const playbackUrl = proxyPort > 0
-          ? toStreamingProxyUrl(url, proxyPort, result.content_type === "live")
+          ? toStreamingProxyUrl(
+              url,
+              proxyPort,
+              result.content_type === "live",
+              result.content_type === "live",
+            )
           : url;
         if (proxyPort > 0) {
           logger.info("[Player] Trying mpegts.js via streaming proxy for", result.name);
@@ -1200,6 +1488,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
   const play = useCallback((result: ChannelResult) => {
     playbackSessionIdRef.current += 1;
+    isPausedRef.current = false;
     const sessionId = playbackSessionIdRef.current;
     clearRecoveryTimer();
     currentChannelRef.current = result;
@@ -1211,6 +1500,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
   const stop = useCallback(() => {
     playbackSessionIdRef.current += 1;
+    isPausedRef.current = false;
     clearRecoveryTimer();
     currentChannelRef.current = null;
     recoveryTimestampsRef.current = [];
@@ -1225,9 +1515,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
   const togglePause = useCallback(() => {
     if (videoElement.paused) {
+      isPausedRef.current = false;
       videoElement.play().catch(() => {});
       setIsPaused(false);
     } else {
+      isPausedRef.current = true;
       videoElement.pause();
       setIsPaused(true);
     }

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -84,6 +84,8 @@ interface HlsErrorPayload {
   details?: string;
 }
 
+export type HlsFatalRecoveryAction = "restart_network" | "recover_media" | "reconnect";
+
 interface MpegtsPlayer {
   destroy(): void;
   attachMediaElement(el: HTMLMediaElement): void;
@@ -135,8 +137,9 @@ function tryConvertToXtreamHls(url: string): string | null {
   return `${origin}/live/${user}/${pass}/${id}.m3u8`;
 }
 
-function toStreamingProxyUrl(url: string, port: number): string {
-  return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}`;
+function toStreamingProxyUrl(url: string, port: number, reconnect: boolean): string {
+  const reconnectParam = reconnect ? "&reconnect=1" : "";
+  return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}${reconnectParam}`;
 }
 
 export function supportsNativeHlsPlayback(
@@ -188,17 +191,23 @@ function readMediaErrorMessage(mediaErr: MediaError | null): string | null {
   return codeMap[mediaErr.code] ?? mediaErr.message ?? "Unknown media error";
 }
 
-export const MAX_PLAYBACK_RECOVERY_ATTEMPTS = 2;
+export const MAX_PLAYBACK_RECOVERY_ATTEMPTS = 5;
 export const PLAYBACK_RECOVERY_WINDOW_MS = 2 * 60_000;
 const LOADING_TIMEOUT_MS = 15_000;
 const NATIVE_HLS_TIMEOUT_MS = 4_000;
 const PLAYBACK_RECOVERY_DELAY_MS = 900;
-const PLAYBACK_STALL_GRACE_MS = 4_000;
-const PLAYBACK_NO_PROGRESS_STALL_MS = 6_000;
+const PLAYBACK_STALL_GRACE_MS = 15_000;
+const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
 const PLAYBACK_WATCHDOG_POLL_MS = 1_000;
 const MIN_PROGRESS_DELTA_SECS = 0.05;
 const HAVE_FUTURE_DATA = 3;
 const HLS_BUFFER_STALLED_ERROR = "bufferStalledError";
+
+export function getHlsFatalRecoveryAction(type?: string): HlsFatalRecoveryAction {
+  if (type === "networkError") return "restart_network";
+  if (type === "mediaError") return "recover_media";
+  return "reconnect";
+}
 
 export function getNextPlaybackRecoveryAttempt(
   recoveryTimestamps: number[],
@@ -707,6 +716,19 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           if (data.fatal) {
             const detail = data.details ?? "fatal hls.js error";
             const type = data.type ?? "hls.js";
+            const recoveryAction = getHlsFatalRecoveryAction(data.type);
+            if (recoveryAction === "restart_network") {
+              logger.warn("[Player] Restarting hls.js network loading after", detail);
+              hls.startLoad(-1);
+              markPotentialStall();
+              return;
+            }
+            if (recoveryAction === "recover_media") {
+              logger.warn("[Player] Recovering hls.js media pipeline after", detail);
+              hls.recoverMediaError();
+              markPotentialStall();
+              return;
+            }
             triggerRuntimeIssue("library_error", `${type}: ${detail}`);
           }
         };
@@ -921,11 +943,23 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
       return new Promise((resolve) => {
         let settled = false;
-        const player = mpegts.createPlayer({
-          type: "mpegts",
-          url,
-          isLive: true,
-        }) as unknown as MpegtsPlayer;
+        const player = mpegts.createPlayer(
+          {
+            type: "mpegts",
+            url,
+            isLive: true,
+          },
+          {
+            // Trade a small amount of live latency for enough network cushion
+            // to ride out the jitter common on IPTV provider connections.
+            enableStashBuffer: true,
+            stashInitialSize: 1024 * 1024,
+            lazyLoad: false,
+            autoCleanupSourceBuffer: true,
+            autoCleanupMaxBackwardDuration: 120,
+            autoCleanupMinBackwardDuration: 60,
+          },
+        ) as unknown as MpegtsPlayer;
         mpegtsPlayerRef.current = player;
 
         const finish = (value: boolean) => {
@@ -1112,7 +1146,9 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         } catch {
           logger.warn("[Player] Could not get streaming proxy port");
         }
-        const playbackUrl = proxyPort > 0 ? toStreamingProxyUrl(url, proxyPort) : url;
+        const playbackUrl = proxyPort > 0
+          ? toStreamingProxyUrl(url, proxyPort, result.content_type === "live")
+          : url;
         if (proxyPort > 0) {
           logger.info("[Player] Trying mpegts.js via streaming proxy for", result.name);
         } else {

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -184,6 +184,27 @@ function toStreamingProxyUrl(
   return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}${reconnectParam}${remuxParam}`;
 }
 
+export function getMpegtsPlaybackUrls(
+  url: string,
+  proxyPort: number,
+  isLive: boolean,
+): string[] {
+  if (proxyPort <= 0) {
+    return [url];
+  }
+
+  const proxyUrl = toStreamingProxyUrl(url, proxyPort, isLive, false);
+  return isLive
+    ? [toStreamingProxyUrl(url, proxyPort, true, true), proxyUrl]
+    : [proxyUrl];
+}
+
+export function shouldSuspendPlaybackWatchdog(
+  visibilityState: DocumentVisibilityState,
+): boolean {
+  return visibilityState === "hidden";
+}
+
 export function supportsNativeHlsPlayback(
   mediaElement: Pick<HTMLMediaElement, "canPlayType">,
 ): boolean {
@@ -1063,6 +1084,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         if (closed || playbackSessionIdRef.current !== sessionId) {
           return;
         }
+        if (shouldSuspendPlaybackWatchdog(document.visibilityState)) {
+          monitor.lastProgressAt = performance.now();
+          monitor.stallStartedAt = null;
+          return;
+        }
         if (playerStateRef.current !== "playing") {
           return;
         }
@@ -1456,25 +1482,29 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         } catch {
           logger.warn("[Player] Could not get streaming proxy port");
         }
-        const playbackUrl = proxyPort > 0
-          ? toStreamingProxyUrl(
-              url,
-              proxyPort,
-              result.content_type === "live",
-              result.content_type === "live",
-            )
-          : url;
+        const playbackUrls = getMpegtsPlaybackUrls(
+          url,
+          proxyPort,
+          result.content_type === "live",
+        );
         if (proxyPort > 0) {
           logger.info("[Player] Trying mpegts.js via streaming proxy for", result.name);
         } else {
           logger.info("[Player] Trying mpegts.js (raw URL) for", result.name);
         }
-        const mpegtsOk = await tryMpegtsPlayback(playbackUrl, abortController.signal);
-        if (!isCurrentPlayback()) {
-          return;
-        }
-        if (mpegtsOk && await handleSuccessfulStart()) {
-          return;
+        for (const [index, playbackUrl] of playbackUrls.entries()) {
+          if (index > 0) {
+            logger.warn(
+              "[Player] Remux playback failed; retrying live stream without ffmpeg",
+            );
+          }
+          const mpegtsOk = await tryMpegtsPlayback(playbackUrl, abortController.signal);
+          if (!isCurrentPlayback()) {
+            return;
+          }
+          if (mpegtsOk && await handleSuccessfulStart()) {
+            return;
+          }
         }
       }
 

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -243,6 +243,8 @@ const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
 const PLAYBACK_WATCHDOG_POLL_MS = 1_000;
 const MIN_PROGRESS_DELTA_SECS = 0.05;
 const HLS_BUFFER_STALLED_ERROR = "bufferStalledError";
+const HLS_FATAL_RECOVERY_MAX_ATTEMPTS = 2;
+const HLS_FATAL_RECOVERY_WINDOW_MS = 30_000;
 const LIVE_RESYNC_MIN_SEEK_SECS = 1;
 const LIVE_RESYNC_MAX_SEEK_SECS = 3;
 const LIVE_RESYNC_MAX_JUMP_SECS = 30;
@@ -781,6 +783,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         lastResyncAt: Number.NEGATIVE_INFINITY,
       };
       let resyncTimer: ReturnType<typeof setTimeout> | null = null;
+      let hlsFatalRecoveryTimestamps: number[] = [];
 
       const handlers: Array<{ target: EventTarget; event: string; handler: EventListener }> = [];
       const addHandler = (target: EventTarget, event: string, handler: EventListener) => {
@@ -920,6 +923,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
       addHandler(videoElement, "playing", () => {
         clearResyncTimer();
+        hlsFatalRecoveryTimestamps = [];
         monitor.lastProgressAt = performance.now();
         monitor.lastCurrentTime = videoElement.currentTime;
         monitor.stallStartedAt = null;
@@ -929,6 +933,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       });
       addHandler(videoElement, "canplay", () => {
         clearResyncTimer();
+        hlsFatalRecoveryTimestamps = [];
         markProgress();
         monitor.stallStartedAt = null;
       });
@@ -983,6 +988,27 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             const detail = data.details ?? "fatal hls.js error";
             const type = data.type ?? "hls.js";
             const recoveryAction = getHlsFatalRecoveryAction(data.type);
+            if (recoveryAction !== "reconnect") {
+              const now = performance.now();
+              const attempt = getNextPlaybackRecoveryAttempt(
+                hlsFatalRecoveryTimestamps,
+                now,
+                HLS_FATAL_RECOVERY_MAX_ATTEMPTS,
+                HLS_FATAL_RECOVERY_WINDOW_MS,
+              );
+              if (attempt === null) {
+                triggerRuntimeIssue(
+                  "library_error",
+                  `${type}: repeated fatal recovery failed (${detail})`,
+                );
+                return;
+              }
+              hlsFatalRecoveryTimestamps = recordPlaybackRecoveryAttempt(
+                hlsFatalRecoveryTimestamps,
+                now,
+                HLS_FATAL_RECOVERY_WINDOW_MS,
+              );
+            }
             if (recoveryAction === "restart_network") {
               logger.warn("[Player] Restarting hls.js network loading after", detail);
               hls.startLoad(-1);
@@ -999,6 +1025,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           }
         };
         const onHlsStallResolved = () => {
+          hlsFatalRecoveryTimestamps = [];
           markProgress();
           monitor.stallStartedAt = null;
         };

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+  areStreamMetadataEqual,
   classifyStream,
+  chooseLiveBufferPlaybackRate,
   decidePlaybackRecovery,
+  findLiveBufferResyncTarget,
+  findLiveLatencyCatchUpTarget,
   formatPlaybackRecoveryMessage,
   getHlsFatalRecoveryAction,
   getNextPlaybackRecoveryAttempt,
@@ -10,6 +14,8 @@ import {
   recordPlaybackRecoveryAttempt,
   shouldResetPlaybackRecoveryAttempts,
   supportsNativeHlsPlayback,
+  tryConvertToXtreamHls,
+  type StreamMetadata,
   type StreamType,
 } from "../src/hooks/useStreamPlayer";
 
@@ -53,6 +59,18 @@ describe("useStreamPlayer helpers", () => {
     ).toBe(true);
 
     expect(supportsNativeHlsPlayback(canPlayTypes({}))).toBe(false);
+  });
+
+  it("converts common Xtream MPEG-TS URL forms to HLS", () => {
+    expect(
+      tryConvertToXtreamHls("http://provider.example/live/user/pass/12345.ts"),
+    ).toBe("http://provider.example/live/user/pass/12345.m3u8");
+    expect(
+      tryConvertToXtreamHls("https://provider.example/user/pass/12345?token=abc"),
+    ).toBe("https://provider.example/live/user/pass/12345.m3u8?token=abc");
+    expect(
+      tryConvertToXtreamHls("http://provider.example/live/user/pass/channel.ts"),
+    ).toBeNull();
   });
 
   it("caps automatic clean reconnect attempts within a rolling window", () => {
@@ -134,5 +152,61 @@ describe("useStreamPlayer helpers", () => {
     expect(getHlsFatalRecoveryAction("mediaError")).toBe("recover_media");
     expect(getHlsFatalRecoveryAction("otherError")).toBe("reconnect");
     expect(getHlsFatalRecoveryAction()).toBe("reconnect");
+  });
+
+  it("jumps across a small buffered live timestamp gap", () => {
+    expect(
+      findLiveBufferResyncTarget(10, [
+        { start: 0, end: 10 },
+        { start: 10.5, end: 20 },
+      ]),
+    ).toBeCloseTo(10.55);
+    expect(
+      findLiveBufferResyncTarget(10, [
+        { start: 0, end: 10 },
+        { start: 45, end: 55 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("moves a stalled live decoder forward while retaining its network cushion", () => {
+    expect(findLiveBufferResyncTarget(10, [{ start: 0, end: 20 }])).toBe(13);
+    expect(findLiveBufferResyncTarget(10, [{ start: 0, end: 10.1 }])).toBeNull();
+  });
+
+  it("uses playback-rate hysteresis to rebuild a low live buffer", () => {
+    expect(chooseLiveBufferPlaybackRate(1, 11.9)).toBe(0.97);
+    expect(chooseLiveBufferPlaybackRate(0.97, 15)).toBe(0.97);
+    expect(chooseLiveBufferPlaybackRate(0.97, 20)).toBe(1);
+    expect(chooseLiveBufferPlaybackRate(1, 31)).toBe(1.08);
+    expect(chooseLiveBufferPlaybackRate(1.08, 25)).toBe(1.08);
+    expect(chooseLiveBufferPlaybackRate(1.08, 20)).toBe(1);
+    expect(chooseLiveBufferPlaybackRate(1, 20)).toBe(1);
+  });
+
+  it("bounds accumulated live latency while retaining a playback cushion", () => {
+    expect(findLiveLatencyCatchUpTarget(10, [{ start: 0, end: 69 }])).toBeNull();
+    expect(findLiveLatencyCatchUpTarget(10, [{ start: 0, end: 71 }])).toBe(51);
+    expect(findLiveLatencyCatchUpTarget(10, [{ start: 80, end: 180 }])).toBeNull();
+  });
+
+  it("deduplicates unchanged player metadata updates", () => {
+    const metadata: StreamMetadata = {
+      width: 1920,
+      height: 1080,
+      resolution: "1080p",
+      codec: "H.264",
+      fps: 50,
+      videoBitrate: "8.0 Mbps",
+      audioCodec: "AAC",
+      audioBitrate: "192",
+      audioOnly: false,
+    };
+
+    expect(areStreamMetadataEqual(metadata, { ...metadata })).toBe(true);
+    expect(
+      areStreamMetadataEqual(metadata, { ...metadata, videoBitrate: "8.1 Mbps" }),
+    ).toBe(false);
+    expect(areStreamMetadataEqual(metadata, null)).toBe(false);
   });
 });

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -3,6 +3,7 @@ import {
   classifyStream,
   decidePlaybackRecovery,
   formatPlaybackRecoveryMessage,
+  getHlsFatalRecoveryAction,
   getNextPlaybackRecoveryAttempt,
   PLAYBACK_RECOVERY_WINDOW_MS,
   prunePlaybackRecoveryHistory,
@@ -60,6 +61,12 @@ describe("useStreamPlayer helpers", () => {
     expect(getNextPlaybackRecoveryAttempt([now - 5_000], now)).toBe(2);
     expect(
       getNextPlaybackRecoveryAttempt([now - 5_000, now - 10_000], now),
+    ).toBe(3);
+    expect(
+      getNextPlaybackRecoveryAttempt(
+        [now - 5_000, now - 10_000, now - 15_000, now - 20_000, now - 25_000],
+        now,
+      ),
     ).toBeNull();
   });
 
@@ -115,10 +122,17 @@ describe("useStreamPlayer helpers", () => {
 
   it("formats reconnect status messaging for the player UI", () => {
     expect(formatPlaybackRecoveryMessage(1)).toBe(
-      "Stream interrupted. Reconnecting (1/2)...",
+      "Stream interrupted. Reconnecting (1/5)...",
     );
-    expect(formatPlaybackRecoveryMessage(2)).toBe(
-      "Stream interrupted. Reconnecting (2/2)...",
+    expect(formatPlaybackRecoveryMessage(5)).toBe(
+      "Stream interrupted. Reconnecting (5/5)...",
     );
+  });
+
+  it("uses hls.js recovery before rebuilding the whole player", () => {
+    expect(getHlsFatalRecoveryAction("networkError")).toBe("restart_network");
+    expect(getHlsFatalRecoveryAction("mediaError")).toBe("recover_media");
+    expect(getHlsFatalRecoveryAction("otherError")).toBe("reconnect");
+    expect(getHlsFatalRecoveryAction()).toBe("reconnect");
   });
 });

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -8,11 +8,13 @@ import {
   findLiveLatencyCatchUpTarget,
   formatPlaybackRecoveryMessage,
   getHlsFatalRecoveryAction,
+  getMpegtsPlaybackUrls,
   getNextPlaybackRecoveryAttempt,
   PLAYBACK_RECOVERY_WINDOW_MS,
   prunePlaybackRecoveryHistory,
   recordPlaybackRecoveryAttempt,
   shouldResetPlaybackRecoveryAttempts,
+  shouldSuspendPlaybackWatchdog,
   supportsNativeHlsPlayback,
   tryConvertToXtreamHls,
   type StreamMetadata,
@@ -59,6 +61,31 @@ describe("useStreamPlayer helpers", () => {
     ).toBe(true);
 
     expect(supportsNativeHlsPlayback(canPlayTypes({}))).toBe(false);
+  });
+
+  it("falls back to the reconnecting proxy when live remux is unavailable", () => {
+    const urls = getMpegtsPlaybackUrls("https://example.com/live.ts", 3210, true);
+
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).toContain("reconnect=1");
+    expect(urls[0]).toContain("remux=1");
+    expect(urls[1]).toContain("reconnect=1");
+    expect(urls[1]).not.toContain("remux=1");
+  });
+
+  it("uses one non-remux URL for VOD and direct playback without a proxy", () => {
+    const vodUrls = getMpegtsPlaybackUrls("https://example.com/movie.ts", 3210, false);
+
+    expect(vodUrls).toHaveLength(1);
+    expect(vodUrls[0]).not.toContain("remux=1");
+    expect(getMpegtsPlaybackUrls("https://example.com/live.ts", 0, true)).toEqual([
+      "https://example.com/live.ts",
+    ]);
+  });
+
+  it("suspends playback watchdog recovery while the app is hidden", () => {
+    expect(shouldSuspendPlaybackWatchdog("hidden")).toBe(true);
+    expect(shouldSuspendPlaybackWatchdog("visible")).toBe(false);
   });
 
   it("converts common Xtream MPEG-TS URL forms to HLS", () => {


### PR DESCRIPTION
## Summary

- keep live upstreams connected through a bounded, paced streaming proxy and normalize MPEG-TS timestamps with FFmpeg stream copy
- recover buffered timestamp/keyframe gaps in place, manage live buffer depth and latency, and make clean reconnects rolling and repeatable
- prefer Xtream HLS when available, tune mpegts.js for jitter, resume unexpected WebView pauses, and prevent background muted-media suspension
- reduce playback-driven React churn and deduplicate unchanged metadata updates
- redact Xtream path credentials from proxy diagnostics

## Long-running playback proof

Tested the exact saved-playlist channel in a clean Windows debug build for **60m18s** in one player/connection session.

- no disconnects or player rebuilds
- no media errors, SourceBuffer append errors, or unexpected pauses
- seven buffered decoder-gap resyncs, all 836-847ms, recovered in place
- final ready state 4 with 20.7s buffered
- 48,973 successful appends / 1.84 GB processed
- FFmpeg remained stream-copy only: 7.55 CPU-seconds and 24.4 MB working set over the hour

## Verification

- `bun test tests` — 76 passed
- `tsc --noEmit` — passed
- `bun run build` — passed
- `rustfmt --check src/engine/stream_proxy.rs` — passed
- `cargo check` — passed
- `cargo test --no-run` — all Rust test binaries compiled
- `tauri build --no-bundle` — optimized Windows release build passed

Rust test execution is still blocked on this machine by the repository/toolchain's existing GNU DLL `STATUS_ENTRYPOINT_NOT_FOUND` issue; compilation succeeds. The repo-wide formatting check also reports unrelated pre-existing formatting in scan/cast files, while the changed Rust file is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live MPEG-TS playback with smoother pacing, reconnects, and timestamp correction.
  * Added stronger live-stream buffering, latency catch-up, and stall recovery.
  * Improved playback routing when using Chromecast, with fallback to in-app playback when needed.
  * Windows playback now better supports autoplay and continued media playback in the background.

* **Bug Fixes**
  * Improved HLS recovery and reduced unnecessary playback interruptions.
  * Recovery messages now accurately show progress across up to five attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->