### PR TITLE
Add AUR packaging with automated publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,18 +279,21 @@ jobs:
           SHA_ARM=$(sha256sum "/tmp/aur/IPTV.Checker_${VERSION}_lin_arm.deb" | cut -d' ' -f1)
           SHA_LICENSE=$(sha256sum LICENSE | cut -d' ' -f1)
 
+          # Must land inside the workspace: the deploy action below runs in a
+          # Docker container that only gets the workspace mounted, not /tmp.
+          mkdir -p aur
           sed -e "s/@PKGVER@/${VERSION}/" \
               -e "s/@SHA_LICENSE@/${SHA_LICENSE}/" \
               -e "s/@SHA_X64@/${SHA_X64}/" \
               -e "s/@SHA_ARM@/${SHA_ARM}/" \
-              packaging/aur/PKGBUILD.tpl > /tmp/aur/PKGBUILD
+              packaging/aur/PKGBUILD.tpl > aur/PKGBUILD
 
       - name: Publish to AUR
         if: env.HAS_AUR_KEY == 'true'
         uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
         with:
           pkgname: iptv-checker-gui
-          pkgbuild: /tmp/aur/PKGBUILD
+          pkgbuild: ./aur/PKGBUILD
           commit_username: kristofferR
           commit_email: 481270+kristofferR@users.noreply.github.com
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.HAS_AUR_KEY == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -290,10 +290,11 @@ jobs:
 
       - name: Publish to AUR
         if: env.HAS_AUR_KEY == 'true'
-        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
           pkgname: iptv-checker-gui
           pkgbuild: ./aur/PKGBUILD
+          test: true
           commit_username: kristofferR
           commit_email: 481270+kristofferR@users.noreply.github.com
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,3 +252,50 @@ jobs:
             -f content="$CONTENT" \
             -f sha="$EXISTING_SHA" \
             -f branch="main"
+
+  aur:
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      HAS_AUR_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY != '' }}
+    steps:
+      - name: Checkout
+        if: env.HAS_AUR_KEY == 'true'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Generate PKGBUILD from template
+        if: env.HAS_AUR_KEY == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p /tmp/aur
+          gh release download "${GITHUB_REF_NAME}" --pattern "IPTV.Checker_${VERSION}_lin_x64.deb" --dir /tmp/aur
+          gh release download "${GITHUB_REF_NAME}" --pattern "IPTV.Checker_${VERSION}_lin_arm.deb" --dir /tmp/aur
+
+          SHA_X64=$(sha256sum "/tmp/aur/IPTV.Checker_${VERSION}_lin_x64.deb" | cut -d' ' -f1)
+          SHA_ARM=$(sha256sum "/tmp/aur/IPTV.Checker_${VERSION}_lin_arm.deb" | cut -d' ' -f1)
+          SHA_LICENSE=$(sha256sum LICENSE | cut -d' ' -f1)
+
+          sed -e "s/@PKGVER@/${VERSION}/" \
+              -e "s/@SHA_LICENSE@/${SHA_LICENSE}/" \
+              -e "s/@SHA_X64@/${SHA_X64}/" \
+              -e "s/@SHA_ARM@/${SHA_ARM}/" \
+              packaging/aur/PKGBUILD.tpl > /tmp/aur/PKGBUILD
+
+      - name: Publish to AUR
+        if: env.HAS_AUR_KEY == 'true'
+        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
+        with:
+          pkgname: iptv-checker-gui
+          pkgbuild: /tmp/aur/PKGBUILD
+          commit_username: kristofferR
+          commit_email: 481270+kristofferR@users.noreply.github.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"
+
+      - name: Skip notice
+        if: env.HAS_AUR_KEY != 'true'
+        run: echo "AUR_SSH_PRIVATE_KEY not configured, skipping AUR publish"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ If it is already there, use:
 brew install --cask --adopt kristofferR/tap/iptv-checker
 ```
 
+### Arch Linux (AUR)
+
+Package: [iptv-checker-gui](https://aur.archlinux.org/packages/iptv-checker-gui)
+
+```bash
+yay -S iptv-checker-gui
+```
+
+Uses the system `ffmpeg` package instead of the bundled sidecar binaries.
+
 ### All platforms
 
 The buttons above link to the default installer for each OS. Every architecture and package format is attached to each [GitHub release](https://github.com/kristofferR/IPTVChecker/releases/latest):

--- a/packaging/aur/PKGBUILD.tpl
+++ b/packaging/aur/PKGBUILD.tpl
@@ -1,0 +1,31 @@
+# Maintainer: kristofferR <481270+kristofferR@users.noreply.github.com>
+#
+# Template for the AUR package. The `aur` job in .github/workflows/release.yml
+# fills in the version and checksum placeholders and pushes the result (with a
+# regenerated .SRCINFO) to the AUR on every release.
+pkgname=iptv-checker-gui
+pkgver=@PKGVER@
+pkgrel=1
+pkgdesc="GUI for validating IPTV playlists and inspecting stream health"
+arch=('x86_64' 'aarch64')
+url="https://github.com/kristofferR/IPTVChecker"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'ffmpeg' 'hicolor-icon-theme')
+# The unrelated freearhey CLI package also installs /usr/bin/iptv-checker.
+conflicts=('iptv-checker')
+options=('!strip' '!debug')
+source=("LICENSE-${pkgver}::https://raw.githubusercontent.com/kristofferR/IPTVChecker/v${pkgver}/LICENSE")
+source_x86_64=("${pkgname}-${pkgver}-x86_64.deb::https://github.com/kristofferR/IPTVChecker/releases/download/v${pkgver}/IPTV.Checker_${pkgver}_lin_x64.deb")
+source_aarch64=("${pkgname}-${pkgver}-aarch64.deb::https://github.com/kristofferR/IPTVChecker/releases/download/v${pkgver}/IPTV.Checker_${pkgver}_lin_arm.deb")
+sha256sums=('@SHA_LICENSE@')
+sha256sums_x86_64=('@SHA_X64@')
+sha256sums_aarch64=('@SHA_ARM@')
+
+package() {
+    # makepkg already extracted the .deb into srcdir; unpack its payload.
+    bsdtar -xf "${srcdir}/data.tar.gz" -C "${pkgdir}"
+    # The deb bundles ffmpeg/ffprobe sidecars; on Arch the app falls back to
+    # the system ffmpeg on PATH, so drop them to avoid owning ffmpeg's files.
+    rm "${pkgdir}/usr/bin/ffmpeg" "${pkgdir}/usr/bin/ffprobe"
+    install -Dm644 "${srcdir}/LICENSE-${pkgver}" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
Adds Arch Linux packaging via the AUR as `iptv-checker-gui`, published automatically on every release.

## What's here

- **`packaging/aur/PKGBUILD.tpl`** — template that repackages the released Linux `.deb` for x86_64 and aarch64. The bundled ffmpeg/ffprobe sidecars are stripped in favor of a dependency on Arch's `ffmpeg` package (the app falls back to PATH when no sidecar is present), which avoids file conflicts with `/usr/bin/ffmpeg`. Named `iptv-checker-gui` because the unrelated freearhey CLI already owns `iptv-checker` on the AUR; a `conflicts` entry covers the shared `/usr/bin/iptv-checker` path.
- **`aur` job in `release.yml`** — mirrors the Homebrew tap flow: downloads the published debs, fills the template with version + sha256 sums, and pushes PKGBUILD + regenerated `.SRCINFO` to the AUR via `KSXGitHub/github-actions-deploy-aur`. Skips cleanly when `AUR_SSH_PRIVATE_KEY` is not configured (secret is already set).
- **README** — Arch install section.

## Validation

Built the v1.6.0 package with `makepkg` in an `archlinux:base-devel` container, then installed it on a clean `archlinux:latest` system: `ldd` on the installed binary resolves every shared library with only the declared dependencies, and ffmpeg/ffprobe are correctly absent from the package.

<!-- crq:skip-autoreview -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arch Linux (AUR) packaging for `iptv-checker-gui`, supporting both x64 and ARM systems.
  * AUR releases are automatically prepared and published when configured.
  * The package uses the system-provided `ffmpeg` rather than bundled binaries.

* **Documentation**
  * Added Arch Linux installation instructions using `yay`.
  * Documented the system `ffmpeg` requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->