### PR TITLE
Fix slow-starting stream playback fallbacks

### DIFF
--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -27,6 +27,9 @@ const PROXY_BUFFERED_READ_TIMEOUT: std::time::Duration = std::time::Duration::fr
 /// Per-read inactivity timeout — resets on every successful read, so it does NOT
 /// cap total stream duration. Only kills truly dead/stalled connections.
 const PROXY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+/// Slow IPTV servers and ffmpeg probing can legitimately take longer to emit
+/// their first media bytes. Steady-state reads still use the shorter timeout.
+const PROXY_STARTUP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Short retry delay for a live MPEG-TS source that drops its upstream socket.
 /// The downstream connection stays open while the proxy reconnects, so the
@@ -772,12 +775,19 @@ where
     let budget = Arc::new(tokio::sync::Semaphore::new(STREAM_PROXY_READ_AHEAD_BYTES));
     let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel(STREAM_PROXY_READ_AHEAD_CHUNKS);
     let reader = tokio::spawn(async move {
+        let mut received_data = false;
         loop {
             let mut chunk = vec![0u8; 64 * 1024];
-            match tokio::time::timeout(PROXY_READ_TIMEOUT, stdout.read(&mut chunk)).await {
+            let read_timeout = if received_data {
+                PROXY_READ_TIMEOUT
+            } else {
+                PROXY_STARTUP_READ_TIMEOUT
+            };
+            match tokio::time::timeout(read_timeout, stdout.read(&mut chunk)).await {
                 Err(_) => return StreamForwardOutcome::UpstreamReadTimeout,
                 Ok(Ok(0)) => return StreamForwardOutcome::Completed,
                 Ok(Ok(read)) => {
+                    received_data = true;
                     chunk.truncate(read);
                     let permits = read.min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
                     let permit = match budget.clone().acquire_many_owned(permits).await {
@@ -929,7 +939,27 @@ fn transport_stream_packet_pcr(packet: &[u8]) -> Option<u64> {
 async fn forward_response_as_chunked_stream<W>(
     writer: &mut W,
     response: reqwest::Response,
+    pacer: Option<&mut TransportStreamPacer>,
+) -> StreamForwardResult
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    forward_response_as_chunked_stream_with_timeouts(
+        writer,
+        response,
+        pacer,
+        PROXY_STARTUP_READ_TIMEOUT,
+        PROXY_READ_TIMEOUT,
+    )
+    .await
+}
+
+async fn forward_response_as_chunked_stream_with_timeouts<W>(
+    writer: &mut W,
+    response: reqwest::Response,
     mut pacer: Option<&mut TransportStreamPacer>,
+    startup_read_timeout: std::time::Duration,
+    steady_read_timeout: std::time::Duration,
 ) -> StreamForwardResult
 where
     W: tokio::io::AsyncWrite + Unpin,
@@ -942,12 +972,20 @@ where
     let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel(STREAM_PROXY_READ_AHEAD_CHUNKS);
     let reader = tokio::spawn(async move {
         let mut stream = response.bytes_stream();
-        while let Some(chunk_result) = stream.next().await {
-            match chunk_result {
-                Ok(chunk) => {
+        let mut received_data = false;
+        loop {
+            let read_timeout = if received_data {
+                steady_read_timeout
+            } else {
+                startup_read_timeout
+            };
+            match tokio::time::timeout(read_timeout, stream.next()).await {
+                Err(_) => return StreamForwardOutcome::UpstreamReadTimeout,
+                Ok(Some(Ok(chunk))) => {
                     if chunk.is_empty() {
                         continue;
                     }
+                    received_data = true;
                     let permits = chunk.len().min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
                     let permit = match budget.clone().acquire_many_owned(permits).await {
                         Ok(permit) => permit,
@@ -957,16 +995,16 @@ where
                         return StreamForwardOutcome::DownstreamClosed;
                     }
                 }
-                Err(err) => {
+                Ok(Some(Err(err))) => {
                     return if err.is_timeout() {
                         StreamForwardOutcome::UpstreamReadTimeout
                     } else {
                         StreamForwardOutcome::UpstreamReadError(reqwest_error_kind(&err))
                     };
                 }
+                Ok(None) => return StreamForwardOutcome::Completed,
             }
         }
-        StreamForwardOutcome::Completed
     });
 
     while let Some((chunk, _budget_permit)) = chunk_rx.recv().await {
@@ -1112,7 +1150,7 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
                 let client = build_proxy_client(
                     accept_invalid_certs,
                     PROXY_CONNECT_TIMEOUT,
-                    PROXY_READ_TIMEOUT,
+                    PROXY_STARTUP_READ_TIMEOUT,
                 );
 
                 let user_agent = HeaderValue::from_str(&user_agent)
@@ -1374,6 +1412,14 @@ mod tests {
         chunks: Vec<TestStreamChunk>,
         tail_delay: Duration,
     ) -> (String, tokio::task::JoinHandle<()>) {
+        spawn_delayed_chunked_upstream(Duration::ZERO, chunks, tail_delay).await
+    }
+
+    async fn spawn_delayed_chunked_upstream(
+        initial_delay: Duration,
+        chunks: Vec<TestStreamChunk>,
+        tail_delay: Duration,
+    ) -> (String, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("test listener should bind");
@@ -1398,6 +1444,9 @@ mod tests {
                 .await
                 .expect("server should write headers");
 
+            if !initial_delay.is_zero() {
+                tokio::time::sleep(initial_delay).await;
+            }
             for chunk in chunks {
                 let size_line = format!("{:x}\r\n", chunk.body.len());
                 if socket.write_all(size_line.as_bytes()).await.is_err() {
@@ -1699,6 +1748,45 @@ segment.ts
             elapsed > simulated_old_total_timeout,
             "stream completed too quickly to cover the old timeout window: {:?}",
             elapsed
+        );
+
+        server_handle.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn forward_response_allows_slow_first_bytes_then_uses_steady_timeout() {
+        let steady_timeout = Duration::from_millis(80);
+        let startup_timeout = Duration::from_millis(250);
+        let initial_delay = Duration::from_millis(150);
+        let chunks = vec![TestStreamChunk {
+            body: vec![0xAA; 64],
+            delay_after: Duration::ZERO,
+        }];
+        let (url, server_handle) =
+            spawn_delayed_chunked_upstream(initial_delay, chunks, Duration::from_millis(150)).await;
+        let client = build_proxy_client(false, Duration::from_secs(1), Duration::from_secs(1));
+        let started = Instant::now();
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .expect("stream request should succeed");
+
+        let mut sink = tokio::io::sink();
+        let result = forward_response_as_chunked_stream_with_timeouts(
+            &mut sink,
+            response,
+            None,
+            startup_timeout,
+            steady_timeout,
+        )
+        .await;
+
+        assert_eq!(result.outcome, StreamForwardOutcome::UpstreamReadTimeout);
+        assert_eq!(result.bytes_forwarded, 64);
+        assert!(
+            started.elapsed() >= initial_delay + steady_timeout,
+            "first media bytes were rejected using the steady-state timeout"
         );
 
         server_handle.await.expect("server task should finish");

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -973,13 +973,14 @@ where
     let reader = tokio::spawn(async move {
         let mut stream = response.bytes_stream();
         let mut received_data = false;
+        let startup_deadline = tokio::time::Instant::now() + startup_read_timeout;
         loop {
-            let read_timeout = if received_data {
-                steady_read_timeout
+            let next_chunk = if received_data {
+                tokio::time::timeout(steady_read_timeout, stream.next()).await
             } else {
-                startup_read_timeout
+                tokio::time::timeout_at(startup_deadline, stream.next()).await
             };
-            match tokio::time::timeout(read_timeout, stream.next()).await {
+            match next_chunk {
                 Err(_) => return StreamForwardOutcome::UpstreamReadTimeout,
                 Ok(Some(Ok(chunk))) => {
                     if chunk.is_empty() {

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -972,21 +972,14 @@ where
     let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::channel(STREAM_PROXY_READ_AHEAD_CHUNKS);
     let reader = tokio::spawn(async move {
         let mut stream = response.bytes_stream();
-        let mut received_data = false;
-        let startup_deadline = tokio::time::Instant::now() + startup_read_timeout;
+        let mut read_deadline = tokio::time::Instant::now() + startup_read_timeout;
         loop {
-            let next_chunk = if received_data {
-                tokio::time::timeout(steady_read_timeout, stream.next()).await
-            } else {
-                tokio::time::timeout_at(startup_deadline, stream.next()).await
-            };
-            match next_chunk {
+            match tokio::time::timeout_at(read_deadline, stream.next()).await {
                 Err(_) => return StreamForwardOutcome::UpstreamReadTimeout,
                 Ok(Some(Ok(chunk))) => {
                     if chunk.is_empty() {
                         continue;
                     }
-                    received_data = true;
                     let permits = chunk.len().min(STREAM_PROXY_READ_AHEAD_BYTES) as u32;
                     let permit = match budget.clone().acquire_many_owned(permits).await {
                         Ok(permit) => permit,
@@ -995,6 +988,7 @@ where
                     if chunk_tx.send((chunk, permit)).await.is_err() {
                         return StreamForwardOutcome::DownstreamClosed;
                     }
+                    read_deadline = tokio::time::Instant::now() + steady_read_timeout;
                 }
                 Ok(Some(Err(err))) => {
                     return if err.is_timeout() {

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -215,6 +215,10 @@ export function getMpegtsPlaybackRoutes(
   return preferRemux ? [remux, direct] : [direct, remux];
 }
 
+export function shouldTryXtreamHlsBeforeMpegts(startMode: PlaybackStartMode): boolean {
+  return startMode === "recovery";
+}
+
 export function shouldSuspendPlaybackWatchdog(
   visibilityState: DocumentVisibilityState,
 ): boolean {
@@ -1315,6 +1319,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     async (
       url: string,
       signal: AbortSignal,
+      isLive: boolean,
       timeoutMs = MPEGTS_PLAYBACK_ROUTE_TIMEOUT_MS,
     ): Promise<boolean> => {
       try {
@@ -1329,7 +1334,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             {
               type: "mpegts",
               url,
-              isLive: true,
+              isLive,
             },
             {
               // Trade a small amount of live latency for enough network cushion
@@ -1493,6 +1498,25 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       const url = result.url;
       const streamType = classifyStream(url);
       const preferNativeHls = streamType === "hls" && supportsNativeHlsPlayback(videoElement);
+      const preferXtreamHls = shouldTryXtreamHlsBeforeMpegts(startMode);
+      const xtreamHlsUrl = streamType === "hls" ? null : tryConvertToXtreamHls(url);
+      const tryXtreamHlsRoute = async (): Promise<boolean> => {
+        if (!xtreamHlsUrl) return false;
+
+        logger.info(
+          startMode === "recovery"
+            ? "[Player] Trying Xtream HLS recovery route for"
+            : "[Player] Trying Xtream HLS fallback for",
+          result.name,
+        );
+        lastErrorRef.current = null;
+        const hlsOk = await tryHlsPlayback(xtreamHlsUrl, abortController.signal);
+        if (!isCurrentPlayback() || !hlsOk) {
+          return false;
+        }
+        logger.info("[Player] Playing via Xtream HLS:", result.name);
+        return handleSuccessfulStart();
+      };
 
       if (preferNativeHls) {
         lastErrorRef.current = null;
@@ -1524,7 +1548,15 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
+      if (preferXtreamHls && await tryXtreamHlsRoute()) {
+        return;
+      }
+      if (!isCurrentPlayback()) {
+        return;
+      }
+
       if (streamType === "mpegts" || streamType === "unknown") {
+        const isLive = result.content_type === "live";
         let proxyPort = 0;
         try {
           proxyPort = await getStreamingProxyPort();
@@ -1534,7 +1566,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         const playbackRoutes = getMpegtsPlaybackRoutes(
           url,
           proxyPort,
-          result.content_type === "live",
+          isLive,
           startMode === "recovery",
         );
         for (const route of playbackRoutes) {
@@ -1547,7 +1579,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             result.name,
           );
           lastErrorRef.current = null;
-          const mpegtsOk = await tryMpegtsPlayback(route.url, abortController.signal);
+          const mpegtsOk = await tryMpegtsPlayback(
+            route.url,
+            abortController.signal,
+            isLive,
+          );
           if (!isCurrentPlayback()) {
             return;
           }
@@ -1557,22 +1593,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
-      if (streamType !== "hls") {
-        const xtreamHlsUrl = tryConvertToXtreamHls(url);
-        if (xtreamHlsUrl) {
-          logger.info("[Player] Trying Xtream HLS fallback for", result.name);
-          lastErrorRef.current = null;
-          const hlsOk = await tryHlsPlayback(xtreamHlsUrl, abortController.signal);
-          if (!isCurrentPlayback()) {
-            return;
-          }
-          if (hlsOk) {
-            logger.info("[Player] Playing via Xtream HLS fallback:", result.name);
-            if (await handleSuccessfulStart()) {
-              return;
-            }
-          }
-        }
+      if (!preferXtreamHls && await tryXtreamHlsRoute()) {
+        return;
+      }
+      if (!isCurrentPlayback()) {
+        return;
       }
 
       if (streamType !== "hls") {

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -1559,17 +1559,19 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
-      lastErrorRef.current = null;
-      const nativeOk = await tryNativePlayback(
-        url,
-        abortController.signal,
-        PLAYBACK_ROUTE_TIMEOUT_MS,
-      );
-      if (!isCurrentPlayback()) {
-        return;
-      }
-      if (nativeOk && await handleSuccessfulStart()) {
-        return;
+      if (streamType !== "hls") {
+        lastErrorRef.current = null;
+        const nativeOk = await tryNativePlayback(
+          url,
+          abortController.signal,
+          PLAYBACK_ROUTE_TIMEOUT_MS,
+        );
+        if (!isCurrentPlayback()) {
+          return;
+        }
+        if (nativeOk && await handleSuccessfulStart()) {
+          return;
+        }
       }
 
       clearLoadingTimer();

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -275,7 +275,8 @@ export const PLAYBACK_RECOVERY_WINDOW_MS = 2 * 60_000;
 // Bound each route independently so a failed speculative route cannot consume
 // the startup budget of a fallback that may still work.
 const PLAYBACK_ROUTE_TIMEOUT_MS = 15_000;
-const LOADING_TIMEOUT_MS = 75_000;
+const MPEGTS_PLAYBACK_ROUTE_TIMEOUT_MS = 25_000;
+const LOADING_TIMEOUT_MS = 90_000;
 const PLAYBACK_RECOVERY_DELAY_MS = 900;
 const PLAYBACK_STALL_GRACE_MS = 15_000;
 const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
@@ -1314,7 +1315,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     async (
       url: string,
       signal: AbortSignal,
-      timeoutMs = PLAYBACK_ROUTE_TIMEOUT_MS,
+      timeoutMs = MPEGTS_PLAYBACK_ROUTE_TIMEOUT_MS,
     ): Promise<boolean> => {
       try {
         const mpegtsModule = await import("mpegts.js");

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -276,7 +276,6 @@ export const PLAYBACK_RECOVERY_WINDOW_MS = 2 * 60_000;
 // the startup budget of a fallback that may still work.
 const PLAYBACK_ROUTE_TIMEOUT_MS = 15_000;
 const LOADING_TIMEOUT_MS = 75_000;
-const NATIVE_HLS_TIMEOUT_MS = 4_000;
 const PLAYBACK_RECOVERY_DELAY_MS = 900;
 const PLAYBACK_STALL_GRACE_MS = 15_000;
 const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
@@ -1235,73 +1234,78 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       signal: AbortSignal,
       timeoutMs = PLAYBACK_ROUTE_TIMEOUT_MS,
     ): Promise<boolean> => {
-      const { default: Hls } = await import("hls.js");
-      if (signal.aborted || !Hls.isSupported()) return false;
+      try {
+        const { default: Hls } = await import("hls.js");
+        if (signal.aborted || !Hls.isSupported()) return false;
 
-      return new Promise((resolve) => {
-        let settled = false;
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const hls = new Hls({
-          maxBufferLength: 30,
-          maxMaxBufferLength: 60,
+        return await new Promise<boolean>((resolve) => {
+          let settled = false;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const hls = new Hls({
+            maxBufferLength: 30,
+            maxMaxBufferLength: 60,
+          });
+          hlsInstanceRef.current = hls;
+
+          const finish = (value: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (timer) clearTimeout(timer);
+            videoElement.removeEventListener("canplay", onCanPlay);
+            videoElement.removeEventListener("error", onVideoError);
+            signal.removeEventListener("abort", onAbort);
+            hls.off(Hls.Events.ERROR, onHlsError);
+            resolve(value);
+          };
+          const destroyPlayer = () => {
+            hls.destroy();
+            if (hlsInstanceRef.current === hls) {
+              hlsInstanceRef.current = null;
+            }
+          };
+          const fail = (reason?: string) => {
+            if (settled) return;
+            if (reason) {
+              lastErrorRef.current = reason;
+            }
+            finish(false);
+            destroyPlayer();
+          };
+          const onCanPlay = () => finish(true);
+          const onVideoError = () => {
+            fail(readMediaErrorMessage(videoElement.error) ?? "HLS media error");
+          };
+          const onHlsError = (_event: unknown, data: HlsErrorPayload) => {
+            if (data.fatal) {
+              const detail = data.details ?? "fatal hls.js error";
+              const type = data.type ?? "hls.js";
+              fail(`${type}: ${detail}`);
+            }
+          };
+          const onAbort = () => {
+            fail();
+          };
+
+          try {
+            timer = setTimeout(() => {
+              fail("HLS playback timed out");
+            }, timeoutMs);
+            videoElement.addEventListener("canplay", onCanPlay, { once: true });
+            videoElement.addEventListener("error", onVideoError, { once: true });
+            signal.addEventListener("abort", onAbort, { once: true });
+            hls.on(Hls.Events.ERROR, onHlsError);
+            hls.loadSource(toProxyUrl(url));
+            hls.attachMedia(videoElement);
+            applyVolume();
+          } catch (error) {
+            fail(error instanceof Error ? error.message : "Could not initialize HLS playback");
+          }
         });
-        hlsInstanceRef.current = hls;
-
-        const finish = (value: boolean) => {
-          if (settled) return;
-          settled = true;
-          if (timer) clearTimeout(timer);
-          videoElement.removeEventListener("canplay", onCanPlay);
-          videoElement.removeEventListener("error", onVideoError);
-          signal.removeEventListener("abort", onAbort);
-          hls.off(Hls.Events.ERROR, onHlsError);
-          resolve(value);
-        };
-        const destroyPlayer = () => {
-          hls.destroy();
-          if (hlsInstanceRef.current === hls) {
-            hlsInstanceRef.current = null;
-          }
-        };
-        const fail = (reason?: string) => {
-          if (settled) return;
-          if (reason) {
-            lastErrorRef.current = reason;
-          }
-          finish(false);
-          destroyPlayer();
-        };
-        const onCanPlay = () => finish(true);
-        const onVideoError = () => {
-          fail(readMediaErrorMessage(videoElement.error) ?? "HLS media error");
-        };
-        const onHlsError = (_event: unknown, data: HlsErrorPayload) => {
-          if (data.fatal) {
-            const detail = data.details ?? "fatal hls.js error";
-            const type = data.type ?? "hls.js";
-            fail(`${type}: ${detail}`);
-          }
-        };
-        const onAbort = () => {
-          fail();
-        };
-
-        timer = setTimeout(() => {
-          fail("HLS playback timed out");
-        }, timeoutMs);
-        videoElement.addEventListener("canplay", onCanPlay, { once: true });
-        videoElement.addEventListener("error", onVideoError, { once: true });
-        signal.addEventListener("abort", onAbort, { once: true });
-        hls.on(Hls.Events.ERROR, onHlsError);
-
-        try {
-          hls.loadSource(toProxyUrl(url));
-          hls.attachMedia(videoElement);
-          applyVolume();
-        } catch (error) {
-          fail(error instanceof Error ? error.message : "Could not initialize HLS playback");
-        }
-      });
+      } catch (error) {
+        lastErrorRef.current =
+          error instanceof Error ? error.message : "Could not initialize HLS playback";
+        return false;
+      }
     },
     [videoElement, applyVolume],
   );
@@ -1312,92 +1316,99 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       signal: AbortSignal,
       timeoutMs = PLAYBACK_ROUTE_TIMEOUT_MS,
     ): Promise<boolean> => {
-      const mpegtsModule = await import("mpegts.js");
-      const mpegts = mpegtsModule.default;
-      if (signal.aborted || !mpegts.isSupported()) return false;
+      try {
+        const mpegtsModule = await import("mpegts.js");
+        const mpegts = mpegtsModule.default;
+        if (signal.aborted || !mpegts.isSupported()) return false;
 
-      return new Promise((resolve) => {
-        let settled = false;
-        let timer: ReturnType<typeof setTimeout> | null = null;
-        const player = mpegts.createPlayer(
-          {
-            type: "mpegts",
-            url,
-            isLive: true,
-          },
-          {
-            // Trade a small amount of live latency for enough network cushion
-            // to ride out the jitter common on IPTV provider connections.
-            enableWorker: true,
-            enableStashBuffer: true,
-            stashInitialSize: 1024 * 1024,
-            lazyLoad: false,
-            autoCleanupSourceBuffer: true,
-            autoCleanupMaxBackwardDuration: 120,
-            autoCleanupMinBackwardDuration: 60,
-          },
-        ) as unknown as MpegtsPlayer;
-        mpegtsPlayerRef.current = player;
+        return await new Promise<boolean>((resolve) => {
+          let settled = false;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const player = mpegts.createPlayer(
+            {
+              type: "mpegts",
+              url,
+              isLive: true,
+            },
+            {
+              // Trade a small amount of live latency for enough network cushion
+              // to ride out the jitter common on IPTV provider connections.
+              enableWorker: true,
+              enableStashBuffer: true,
+              stashInitialSize: 1024 * 1024,
+              lazyLoad: false,
+              autoCleanupSourceBuffer: true,
+              autoCleanupMaxBackwardDuration: 120,
+              autoCleanupMinBackwardDuration: 60,
+            },
+          ) as unknown as MpegtsPlayer;
+          mpegtsPlayerRef.current = player;
 
-        const finish = (value: boolean) => {
-          if (settled) return;
-          settled = true;
-          if (timer) clearTimeout(timer);
-          videoElement.removeEventListener("canplay", onCanPlay);
-          videoElement.removeEventListener("error", onError);
-          signal.removeEventListener("abort", onAbort);
-          player.off?.("error", onPlayerError);
-          resolve(value);
-        };
-        const destroyPlayer = () => {
-          player.destroy();
-          if (mpegtsPlayerRef.current === player) {
-            mpegtsPlayerRef.current = null;
+          const finish = (value: boolean) => {
+            if (settled) return;
+            settled = true;
+            if (timer) clearTimeout(timer);
+            videoElement.removeEventListener("canplay", onCanPlay);
+            videoElement.removeEventListener("error", onError);
+            signal.removeEventListener("abort", onAbort);
+            player.off?.("error", onPlayerError);
+            resolve(value);
+          };
+          const destroyPlayer = () => {
+            player.destroy();
+            if (mpegtsPlayerRef.current === player) {
+              mpegtsPlayerRef.current = null;
+            }
+          };
+          const fail = (reason?: string) => {
+            if (settled) return;
+            if (reason) {
+              lastErrorRef.current = reason;
+            }
+            finish(false);
+            destroyPlayer();
+          };
+          const onCanPlay = () => {
+            finish(true);
+          };
+          const onError = () => {
+            fail(readMediaErrorMessage(videoElement.error) ?? "MPEG-TS media error");
+          };
+          const onPlayerError = (
+            errorType?: unknown,
+            errorDetail?: unknown,
+            info?: unknown,
+          ) => {
+            const segments = [errorType, errorDetail, info]
+              .filter((value): value is string =>
+                typeof value === "string" && value.length > 0
+              );
+            fail(segments.join(": ") || "mpegts.js error");
+          };
+          const onAbort = () => {
+            fail();
+          };
+
+          try {
+            timer = setTimeout(() => {
+              fail("Stream startup timed out");
+            }, timeoutMs);
+            videoElement.addEventListener("canplay", onCanPlay, { once: true });
+            videoElement.addEventListener("error", onError, { once: true });
+            signal.addEventListener("abort", onAbort, { once: true });
+            player.on?.("error", onPlayerError);
+            player.attachMediaElement(videoElement);
+            player.load();
+            applyVolume();
+          } catch (error) {
+            fail(error instanceof Error ? error.message : "Could not initialize MPEG-TS playback");
           }
-        };
-        const fail = (reason?: string) => {
-          if (settled) return;
-          if (reason) {
-            lastErrorRef.current = reason;
-          }
-          finish(false);
-          destroyPlayer();
-        };
-        const onCanPlay = () => {
-          finish(true);
-        };
-        const onError = () => {
-          fail(readMediaErrorMessage(videoElement.error) ?? "MPEG-TS media error");
-        };
-        const onPlayerError = (
-          errorType?: unknown,
-          errorDetail?: unknown,
-          info?: unknown,
-        ) => {
-          const segments = [errorType, errorDetail, info]
-            .filter((value): value is string => typeof value === "string" && value.length > 0);
-          fail(segments.join(": ") || "mpegts.js error");
-        };
-        const onAbort = () => {
-          fail();
-        };
-
-        timer = setTimeout(() => {
-          fail("Stream startup timed out");
-        }, timeoutMs);
-        videoElement.addEventListener("canplay", onCanPlay, { once: true });
-        videoElement.addEventListener("error", onError, { once: true });
-        signal.addEventListener("abort", onAbort, { once: true });
-        player.on?.("error", onPlayerError);
-
-        try {
-          player.attachMediaElement(videoElement);
-          player.load();
-          applyVolume();
-        } catch (error) {
-          fail(error instanceof Error ? error.message : "Could not initialize MPEG-TS playback");
-        }
-      });
+        });
+      } catch (error) {
+        lastErrorRef.current =
+          error instanceof Error ? error.message : "Could not initialize MPEG-TS playback";
+        return false;
+      }
     },
     [videoElement, applyVolume],
   );
@@ -1484,7 +1495,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
       if (preferNativeHls) {
         lastErrorRef.current = null;
-        const nativeOk = await tryNativePlayback(url, abortController.signal, NATIVE_HLS_TIMEOUT_MS);
+        const nativeOk = await tryNativePlayback(
+          url,
+          abortController.signal,
+          PLAYBACK_ROUTE_TIMEOUT_MS,
+        );
         if (!isCurrentPlayback()) {
           return;
         }

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -104,6 +104,12 @@ interface HlsErrorPayload {
 }
 
 export type HlsFatalRecoveryAction = "restart_network" | "recover_media" | "reconnect";
+export type MpegtsPlaybackRouteKind = "direct" | "remux";
+
+export interface MpegtsPlaybackRoute {
+  kind: MpegtsPlaybackRouteKind;
+  url: string;
+}
 
 interface MpegtsPlayer {
   destroy(): void;
@@ -184,19 +190,29 @@ function toStreamingProxyUrl(
   return `http://127.0.0.1:${port}/stream?url=${encodeURIComponent(url)}${reconnectParam}${remuxParam}`;
 }
 
-export function getMpegtsPlaybackUrls(
+export function getMpegtsPlaybackRoutes(
   url: string,
   proxyPort: number,
   isLive: boolean,
-): string[] {
+  preferRemux: boolean,
+): MpegtsPlaybackRoute[] {
   if (proxyPort <= 0) {
-    return [url];
+    return [{ kind: "direct", url }];
   }
 
-  const proxyUrl = toStreamingProxyUrl(url, proxyPort, isLive, false);
-  return isLive
-    ? [toStreamingProxyUrl(url, proxyPort, true, true), proxyUrl]
-    : [proxyUrl];
+  const direct = {
+    kind: "direct",
+    url: toStreamingProxyUrl(url, proxyPort, isLive, false),
+  } satisfies MpegtsPlaybackRoute;
+  if (!isLive) {
+    return [direct];
+  }
+
+  const remux = {
+    kind: "remux",
+    url: toStreamingProxyUrl(url, proxyPort, true, true),
+  } satisfies MpegtsPlaybackRoute;
+  return preferRemux ? [remux, direct] : [direct, remux];
 }
 
 export function shouldSuspendPlaybackWatchdog(
@@ -256,7 +272,10 @@ function readMediaErrorMessage(mediaErr: MediaError | null): string | null {
 
 export const MAX_PLAYBACK_RECOVERY_ATTEMPTS = 5;
 export const PLAYBACK_RECOVERY_WINDOW_MS = 2 * 60_000;
-const LOADING_TIMEOUT_MS = 15_000;
+// Bound each route independently so a failed speculative route cannot consume
+// the startup budget of a fallback that may still work.
+const PLAYBACK_ROUTE_TIMEOUT_MS = 15_000;
+const LOADING_TIMEOUT_MS = 75_000;
 const NATIVE_HLS_TIMEOUT_MS = 4_000;
 const PLAYBACK_RECOVERY_DELAY_MS = 900;
 const PLAYBACK_STALL_GRACE_MS = 15_000;
@@ -1192,6 +1211,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
         if (timeoutMs != null) {
           timer = setTimeout(() => {
+            lastErrorRef.current = "Native playback timed out";
             videoElement.removeAttribute("src");
             videoElement.load();
             finish(false);
@@ -1210,12 +1230,17 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   );
 
   const tryHlsPlayback = useCallback(
-    async (url: string, signal: AbortSignal): Promise<boolean> => {
+    async (
+      url: string,
+      signal: AbortSignal,
+      timeoutMs = PLAYBACK_ROUTE_TIMEOUT_MS,
+    ): Promise<boolean> => {
       const { default: Hls } = await import("hls.js");
       if (signal.aborted || !Hls.isSupported()) return false;
 
       return new Promise((resolve) => {
         let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
         const hls = new Hls({
           maxBufferLength: 30,
           maxMaxBufferLength: 60,
@@ -1225,6 +1250,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         const finish = (value: boolean) => {
           if (settled) return;
           settled = true;
+          if (timer) clearTimeout(timer);
           videoElement.removeEventListener("canplay", onCanPlay);
           videoElement.removeEventListener("error", onVideoError);
           signal.removeEventListener("abort", onAbort);
@@ -1237,47 +1263,62 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             hlsInstanceRef.current = null;
           }
         };
+        const fail = (reason?: string) => {
+          if (settled) return;
+          if (reason) {
+            lastErrorRef.current = reason;
+          }
+          finish(false);
+          destroyPlayer();
+        };
         const onCanPlay = () => finish(true);
         const onVideoError = () => {
-          lastErrorRef.current = readMediaErrorMessage(videoElement.error);
-          destroyPlayer();
-          finish(false);
+          fail(readMediaErrorMessage(videoElement.error) ?? "HLS media error");
         };
         const onHlsError = (_event: unknown, data: HlsErrorPayload) => {
           if (data.fatal) {
             const detail = data.details ?? "fatal hls.js error";
             const type = data.type ?? "hls.js";
-            lastErrorRef.current = `${type}: ${detail}`;
-            destroyPlayer();
-            finish(false);
+            fail(`${type}: ${detail}`);
           }
         };
         const onAbort = () => {
-          destroyPlayer();
-          finish(false);
+          fail();
         };
 
+        timer = setTimeout(() => {
+          fail("HLS playback timed out");
+        }, timeoutMs);
         videoElement.addEventListener("canplay", onCanPlay, { once: true });
         videoElement.addEventListener("error", onVideoError, { once: true });
         signal.addEventListener("abort", onAbort, { once: true });
         hls.on(Hls.Events.ERROR, onHlsError);
 
-        hls.loadSource(toProxyUrl(url));
-        hls.attachMedia(videoElement);
-        applyVolume();
+        try {
+          hls.loadSource(toProxyUrl(url));
+          hls.attachMedia(videoElement);
+          applyVolume();
+        } catch (error) {
+          fail(error instanceof Error ? error.message : "Could not initialize HLS playback");
+        }
       });
     },
     [videoElement, applyVolume],
   );
 
   const tryMpegtsPlayback = useCallback(
-    async (url: string, signal: AbortSignal): Promise<boolean> => {
+    async (
+      url: string,
+      signal: AbortSignal,
+      timeoutMs = PLAYBACK_ROUTE_TIMEOUT_MS,
+    ): Promise<boolean> => {
       const mpegtsModule = await import("mpegts.js");
       const mpegts = mpegtsModule.default;
       if (signal.aborted || !mpegts.isSupported()) return false;
 
       return new Promise((resolve) => {
         let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
         const player = mpegts.createPlayer(
           {
             type: "mpegts",
@@ -1301,22 +1342,32 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         const finish = (value: boolean) => {
           if (settled) return;
           settled = true;
+          if (timer) clearTimeout(timer);
           videoElement.removeEventListener("canplay", onCanPlay);
           videoElement.removeEventListener("error", onError);
           signal.removeEventListener("abort", onAbort);
           player.off?.("error", onPlayerError);
           resolve(value);
         };
-        const onCanPlay = () => {
-          finish(true);
-        };
-        const onError = () => {
-          lastErrorRef.current = readMediaErrorMessage(videoElement.error);
+        const destroyPlayer = () => {
           player.destroy();
           if (mpegtsPlayerRef.current === player) {
             mpegtsPlayerRef.current = null;
           }
+        };
+        const fail = (reason?: string) => {
+          if (settled) return;
+          if (reason) {
+            lastErrorRef.current = reason;
+          }
           finish(false);
+          destroyPlayer();
+        };
+        const onCanPlay = () => {
+          finish(true);
+        };
+        const onError = () => {
+          fail(readMediaErrorMessage(videoElement.error) ?? "MPEG-TS media error");
         };
         const onPlayerError = (
           errorType?: unknown,
@@ -1325,29 +1376,27 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         ) => {
           const segments = [errorType, errorDetail, info]
             .filter((value): value is string => typeof value === "string" && value.length > 0);
-          lastErrorRef.current = segments.join(": ") || "mpegts.js error";
-          player.destroy();
-          if (mpegtsPlayerRef.current === player) {
-            mpegtsPlayerRef.current = null;
-          }
-          finish(false);
+          fail(segments.join(": ") || "mpegts.js error");
         };
         const onAbort = () => {
-          player.destroy();
-          if (mpegtsPlayerRef.current === player) {
-            mpegtsPlayerRef.current = null;
-          }
-          finish(false);
+          fail();
         };
 
+        timer = setTimeout(() => {
+          fail("Stream startup timed out");
+        }, timeoutMs);
         videoElement.addEventListener("canplay", onCanPlay, { once: true });
         videoElement.addEventListener("error", onError, { once: true });
         signal.addEventListener("abort", onAbort, { once: true });
         player.on?.("error", onPlayerError);
 
-        player.attachMediaElement(videoElement);
-        player.load();
-        applyVolume();
+        try {
+          player.attachMediaElement(videoElement);
+          player.load();
+          applyVolume();
+        } catch (error) {
+          fail(error instanceof Error ? error.message : "Could not initialize MPEG-TS playback");
+        }
       });
     },
     [videoElement, applyVolume],
@@ -1434,6 +1483,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       const preferNativeHls = streamType === "hls" && supportsNativeHlsPlayback(videoElement);
 
       if (preferNativeHls) {
+        lastErrorRef.current = null;
         const nativeOk = await tryNativePlayback(url, abortController.signal, NATIVE_HLS_TIMEOUT_MS);
         if (!isCurrentPlayback()) {
           return;
@@ -1445,6 +1495,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
       if (streamType === "hls") {
         logger.info("[Player] Trying hls.js via proxy for", result.name);
+        lastErrorRef.current = null;
         const hlsOk = await tryHlsPlayback(url, abortController.signal);
         if (!isCurrentPlayback()) {
           return;
@@ -1457,24 +1508,6 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
-      if (streamType !== "hls") {
-        const xtreamHlsUrl = tryConvertToXtreamHls(url);
-        if (xtreamHlsUrl) {
-          logger.info("[Player] Trying Xtream HLS conversion for", result.name);
-          const hlsOk = await tryHlsPlayback(xtreamHlsUrl, abortController.signal);
-          if (!isCurrentPlayback()) {
-            return;
-          }
-          if (hlsOk) {
-            logger.info("[Player] Playing via Xtream HLS conversion:", result.name);
-            if (await handleSuccessfulStart()) {
-              return;
-            }
-          }
-          logger.info("[Player] Xtream HLS conversion failed, trying streaming proxy");
-        }
-      }
-
       if (streamType === "mpegts" || streamType === "unknown") {
         let proxyPort = 0;
         try {
@@ -1482,23 +1515,23 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         } catch {
           logger.warn("[Player] Could not get streaming proxy port");
         }
-        const playbackUrls = getMpegtsPlaybackUrls(
+        const playbackRoutes = getMpegtsPlaybackRoutes(
           url,
           proxyPort,
           result.content_type === "live",
+          startMode === "recovery",
         );
-        if (proxyPort > 0) {
-          logger.info("[Player] Trying mpegts.js via streaming proxy for", result.name);
-        } else {
-          logger.info("[Player] Trying mpegts.js (raw URL) for", result.name);
-        }
-        for (const [index, playbackUrl] of playbackUrls.entries()) {
-          if (index > 0) {
-            logger.warn(
-              "[Player] Remux playback failed; retrying live stream without ffmpeg",
-            );
-          }
-          const mpegtsOk = await tryMpegtsPlayback(playbackUrl, abortController.signal);
+        for (const route of playbackRoutes) {
+          logger.info(
+            route.kind === "remux"
+              ? "[Player] Trying normalized MPEG-TS remux for"
+              : proxyPort > 0
+                ? "[Player] Trying mpegts.js via streaming proxy for"
+                : "[Player] Trying mpegts.js (raw URL) for",
+            result.name,
+          );
+          lastErrorRef.current = null;
+          const mpegtsOk = await tryMpegtsPlayback(route.url, abortController.signal);
           if (!isCurrentPlayback()) {
             return;
           }
@@ -1508,7 +1541,30 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
-      const nativeOk = await tryNativePlayback(url, abortController.signal);
+      if (streamType !== "hls") {
+        const xtreamHlsUrl = tryConvertToXtreamHls(url);
+        if (xtreamHlsUrl) {
+          logger.info("[Player] Trying Xtream HLS fallback for", result.name);
+          lastErrorRef.current = null;
+          const hlsOk = await tryHlsPlayback(xtreamHlsUrl, abortController.signal);
+          if (!isCurrentPlayback()) {
+            return;
+          }
+          if (hlsOk) {
+            logger.info("[Player] Playing via Xtream HLS fallback:", result.name);
+            if (await handleSuccessfulStart()) {
+              return;
+            }
+          }
+        }
+      }
+
+      lastErrorRef.current = null;
+      const nativeOk = await tryNativePlayback(
+        url,
+        abortController.signal,
+        PLAYBACK_ROUTE_TIMEOUT_MS,
+      );
       if (!isCurrentPlayback()) {
         return;
       }

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -8,7 +8,7 @@ import {
   findLiveLatencyCatchUpTarget,
   formatPlaybackRecoveryMessage,
   getHlsFatalRecoveryAction,
-  getMpegtsPlaybackUrls,
+  getMpegtsPlaybackRoutes,
   getNextPlaybackRecoveryAttempt,
   PLAYBACK_RECOVERY_WINDOW_MS,
   prunePlaybackRecoveryHistory,
@@ -63,23 +63,45 @@ describe("useStreamPlayer helpers", () => {
     expect(supportsNativeHlsPlayback(canPlayTypes({}))).toBe(false);
   });
 
-  it("falls back to the reconnecting proxy when live remux is unavailable", () => {
-    const urls = getMpegtsPlaybackUrls("https://example.com/live.ts", 3210, true);
+  it("uses the compatible direct route before remux for initial live playback", () => {
+    const routes = getMpegtsPlaybackRoutes(
+      "https://example.com/live.ts",
+      3210,
+      true,
+      false,
+    );
 
-    expect(urls).toHaveLength(2);
-    expect(urls[0]).toContain("reconnect=1");
-    expect(urls[0]).toContain("remux=1");
-    expect(urls[1]).toContain("reconnect=1");
-    expect(urls[1]).not.toContain("remux=1");
+    expect(routes).toHaveLength(2);
+    expect(routes[0]?.kind).toBe("direct");
+    expect(routes[0]?.url).toContain("reconnect=1");
+    expect(routes[0]?.url).not.toContain("remux=1");
+    expect(routes[1]?.kind).toBe("remux");
+    expect(routes[1]?.url).toContain("remux=1");
+  });
+
+  it("prefers timestamp-normalizing remux when recovering live playback", () => {
+    const routes = getMpegtsPlaybackRoutes(
+      "https://example.com/live.ts",
+      3210,
+      true,
+      true,
+    );
+
+    expect(routes.map((route) => route.kind)).toEqual(["remux", "direct"]);
   });
 
   it("uses one non-remux URL for VOD and direct playback without a proxy", () => {
-    const vodUrls = getMpegtsPlaybackUrls("https://example.com/movie.ts", 3210, false);
+    const vodRoutes = getMpegtsPlaybackRoutes(
+      "https://example.com/movie.ts",
+      3210,
+      false,
+      false,
+    );
 
-    expect(vodUrls).toHaveLength(1);
-    expect(vodUrls[0]).not.toContain("remux=1");
-    expect(getMpegtsPlaybackUrls("https://example.com/live.ts", 0, true)).toEqual([
-      "https://example.com/live.ts",
+    expect(vodRoutes).toHaveLength(1);
+    expect(vodRoutes[0]?.url).not.toContain("remux=1");
+    expect(getMpegtsPlaybackRoutes("https://example.com/live.ts", 0, true, false)).toEqual([
+      { kind: "direct", url: "https://example.com/live.ts" },
     ]);
   });
 

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -15,6 +15,7 @@ import {
   recordPlaybackRecoveryAttempt,
   shouldResetPlaybackRecoveryAttempts,
   shouldSuspendPlaybackWatchdog,
+  shouldTryXtreamHlsBeforeMpegts,
   supportsNativeHlsPlayback,
   tryConvertToXtreamHls,
   type StreamMetadata,
@@ -88,6 +89,11 @@ describe("useStreamPlayer helpers", () => {
     );
 
     expect(routes.map((route) => route.kind)).toEqual(["remux", "direct"]);
+  });
+
+  it("tries Xtream HLS before MPEG-TS only during automatic recovery", () => {
+    expect(shouldTryXtreamHlsBeforeMpegts("manual")).toBe(false);
+    expect(shouldTryXtreamHlsBeforeMpegts("recovery")).toBe(true);
   });
 
   it("uses one non-remux URL for VOD and direct playback without a proxy", () => {


### PR DESCRIPTION
## Summary

- try the original MPEG-TS stream before speculative Xtream HLS or ffmpeg remux routes
- give each playback route an independent startup timeout so one failed route cannot consume every fallback budget
- allow slow initial proxy and ffmpeg media bytes while retaining the shorter steady-state stall timeout
- keep timestamp-normalizing remux preferred during automatic recovery
- add focused route-order and slow-start regression coverage

## Root cause

Playback startup could spend its shared timeout on a speculative converted or remuxed route before reaching the original stream URL. The proxy also applied its six-second steady-state read timeout to the first media bytes, rejecting otherwise valid slow-starting providers.

## Validation

- 80 frontend tests
- TypeScript typecheck
- production frontend build
- 250 Rust unit tests
- 4 Rust integration tests
- focused validation rerun after local review findings

Ref #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for live MPEG-TS streaming when the first bytes arrive slowly by using a longer startup allowance, then switching to the steady-state timeout.
  * Refined MPEG-TS playback fallback behavior with explicit direct vs remux routes and updated fallback ordering for normal versus recovery scenarios.
  * Standardized playback timeouts and error messaging across native, HLS, and remux-assisted paths.

* **Tests**
  * Added coverage for delayed initial chunks to verify startup tolerance, followed by steady-state timeout behavior.
  * Updated tests to validate direct/remux route ordering and new route structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->