### PR TITLE
Fix filtered scan startup and MPEG-TS worker playback

### DIFF
--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -1072,11 +1073,35 @@ async fn record_backend_perf(
     let _ = app.emit("scan://backend-perf", sample);
 }
 
-fn source_mtime_ms(path: &str) -> Option<u64> {
+fn hash_source_metadata(
+    path: &str,
+    metadata: &std::fs::Metadata,
+    hasher: &mut DefaultHasher,
+) -> Option<()> {
+    path.hash(hasher);
+    metadata.len().hash(hasher);
+    metadata.modified().ok()?.hash(hasher);
+    Some(())
+}
+
+fn source_fingerprint(path: &str) -> Option<u64> {
     let metadata = std::fs::metadata(path).ok()?;
-    let modified = metadata.modified().ok()?;
-    let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
-    Some(duration.as_millis().min(u128::from(u64::MAX)) as u64)
+    let mut hasher = DefaultHasher::new();
+
+    if metadata.is_dir() {
+        "directory".hash(&mut hasher);
+        let playlist_paths = parser::find_playlists_in_dir(path).ok()?;
+        playlist_paths.len().hash(&mut hasher);
+        for playlist_path in playlist_paths {
+            let playlist_metadata = std::fs::metadata(&playlist_path).ok()?;
+            hash_source_metadata(&playlist_path, &playlist_metadata, &mut hasher)?;
+        }
+    } else {
+        "file".hash(&mut hasher);
+        hash_source_metadata(path, &metadata, &mut hasher)?;
+    }
+
+    Some(hasher.finish())
 }
 
 pub(crate) fn playlist_preview_cache_key_from_parts(
@@ -1122,9 +1147,9 @@ pub(crate) async fn seed_cached_playlist_preview(
         group_filter,
         channel_search,
     );
-    let source_mtime = source_mtime_ms(file_path);
+    let source_fingerprint = source_fingerprint(file_path);
     state
-        .put_cached_playlist_preview(cache_key, Arc::new(preview.clone()), source_mtime)
+        .put_cached_playlist_preview(cache_key, Arc::new(preview.clone()), source_fingerprint)
         .await;
 }
 
@@ -1134,10 +1159,10 @@ async fn parse_playlist_with_cache(
     config: &ScanConfig,
     run_id: &str,
 ) -> Result<Arc<PlaylistPreview>, AppError> {
-    let source_mtime = source_mtime_ms(&config.file_path);
+    let source_fingerprint = source_fingerprint(&config.file_path);
     let cache_key = playlist_preview_cache_key(config);
     if let Some(cached) = state
-        .get_cached_playlist_preview(&cache_key, source_mtime)
+        .get_cached_playlist_preview(&cache_key, source_fingerprint)
         .await
     {
         log::info!(
@@ -1157,7 +1182,7 @@ async fn parse_playlist_with_cache(
             None,
         );
         if let Some(full_preview) = state
-            .get_cached_playlist_preview(&full_preview_cache_key, source_mtime)
+            .get_cached_playlist_preview(&full_preview_cache_key, source_fingerprint)
             .await
         {
             let filter_started_at = Instant::now();
@@ -1187,11 +1212,9 @@ async fn parse_playlist_with_cache(
                 run_id,
                 config.file_path
             );
-            let filtered_preview = Arc::new(filtered_preview);
-            state
-                .put_cached_playlist_preview(cache_key, Arc::clone(&filtered_preview), source_mtime)
-                .await;
-            return Ok(filtered_preview);
+            // Derived previews are cheap to recreate and must not evict the
+            // reusable full preview, especially for in-memory provider sources.
+            return Ok(Arc::new(filtered_preview));
         }
     }
 
@@ -1228,7 +1251,7 @@ async fn parse_playlist_with_cache(
     .await;
     let preview = Arc::new(preview);
     state
-        .put_cached_playlist_preview(cache_key, Arc::clone(&preview), source_mtime)
+        .put_cached_playlist_preview(cache_key, Arc::clone(&preview), source_fingerprint)
         .await;
     Ok(preview)
 }
@@ -3013,6 +3036,52 @@ mod tests {
             ),
             "/tmp/playlist.m3u8|i:saved:abc|n:My Playlist|g:Sports|s:arsenal"
         );
+    }
+
+    #[test]
+    fn source_fingerprint_tracks_nested_playlist_changes() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be monotonic")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("iptv-scan-fingerprint-{unique}"));
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).expect("nested fixture dir should be created");
+
+        let first_playlist = nested.join("first.m3u8");
+        std::fs::write(
+            &first_playlist,
+            "#EXTM3U\n#EXTINF:-1,One\nhttp://example.com/one.m3u8\n",
+        )
+        .expect("first fixture should be writable");
+        let initial = source_fingerprint(&root.to_string_lossy())
+            .expect("directory fingerprint should be available");
+
+        std::fs::write(
+            &first_playlist,
+            "#EXTM3U\n#EXTINF:-1,One Updated\nhttp://example.com/one.m3u8\n",
+        )
+        .expect("nested fixture should be editable");
+        let after_edit = source_fingerprint(&root.to_string_lossy())
+            .expect("edited directory fingerprint should be available");
+        assert_ne!(initial, after_edit);
+
+        let second_playlist = root.join("second.m3u");
+        std::fs::write(
+            &second_playlist,
+            "#EXTM3U\n#EXTINF:-1,Two\nhttp://example.com/two.m3u8\n",
+        )
+        .expect("second fixture should be writable");
+        let after_add = source_fingerprint(&root.to_string_lossy())
+            .expect("expanded directory fingerprint should be available");
+        assert_ne!(after_edit, after_add);
+
+        std::fs::remove_file(&second_playlist).expect("second fixture should be removable");
+        let after_remove = source_fingerprint(&root.to_string_lossy())
+            .expect("reduced directory fingerprint should be available");
+        assert_ne!(after_add, after_remove);
+
+        std::fs::remove_dir_all(root).expect("fixture directory should be removable");
     }
 
     #[test]

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1148,6 +1148,53 @@ async fn parse_playlist_with_cache(
         return Ok(cached);
     }
 
+    if config.group_filter.is_some() || config.channel_search.is_some() {
+        let full_preview_cache_key = playlist_preview_cache_key_from_parts(
+            &config.file_path,
+            config.source_identity.as_deref(),
+            config.playlist_display_name.as_deref(),
+            None,
+            None,
+        );
+        if let Some(full_preview) = state
+            .get_cached_playlist_preview(&full_preview_cache_key, source_mtime)
+            .await
+        {
+            let filter_started_at = Instant::now();
+            let group_filter = config.group_filter.clone();
+            let channel_search = config.channel_search.clone();
+            let filtered_preview = tokio::task::spawn_blocking(move || {
+                parser::filter_playlist_preview(
+                    full_preview.as_ref(),
+                    &group_filter,
+                    &channel_search,
+                )
+            })
+            .await
+            .map_err(|err| AppError::Other(format!("Playlist filter task failed: {err}")))??;
+            let filter_ms = filter_started_at.elapsed().as_secs_f64() * 1000.0;
+            record_backend_perf(
+                app,
+                state,
+                "scan.preflight.filter_cached_ms",
+                filter_ms,
+                Some(run_id),
+            )
+            .await;
+
+            log::info!(
+                "Scan {}: derived filtered playlist preview from full cache for {}",
+                run_id,
+                config.file_path
+            );
+            let filtered_preview = Arc::new(filtered_preview);
+            state
+                .put_cached_playlist_preview(cache_key, Arc::clone(&filtered_preview), source_mtime)
+                .await;
+            return Ok(filtered_preview);
+        }
+    }
+
     let parse_started_at = Instant::now();
     // Parsing a big playlist is seconds of CPU-bound work; keep it off the
     // async runtime that is also driving proxies and event emission.

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -444,13 +444,22 @@ pub fn filter_playlist_preview(
     }
 
     let (live_count, movie_count, series_count) = content_type_totals(&channels);
-    let mut filtered = preview.clone();
-    filtered.total_channels = channels.len();
-    filtered.live_count = live_count;
-    filtered.movie_count = movie_count;
-    filtered.series_count = series_count;
-    filtered.channels = channels;
-    Ok(filtered)
+    Ok(PlaylistPreview {
+        file_path: preview.file_path.clone(),
+        file_name: preview.file_name.clone(),
+        source_identity: preview.source_identity.clone(),
+        saved_playlist_id: preview.saved_playlist_id.clone(),
+        server_location: preview.server_location.clone(),
+        single_provider: preview.single_provider,
+        xtream_max_connections: preview.xtream_max_connections,
+        xtream_account_info: preview.xtream_account_info.clone(),
+        total_channels: channels.len(),
+        live_count,
+        movie_count,
+        series_count,
+        groups: preview.groups.clone(),
+        channels,
+    })
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -406,6 +406,53 @@ fn content_type_totals(channels: &[Channel]) -> (usize, usize, usize) {
     (live, movie, series)
 }
 
+/// Derive a filtered preview from an already-parsed source while preserving
+/// source indices and metadata. This avoids rereading very large playlists
+/// when a scan adds only a group or channel-name filter.
+pub fn filter_playlist_preview(
+    preview: &PlaylistPreview,
+    group_filter: &Option<String>,
+    channel_search: &Option<String>,
+) -> Result<PlaylistPreview, AppError> {
+    let pattern = compile_channel_search_pattern(channel_search)?;
+    let selected_group = group_filter
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_lowercase);
+    let source_is_directory = Path::new(&preview.file_path).is_dir();
+
+    let mut channels = Vec::new();
+    for channel in &preview.channels {
+        let include_group = selected_group.as_ref().is_none_or(|selected| {
+            channel.group.trim().to_lowercase() == *selected
+                || (source_is_directory
+                    && format!("{PLAYLIST_GROUP_PREFIX}{}", channel.playlist)
+                        .trim()
+                        .to_lowercase()
+                        == *selected)
+        });
+        if !include_group {
+            continue;
+        }
+
+        if let Some(pattern) = &pattern {
+            if !pattern.is_match(&channel.name)? {
+                continue;
+            }
+        }
+        channels.push(channel.clone());
+    }
+
+    let (live_count, movie_count, series_count) = content_type_totals(&channels);
+    let mut filtered = preview.clone();
+    filtered.total_channels = channels.len();
+    filtered.live_count = live_count;
+    filtered.movie_count = movie_count;
+    filtered.series_count = series_count;
+    filtered.channels = channels;
+    Ok(filtered)
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ParseProgress {
     pub channels_found: usize,
@@ -889,6 +936,45 @@ http://example.com/three.m3u8
         assert!(preview.groups.contains(&"News".to_string()));
 
         std::fs::remove_file(path).expect("fixture file should be removable");
+    }
+
+    #[test]
+    fn test_filter_cached_preview_matches_filtered_parse() {
+        let playlist = b"\
+#EXTM3U
+#EXTINF:-1 group-title=\"Sports\",Channel One
+http://example.com/one.m3u8
+#EXTINF:-1 group-title=\"News\",Channel Two
+http://example.com/two.m3u8
+#EXTINF:-1 group-title=\"Sports\",Channel Three
+http://example.com/three.mp4
+";
+        let full =
+            parse_m3u(playlist, "cached.m3u8", &None, &None).expect("full playlist should parse");
+        let group_filter = Some(" sports ".to_string());
+        let channel_search = Some("one|three".to_string());
+        let derived = filter_playlist_preview(&full, &group_filter, &channel_search)
+            .expect("cached preview should filter");
+        let reparsed = parse_m3u(playlist, "cached.m3u8", &group_filter, &channel_search)
+            .expect("filtered playlist should parse");
+
+        assert_eq!(
+            derived
+                .channels
+                .iter()
+                .map(|channel| channel.index)
+                .collect::<Vec<_>>(),
+            reparsed
+                .channels
+                .iter()
+                .map(|channel| channel.index)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(derived.total_channels, reparsed.total_channels);
+        assert_eq!(derived.live_count, reparsed.live_count);
+        assert_eq!(derived.movie_count, reparsed.movie_count);
+        assert_eq!(derived.series_count, reparsed.series_count);
+        assert_eq!(derived.groups, reparsed.groups);
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -23,7 +23,7 @@ fn now_epoch_ms() -> u64 {
 
 #[derive(Clone)]
 pub struct CachedPlaylistPreview {
-    pub source_mtime_ms: Option<u64>,
+    pub source_fingerprint: Option<u64>,
     // Arc so cache hits hand out a reference instead of deep-copying a
     // potentially 100k-channel preview on every open/scan start.
     pub preview: Arc<PlaylistPreview>,
@@ -31,9 +31,9 @@ pub struct CachedPlaylistPreview {
 }
 
 impl CachedPlaylistPreview {
-    fn new(preview: Arc<PlaylistPreview>, source_mtime_ms: Option<u64>) -> Self {
+    fn new(preview: Arc<PlaylistPreview>, source_fingerprint: Option<u64>) -> Self {
         Self {
-            source_mtime_ms,
+            source_fingerprint,
             preview,
             cached_at_epoch_ms: now_epoch_ms(),
         }
@@ -139,11 +139,11 @@ impl AppState {
     pub async fn get_cached_playlist_preview(
         &self,
         cache_key: &str,
-        source_mtime_ms: Option<u64>,
+        source_fingerprint: Option<u64>,
     ) -> Option<Arc<PlaylistPreview>> {
         let cache = self.playlist_preview_cache.lock().await;
         cache.get(cache_key).and_then(|cached| {
-            if cached.source_mtime_ms == source_mtime_ms {
+            if cached.source_fingerprint == source_fingerprint {
                 Some(Arc::clone(&cached.preview))
             } else {
                 None
@@ -155,7 +155,7 @@ impl AppState {
         &self,
         cache_key: String,
         preview: Arc<PlaylistPreview>,
-        source_mtime_ms: Option<u64>,
+        source_fingerprint: Option<u64>,
     ) {
         let mut cache = self.playlist_preview_cache.lock().await;
         if cache.len() >= PLAYLIST_PREVIEW_CACHE_LIMIT && !cache.contains_key(&cache_key) {
@@ -169,7 +169,7 @@ impl AppState {
         }
         cache.insert(
             cache_key,
-            CachedPlaylistPreview::new(preview, source_mtime_ms),
+            CachedPlaylistPreview::new(preview, source_fingerprint),
         );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://localhost:* ws://localhost:* https://api.github.com https: http: streamproxy: http://streamproxy.localhost; img-src 'self' asset: http://asset.localhost data: blob: https: http:; media-src 'self' https: http: blob: streamproxy: http://streamproxy.localhost; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self';"
+      "csp": "default-src 'self'; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://localhost:* ws://localhost:* https://api.github.com https: http: streamproxy: http://streamproxy.localhost; img-src 'self' asset: http://asset.localhost data: blob: https: http:; media-src 'self' https: http: blob: streamproxy: http://streamproxy.localhost; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self';"
     }
   },
   "bundle": {

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -24,6 +24,7 @@ import {
   type StreamMetadata,
 } from "../lib/playback";
 import { createRuntimeMonitor, type MpegtsPlayer } from "../lib/runtimeMonitor";
+import { canUseBlobWorkers } from "../lib/workerSupport";
 
 // Re-exported for components (e.g. StreamPlayer) that read the recovery cap
 // alongside the hook. The implementation lives in lib/playback.
@@ -595,7 +596,10 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       timeoutMs = MPEGTS_PLAYBACK_ROUTE_TIMEOUT_MS,
     ): Promise<boolean> => {
       try {
-        const mpegtsModule = await import("mpegts.js");
+        const [mpegtsModule, enableWorker] = await Promise.all([
+          import("mpegts.js"),
+          canUseBlobWorkers(),
+        ]);
         const mpegts = mpegtsModule.default;
         if (signal.aborted || !mpegts.isSupported()) return false;
 
@@ -611,7 +615,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             {
               // Trade a small amount of live latency for enough network cushion
               // to ride out the jitter common on IPTV provider connections.
-              enableWorker: true,
+              enableWorker,
               enableStashBuffer: true,
               stashInitialSize: 1024 * 1024,
               lazyLoad: false,

--- a/src/lib/workerSupport.ts
+++ b/src/lib/workerSupport.ts
@@ -1,0 +1,81 @@
+interface WorkerProbe {
+  addEventListener(
+    type: "message" | "error",
+    listener: EventListener,
+    options?: AddEventListenerOptions,
+  ): void;
+  removeEventListener(type: "message" | "error", listener: EventListener): void;
+  terminate(): void;
+}
+
+interface BlobWorkerProbeOptions {
+  createWorker?: (url: string) => WorkerProbe;
+  createObjectUrl?: (blob: Blob) => string;
+  revokeObjectUrl?: (url: string) => void;
+  timeoutMs?: number;
+}
+
+/**
+ * Verify that a blob-backed worker can actually run, not merely be constructed.
+ * CSP violations are reported asynchronously, which otherwise leaves mpegts.js
+ * waiting on a worker that will never start or request the stream.
+ */
+export function probeBlobWorkerSupport(
+  options: BlobWorkerProbeOptions = {},
+): Promise<boolean> {
+  const {
+    createWorker = (url) => new Worker(url),
+    createObjectUrl = (blob) => URL.createObjectURL(blob),
+    revokeObjectUrl = (url) => URL.revokeObjectURL(url),
+    timeoutMs = 1_000,
+  } = options;
+
+  if (
+    options.createWorker == null &&
+    (typeof Worker === "undefined" ||
+      typeof Blob === "undefined" ||
+      typeof URL.createObjectURL !== "function")
+  ) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    let worker: WorkerProbe | null = null;
+    let objectUrl: string | null = null;
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (supported: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== null) clearTimeout(timer);
+      worker?.removeEventListener("message", onReady);
+      worker?.removeEventListener("error", onError);
+      worker?.terminate();
+      if (objectUrl !== null) revokeObjectUrl(objectUrl);
+      resolve(supported);
+    };
+    const onReady: EventListener = () => finish(true);
+    const onError: EventListener = () => finish(false);
+
+    try {
+      const script = new Blob(['self.postMessage("ready");'], {
+        type: "text/javascript",
+      });
+      objectUrl = createObjectUrl(script);
+      worker = createWorker(objectUrl);
+      worker.addEventListener("message", onReady, { once: true });
+      worker.addEventListener("error", onError, { once: true });
+      timer = setTimeout(() => finish(false), timeoutMs);
+    } catch {
+      finish(false);
+    }
+  });
+}
+
+let cachedBlobWorkerSupport: Promise<boolean> | null = null;
+
+export function canUseBlobWorkers(): Promise<boolean> {
+  cachedBlobWorkerSupport ??= probeBlobWorkerSupport();
+  return cachedBlobWorkerSupport;
+}

--- a/tests/workerSupport.test.ts
+++ b/tests/workerSupport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { probeBlobWorkerSupport } from "../src/lib/workerSupport";
+
+type Listener = EventListener;
+
+function createProbeWorker(outcome: "ready" | "error") {
+  const listeners = new Map<"message" | "error", Listener>();
+  let terminated = false;
+
+  const worker = {
+    addEventListener(type: "message" | "error", listener: Listener) {
+      listeners.set(type, listener);
+    },
+    removeEventListener(type: "message" | "error", listener: Listener) {
+      if (listeners.get(type) === listener) listeners.delete(type);
+    },
+    terminate() {
+      terminated = true;
+    },
+  };
+
+  queueMicrotask(() => {
+    listeners.get(outcome === "ready" ? "message" : "error")?.(new Event(outcome));
+  });
+
+  return {
+    worker,
+    wasTerminated: () => terminated,
+  };
+}
+
+describe("blob worker support probe", () => {
+  it("accepts a worker only after its script responds", async () => {
+    const probe = createProbeWorker("ready");
+    let revokedUrl: string | null = null;
+
+    const supported = await probeBlobWorkerSupport({
+      createWorker: () => probe.worker,
+      createObjectUrl: () => "blob:test-worker",
+      revokeObjectUrl: (url) => {
+        revokedUrl = url;
+      },
+      timeoutMs: 100,
+    });
+
+    expect(supported).toBe(true);
+    expect(probe.wasTerminated()).toBe(true);
+    expect(revokedUrl).toBe("blob:test-worker");
+  });
+
+  it("falls back when CSP or the browser rejects the worker script", async () => {
+    const probe = createProbeWorker("error");
+
+    const supported = await probeBlobWorkerSupport({
+      createWorker: () => probe.worker,
+      createObjectUrl: () => "blob:blocked-worker",
+      revokeObjectUrl: () => {},
+      timeoutMs: 100,
+    });
+
+    expect(supported).toBe(false);
+    expect(probe.wasTerminated()).toBe(true);
+  });
+
+  it("falls back when worker construction fails synchronously", async () => {
+    const supported = await probeBlobWorkerSupport({
+      createWorker: () => {
+        throw new Error("workers unavailable");
+      },
+      createObjectUrl: () => "blob:failed-worker",
+      revokeObjectUrl: () => {},
+      timeoutMs: 100,
+    });
+
+    expect(supported).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- derive group/name-filtered scan previews from the existing full in-memory preview cache
- preserve stable channel indices, metadata, content counts, and directory group behavior
- allow blob-backed MPEG-TS workers through the Tauri CSP
- probe worker execution once and fall back to inline transmuxing if startup is blocked

## Root cause

Filtered scan settings were part of the preview cache key, so the first scan after selecting a group or source filter missed the already-loaded full preview and reparsed very large playlists from disk.

MPEG-TS playback enabled the mpegts.js blob worker, but the app CSP did not permit blob workers. The asynchronous worker failure left mpegts.js waiting without ever requesting the localhost proxy/remux route.

## Validation

- `bun run test:frontend` — 90 passed
- `bun run typecheck`
- `cargo test --manifest-path src-tauri/Cargo.toml test_filter_cached_preview_matches_filtered_parse`
- `cargo check` in `src-tauri`
- `bun tauri build --debug --bundles app`
- installed debug bundle passed strict local signature verification and launched successfully

CodeRabbit local preflight was attempted three times but the external review service exited during setup without returning findings.