### PR TITLE
Add a signed in-app updater, and gate CI on lint, format, and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Lint and format check
+        run: bun run lint
+
       - name: Type check
         run: bun run typecheck
 
@@ -67,6 +70,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
       - name: Download ffmpeg binaries
         run: |
@@ -77,6 +82,14 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - name: Check formatting
+        working-directory: src-tauri
+        run: cargo fmt --check
+
+      - name: Clippy
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run Rust tests
         working-directory: src-tauri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
   build:
     strategy:
       fail-fast: false
+      # Run targets one at a time: tauri-action's updater step downloads the
+      # release's latest.json, adds this target's entry, and re-uploads it.
+      # Concurrent jobs would clobber each other's entries.
+      max-parallel: 1
       matrix:
         include:
           - os: macos-latest
@@ -81,7 +85,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Windows code signing (optional)
+          # Updater signing (required for the auto-update artifacts).
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
@@ -91,7 +95,9 @@ jobs:
           prerelease: false
           # Keep these aliases stable: kristofferR/homebrew-tap builds asset URLs from them.
           assetNamePattern: "IPTV.Checker_[version]_${{ env.ASSET_PLATFORM }}_${{ env.ASSET_ARCH }}[_setup][ext]"
-          args: --target ${{ matrix.target }}
+          # The release config enables createUpdaterArtifacts. It is kept out of
+          # the base config so a local `tauri build` doesn't need the signing key.
+          args: --target ${{ matrix.target }} --config src-tauri/tauri.conf.release.json
 
       - name: Verify production binary set
         shell: bash
@@ -99,11 +105,79 @@ jobs:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: bash scripts/verify-production-binaries.sh "${TARGET_TRIPLE}"
 
+      # tauri-action notarizes the .app but not the .dmg, so a downloaded .dmg
+      # would still be gatekeeper-prompted. Notarize + staple it, re-upload it
+      # under the stable name, and point the updater at it: the .dmg is the
+      # artifact users download, so it is the one that should be installed.
+      - name: Notarize the .dmg and point the updater at it
+        if: startsWith(matrix.os, 'macos')
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_MAC_ARCH: ${{ startsWith(matrix.target, 'aarch64') && 'aarch64' || 'x64' }}
+          UPDATER_PLATFORM: ${{ startsWith(matrix.target, 'aarch64') && 'darwin-aarch64' || 'darwin-x86_64' }}
+          TARGET_TRIPLE: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
+            # A tagged release promises a signed, notarized download — fail
+            # rather than publish an unstapled .dmg. Manual (workflow_dispatch)
+            # runs may still skip when the secrets aren't configured.
+            if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+              echo "Missing Apple notarization secrets for a tagged release." >&2
+              exit 1
+            fi
+            echo "No Apple credentials configured — skipping .dmg notarization."
+            exit 0
+          fi
+
+          src="$(find "src-tauri/target/${TARGET_TRIPLE}/release/bundle/dmg" -name '*.dmg' | head -1)"
+          if [ -z "${src}" ]; then echo "No .dmg found." >&2; exit 1; fi
+          xcrun notarytool submit "${src}" --apple-id "${APPLE_ID}" \
+            --password "${APPLE_PASSWORD}" --team-id "${APPLE_TEAM_ID}" --wait
+          xcrun stapler staple "${src}"
+
+          version="$(jq -r '.version' src-tauri/tauri.conf.json)"
+          dest="IPTV.Checker_${version}_mac_${ASSET_ARCH}.dmg"
+          cp "${src}" "${dest}"
+          bun run tauri signer sign "${dest}"
+          gh release upload "${GITHUB_REF_NAME}" "${dest}" "${dest}.sig" --clobber
+
+          bash scripts/patch-updater-manifest.sh \
+            "${GITHUB_REF_NAME}" "${UPDATER_PLATFORM}" "app" "${dest}" "$(cat "${dest}.sig")"
+
+          # Drop the stock .app.tar.gz updater archive: latest.json now points
+          # at the stapled .dmg, so the archive would only confuse the release
+          # listing (and is not notarized).
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            | jq -r --arg tag "${GITHUB_REF_NAME}" '.[] | select(.tag_name == $tag) | .id' | head -n1)"
+          assets="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets" --paginate)"
+          for stale in \
+            "IPTV.Checker_${version}_${TAURI_MAC_ARCH}.app.tar.gz" \
+            "IPTV.Checker_${version}_${TAURI_MAC_ARCH}.app.tar.gz.sig" \
+            "IPTV.Checker_${version}_mac_${ASSET_ARCH}.app.tar.gz" \
+            "IPTV.Checker_${version}_mac_${ASSET_ARCH}.app.tar.gz.sig" \
+            "IPTV.Checker_${version}_${TAURI_MAC_ARCH}.dmg"; do
+            stale_id="$(printf '%s\n' "${assets}" \
+              | jq -r --arg name "${stale}" '.[] | select(.name == $name) | .id' | head -n1)"
+            if [ -n "${stale_id}" ]; then
+              echo "Deleting superseded asset ${stale}."
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${stale_id}"
+            fi
+          done
+
       - name: Harden and replace AppImage release asset
         if: startsWith(matrix.target, 'x86_64-unknown-linux') || startsWith(matrix.target, 'aarch64-unknown-linux')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_TRIPLE: ${{ matrix.target }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          UPDATER_PLATFORM: ${{ startsWith(matrix.target, 'aarch64') && 'linux-aarch64' || 'linux-x86_64' }}
         run: |
           appimage="$(bash scripts/find-appimage.sh "${TARGET_TRIPLE}")"
           bash scripts/harden-appimage-runtime.sh "${appimage}"
@@ -112,6 +186,18 @@ jobs:
           release_asset="IPTV.Checker_${version}_lin_${ASSET_ARCH}.AppImage"
           cp "${appimage}" "${release_asset}"
           gh release upload "${GITHUB_REF_NAME}" "${release_asset}" --clobber
+
+          # Hardening rewrites the AppImage after tauri-action signed it, so the
+          # signature already in latest.json does not match the published bytes.
+          # Re-sign the hardened file and repoint the manifest, or every Linux
+          # auto-update would fail minisign verification.
+          bun run tauri signer sign "${release_asset}"
+          # Replace the stale detached signature asset too, so anyone verifying
+          # the published AppImage by hand gets the matching one.
+          gh release upload "${GITHUB_REF_NAME}" "${release_asset}.sig" --clobber
+          bash scripts/patch-updater-manifest.sh \
+            "${GITHUB_REF_NAME}" "${UPDATER_PLATFORM}" "appimage" \
+            "${release_asset}" "$(cat "${release_asset}.sig")"
 
       - name: Create Windows portable zip
         if: startsWith(matrix.target, 'x86_64-pc-windows') || startsWith(matrix.target, 'aarch64-pc-windows')
@@ -215,6 +301,10 @@ jobs:
             name "IPTV Checker"
             desc "Validate IPTV playlists and inspect stream health"
             homepage "https://github.com/${REPO}"
+
+            # The app ships a signed in-app updater, so a cask-installed copy can
+            # update itself between \`brew upgrade\` runs.
+            auto_updates true
 
             preflight do
               old_app = Pathname.new("/Applications/IPTV Checker.app")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,10 @@ jobs:
             exit 0
           fi
 
-          src="$(find "src-tauri/target/${TARGET_TRIPLE}/release/bundle/dmg" -name '*.dmg' | head -1)"
+          # -print -quit rather than piping to head: under `set -o pipefail` a
+          # missing bundle dir makes find fail the whole step before the guard
+          # below can report it.
+          src="$(find "src-tauri/target/${TARGET_TRIPLE}/release/bundle/dmg" -name '*.dmg' -print -quit || true)"
           if [ -z "${src}" ]; then echo "No .dmg found." >&2; exit 1; fi
           xcrun notarytool submit "${src}" --apple-id "${APPLE_ID}" \
             --password "${APPLE_PASSWORD}" --team-id "${APPLE_TEAM_ID}" --wait

--- a/docs/ui-performance-baseline.md
+++ b/docs/ui-performance-baseline.md
@@ -17,7 +17,34 @@ This benchmark uses:
 
 It reports `avg`, `p50`, and `p95` timings for common filter/sort cases.
 
-## 2) Runtime UI Sampling (Dev Builds)
+## 2) Result Batching Microbenchmark
+
+Run:
+
+```bash
+bun run perf:ui-batching
+```
+
+Replays a whole scan through `applyResultUpdates` one 16-result batch at a
+time — the path every `scan://channel-result` batch takes — and reports total
+and per-batch cost at 1k, 10k, and 50k channels.
+
+This exists because the fold used to be quadratic: the UI kept results twice,
+once in `flatResults` and once in an index-keyed object that was spread on
+every batch. Dropping the second copy (results now live only in `flatResults`,
+with an append-only index → position map) took a 50k-channel scan from ~13.8s
+of pure store bookkeeping to ~0.2s:
+
+| Channels | Before | After |
+|---------:|-------:|------:|
+| 1,000 | 3.0 ms | 0.4 ms |
+| 10,000 | 445 ms | 17.6 ms |
+| 50,000 | 13,761 ms | 213 ms |
+
+Measured on an Apple Silicon dev machine; treat the ratio, not the absolute
+numbers, as the baseline.
+
+## 3) Runtime UI Sampling (Dev Builds)
 
 In dev builds, the app records UI perf samples in memory:
 
@@ -46,7 +73,7 @@ To re-enable:
 localStorage.removeItem("iptv-checker.ui-perf.disabled")
 ```
 
-## 3) Manual UI Checks
+## 4) Manual UI Checks
 
 1. Start app: `bun tauri dev`
 2. Open each baseline playlist

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "setup:ffmpeg": "bash scripts/download-ffmpeg.sh",
     "clean:fuzz-local": "bash scripts/clean-fuzz-local.sh",
     "lint": "biome check .",
-    "format": "biome check --write ."
+    "format": "biome check --write .",
+    "perf:ui-batching": "bun run scripts/benchmark-result-batching.ts"
   },
   "dependencies": {
     "@bradleyhodges/sfsymbols": "^7.0.4",

--- a/scripts/benchmark-result-batching.ts
+++ b/scripts/benchmark-result-batching.ts
@@ -1,0 +1,89 @@
+/**
+ * Measures the per-batch cost of folding incoming scan results into the store's
+ * collections — the path every `scan://channel-result` batch takes.
+ *
+ * Run: bun run perf:ui-batching
+ */
+import {
+  applyResultUpdates,
+  emptyResultCollections,
+  type ScanResultCollections,
+} from "../src/hooks/useScan.helpers";
+import type { ChannelResult } from "../src/lib/types";
+
+const CHANNEL_COUNTS = [1_000, 10_000, 50_000];
+const BATCH_SIZE = 16;
+
+function makeResult(index: number): ChannelResult {
+  return {
+    index,
+    playlist: "bench.m3u",
+    name: `Channel ${index}`,
+    group: `Group ${index % 40}`,
+    language: null,
+    tvg_id: index % 3 === 0 ? `epg-${index}` : null,
+    tvg_name: null,
+    tvg_logo: null,
+    tvg_chno: null,
+    url: `http://example.com/${index}.m3u8`,
+    content_type: "live",
+    status: index % 5 === 0 ? "dead" : "alive",
+    codec: "h264",
+    resolution: "1920x1080",
+    width: 1920,
+    height: 1080,
+    fps: 50,
+    latency_ms: 120,
+    hdr_format: null,
+    video_bitrate: null,
+    audio_bitrate: null,
+    audio_codec: null,
+    audio_channel_layout: null,
+    audio_only: false,
+    screenshot_path: null,
+    label_mismatches: index % 11 === 0 ? ["Label mismatch"] : [],
+    low_framerate: index % 7 === 0,
+    error_message: null,
+    channel_id: `id-${index}`,
+    extinf_line: `#EXTINF:-1,Channel ${index}`,
+    metadata_lines: [],
+    stream_url: null,
+  };
+}
+
+/** Replays a whole scan one batch at a time, as the rAF batching does. */
+function runScan(total: number): { totalMs: number; batches: number } {
+  const results = Array.from({ length: total }, (_, i) => makeResult(i));
+  let collections: ScanResultCollections = emptyResultCollections();
+  let batches = 0;
+
+  const started = performance.now();
+  for (let offset = 0; offset < results.length; offset += BATCH_SIZE) {
+    collections = applyResultUpdates(collections, results.slice(offset, offset + BATCH_SIZE));
+    batches += 1;
+  }
+  const totalMs = performance.now() - started;
+
+  if (collections.flatResults.length !== total) {
+    throw new Error(`expected ${total} results, folded ${collections.flatResults.length}`);
+  }
+  return { totalMs, batches };
+}
+
+function main(): void {
+  console.log(`Result batching (batch size ${BATCH_SIZE})\n`);
+  for (const total of CHANNEL_COUNTS) {
+    runScan(Math.min(total, 1_000)); // warm up
+    const { totalMs, batches } = runScan(total);
+    console.log(
+      [
+        `  ${String(total).padStart(6, " ")} channels`,
+        `batches=${String(batches).padStart(5, " ")}`,
+        `total=${totalMs.toFixed(1).padStart(8, " ")}ms`,
+        `per-batch=${(totalMs / batches).toFixed(3).padStart(7, " ")}ms`,
+      ].join("  "),
+    );
+  }
+}
+
+main();

--- a/scripts/patch-updater-manifest.sh
+++ b/scripts/patch-updater-manifest.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repoint one platform entry in a release's latest.json at a specific asset.
+#
+# tauri-action signs the artifacts it builds and writes their URLs into
+# latest.json, but two of our release assets are replaced *after* that:
+#
+#   * the macOS .dmg — notarized and stapled in a later step, and used instead
+#     of Tauri's stock .app.tar.gz so the updater installs the same artifact
+#     users download;
+#   * the Linux AppImage — rewritten in place by harden-appimage-runtime.sh.
+#
+# In both cases the stock signature no longer matches the published bytes, so
+# the caller re-signs the final asset and hands the signature to this script.
+#
+# The updater resolves a manifest entry by trying "{os}-{arch}-{installer}"
+# before "{os}-{arch}" (see tauri-plugin-updater's `update_url_and_signature`),
+# so both keys are written — otherwise a stale installer-suffixed entry written
+# by tauri-action would still win.
+#
+# Usage:
+#   patch-updater-manifest.sh <tag> <os-arch> <installer> <asset-name> <signature>
+#
+# Requires GITHUB_TOKEN and GITHUB_REPOSITORY in the environment.
+
+if [[ $# -ne 5 ]]; then
+    echo "Usage: $0 <tag> <os-arch> <installer> <asset-name> <signature>" >&2
+    exit 2
+fi
+
+TAG="$1"
+PLATFORM="$2"
+INSTALLER="$3"
+ASSET_NAME="$4"
+SIGNATURE="$5"
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+if [[ -z "${SIGNATURE}" ]]; then
+    echo "Error: refusing to write an empty signature for ${PLATFORM}." >&2
+    exit 1
+fi
+
+release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+    | jq -r --arg tag "${TAG}" '.[] | select(.tag_name == $tag) | .id' \
+    | head -n1)"
+if [[ -z "${release_id}" ]]; then
+    echo "Error: no release found for tag ${TAG}." >&2
+    exit 1
+fi
+
+assets="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets" --paginate)"
+
+asset_id="$(printf '%s\n' "${assets}" \
+    | jq -r --arg name "${ASSET_NAME}" '.[] | select(.name == $name) | .id' \
+    | head -n1)"
+if [[ -z "${asset_id}" ]]; then
+    echo "Error: asset ${ASSET_NAME} was not found on release ${TAG}." >&2
+    exit 1
+fi
+
+manifest_id="$(printf '%s\n' "${assets}" \
+    | jq -r '.[] | select(.name == "latest.json") | .id' \
+    | head -n1)"
+if [[ -z "${manifest_id}" ]]; then
+    echo "Error: latest.json was not found; cannot repoint the ${PLATFORM} updater." >&2
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+gh api -H "Accept: application/octet-stream" \
+    "repos/${GITHUB_REPOSITORY}/releases/assets/${manifest_id}" \
+    > "${WORK_DIR}/latest.json"
+
+# The API asset URL (rather than browser_download_url) is what the updater
+# fetches; it sends `Accept: application/octet-stream`, so GitHub streams the
+# bytes instead of the asset's JSON metadata.
+asset_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+
+jq \
+    --arg platform "${PLATFORM}" \
+    --arg installer "${INSTALLER}" \
+    --arg url "${asset_url}" \
+    --arg signature "${SIGNATURE}" \
+    '.platforms[$platform].url = $url
+      | .platforms[$platform].signature = $signature
+      | .platforms[($platform + "-" + $installer)].url = $url
+      | .platforms[($platform + "-" + $installer)].signature = $signature' \
+    "${WORK_DIR}/latest.json" > "${WORK_DIR}/latest.next.json"
+
+mv "${WORK_DIR}/latest.next.json" "${WORK_DIR}/latest.json"
+gh release upload "${TAG}" "${WORK_DIR}/latest.json" --clobber
+
+echo "Repointed ${PLATFORM} and ${PLATFORM}-${INSTALLER} at ${ASSET_NAME}."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1118,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1520,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2545,6 +2575,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-store",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
@@ -2970,6 +3001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3526,20 @@ dependencies = [
  "objc2-ui-kit",
  "serde",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4505,6 +4568,7 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5322,6 +5386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5651,6 +5726,39 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -7385,6 +7493,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xcap"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7575,6 +7693,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-os = "2"
 base64 = "0.22.1"
 sha2 = "0.10"
 tauri-plugin-notification = "2"
+tauri-plugin-updater = "2"
 # rev-pinned: the fuzz crate resolves this git dep independently of the main
 # Cargo.lock, and upstream's newer revisions pull xcap 0.9+ (pipewire system
 # libs), which broke the fuzz CI job. Bump the rev deliberately, not implicitly.

--- a/src-tauri/examples/backend_bench.rs
+++ b/src-tauri/examples/backend_bench.rs
@@ -140,7 +140,6 @@ async fn main() -> Result<(), String> {
         let cancel = cancel.clone();
         let first_result_ms = Arc::clone(&first_result_ms);
         let url = format!("{}/stream/{}", base_url, index);
-        let started_at = started_at;
 
         tokio::spawn(async move {
             let _permit = permit;

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -179,11 +179,11 @@ fn compute_history_diff_from_results(
 ) -> ScanHistoryDiff {
     let newer_map: HashMap<String, ChannelStatus> = newer_results
         .iter()
-        .map(|result| (channel_identity_key(result), result.status.clone()))
+        .map(|result| (channel_identity_key(result), result.status))
         .collect();
     let older_map: HashMap<String, ChannelStatus> = older_results
         .iter()
-        .map(|result| (channel_identity_key(result), result.status.clone()))
+        .map(|result| (channel_identity_key(result), result.status))
         .collect();
 
     let channels_gained = newer_map
@@ -381,7 +381,7 @@ fn migrate_v1_to_v2(base_dir: &Path) -> Result<(), AppError> {
 
     let mut index_entries = Vec::with_capacity(v1_store.entries.len());
     for (_playlist_key, mut entries) in by_playlist {
-        entries.sort_by(|a, b| b.scanned_at_epoch_ms.cmp(&a.scanned_at_epoch_ms));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.scanned_at_epoch_ms));
 
         for i in 0..entries.len() {
             let diff = if i + 1 < entries.len() {
@@ -462,7 +462,7 @@ fn enforce_playlist_retention_v2(
         }
     }
 
-    matching.sort_by(|a, b| b.scanned_at_epoch_ms.cmp(&a.scanned_at_epoch_ms));
+    matching.sort_by_key(|entry| std::cmp::Reverse(entry.scanned_at_epoch_ms));
 
     // Delete per-run files for entries that will be removed
     if matching.len() > history_limit {
@@ -518,7 +518,7 @@ fn append_scan_history_at_dir(
         .iter()
         .filter(|e| e.playlist_key == playlist_key && e.scope_key == scope_key)
         .collect();
-    candidates.sort_by(|a, b| b.scanned_at_epoch_ms.cmp(&a.scanned_at_epoch_ms));
+    candidates.sort_by_key(|entry| std::cmp::Reverse(entry.scanned_at_epoch_ms));
 
     let diff = if let Some(prev_entry) = candidates.first() {
         match load_run_file(base_dir, &prev_entry.id) {
@@ -588,7 +588,7 @@ fn get_scan_history_from_dir(
         .iter()
         .filter(|entry| entry.playlist_key == playlist_key)
         .collect();
-    matching.sort_by(|a, b| b.scanned_at_epoch_ms.cmp(&a.scanned_at_epoch_ms));
+    matching.sort_by_key(|entry| std::cmp::Reverse(entry.scanned_at_epoch_ms));
 
     let items = matching
         .iter()

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod saved;
 pub mod scan;
 pub mod server_test;
 pub mod settings;
+pub mod updater;

--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -187,7 +187,7 @@ fn extract_host_fast(url: &str) -> Option<&str> {
     } else {
         // Host ends at first '/', ':', '?', or '#' (port, path, query, or fragment)
         let end = after_userinfo
-            .find(|c: char| c == '/' || c == ':' || c == '?' || c == '#')
+            .find(['/', ':', '?', '#'])
             .unwrap_or(after_userinfo.len());
         &after_userinfo[..end]
     };
@@ -398,8 +398,8 @@ async fn populate_server_metadata(app: Option<&AppHandle>, preview: &mut Playlis
 /// Prefers the filename from the path (e.g. "news.m3u"), falling back to the
 /// hostname (e.g. "iptv-org.github.io").
 pub(crate) fn friendly_name_from_url(url: &Url) -> String {
-    if let Some(segments) = url.path_segments() {
-        if let Some(last) = segments.filter(|s| !s.is_empty()).last() {
+    if let Some(mut segments) = url.path_segments() {
+        if let Some(last) = segments.rfind(|s| !s.is_empty()) {
             // Use the segment if it looks like a real name (has extension,
             // is short, or isn't a pure hex hash).
             if last.contains('.') || last.len() < 40 || !last.chars().all(|c| c.is_ascii_hexdigit())

--- a/src-tauri/src/commands/recent.rs
+++ b/src-tauri/src/commands/recent.rs
@@ -393,7 +393,7 @@ fn apply_recent_menu_update(app: &tauri::AppHandle, entries: &[RecentPlaylistEnt
     if let Ok(items) = recent_submenu.items() {
         for index in (0..items.len()).rev() {
             let item = &items[index];
-            if item.id() == &"menu.file.recent.clear" {
+            if item.id() == "menu.file.recent.clear" {
                 continue;
             }
             let _ = recent_submenu.remove_at(index);

--- a/src-tauri/src/commands/saved.rs
+++ b/src-tauri/src/commands/saved.rs
@@ -77,7 +77,11 @@ fn default_display_name(source: &SavedPlaylistSource) -> String {
                 .as_deref()
                 .or_else(|| servers.first().map(String::as_str))
                 .unwrap_or("Xtream");
-            format!("{} ({})", crate::commands::playlist::xtream_host_label(server), username)
+            format!(
+                "{} ({})",
+                crate::commands::playlist::xtream_host_label(server),
+                username
+            )
         }
     }
 }

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -89,6 +89,18 @@ impl SharedUrlResult {
     }
 }
 
+/// Per-URL memo of check results, so channels that share a stream URL are only
+/// fetched once. The `OnceCell` lets the second waiter block on the first
+/// worker's result instead of racing it.
+type SharedUrlResultCache = Arc<
+    tokio::sync::Mutex<
+        HashMap<
+            String,
+            Arc<tokio::sync::OnceCell<Result<(SharedUrlResult, WorkerTiming), AppError>>>,
+        >,
+    >,
+>;
+
 fn set_screenshot_capture_success(shared: &mut SharedUrlResult, path: String) {
     shared.screenshot_path = Some(path);
     shared.screenshot_error_reason = None;
@@ -346,7 +358,7 @@ async fn compute_shared_url_result(
     };
     let redacted_target_url = stream_proxy::redact_url(&target_url);
     let mut shared = SharedUrlResult {
-        status: status.clone(),
+        status,
         drm_system,
         latency_ms,
         codec: None,
@@ -485,10 +497,9 @@ async fn compute_shared_url_result(
                     shared.video_bitrate = Some(format!("{kbps} kbps"));
                 }
                 format_bitrate_kbps = diag.format_bitrate_kbps;
-                shared.channel_log.diagnostics_output =
-                    Some(crate::models::scan_log::cap_diagnostics_output(
-                        diag.diagnostics_output,
-                    ));
+                shared.channel_log.diagnostics_output = Some(
+                    crate::models::scan_log::cap_diagnostics_output(diag.diagnostics_output),
+                );
 
                 let png_fallback_result = if diag.screenshot_path.is_none()
                     && want_screenshot
@@ -1033,7 +1044,10 @@ fn filter_channels_by_selection(
 fn filter_channels_by_content_type(channels: &mut Vec<Channel>, hide_vod_content: bool) {
     if hide_vod_content {
         channels.retain(|channel| {
-            matches!(channel.content_type, crate::models::channel::ContentType::Live)
+            matches!(
+                channel.content_type,
+                crate::models::channel::ContentType::Live
+            )
         });
     }
 }
@@ -1585,9 +1599,7 @@ async fn prepare_screenshots_dir(
         let dir_clone = dir.clone();
         tokio::task::spawn_blocking(move || std::fs::create_dir_all(&dir_clone))
             .await
-            .map_err(|e| {
-                AppError::Other(format!("Failed to create screenshots directory: {}", e))
-            })?
+            .map_err(|e| AppError::Other(format!("Failed to create screenshots directory: {}", e)))?
             .map_err(|e| {
                 AppError::Other(format!("Failed to create screenshots directory: {}", e))
             })?;
@@ -1641,7 +1653,8 @@ async fn pause_if_network_down(
     cancel: &CancellationToken,
     consecutive_net_failures: &AtomicU32,
 ) -> bool {
-    if consecutive_net_failures.load(Ordering::Relaxed) < connectivity::CONSECUTIVE_FAILURE_THRESHOLD
+    if consecutive_net_failures.load(Ordering::Relaxed)
+        < connectivity::CONSECUTIVE_FAILURE_THRESHOLD
     {
         return true;
     }
@@ -1726,7 +1739,10 @@ impl AdaptiveThrottle {
             if !self.engaged.swap(true, Ordering::Relaxed) {
                 log::info!(
                     "Adaptive throttle engaged: pressure_ratio={:.2} ({}/{} channels), delay={}ms",
-                    pressure_ratio, pressure, total_so_far, delay_ms
+                    pressure_ratio,
+                    pressure,
+                    total_so_far,
+                    delay_ms
                 );
                 let _ = app.emit(
                     "scan://adaptive-throttle",
@@ -1826,7 +1842,7 @@ impl ScreenshotDiskGuard {
             return false;
         }
         let count = self.check_counter.fetch_add(1, Ordering::Relaxed);
-        if count % 20 != 0 {
+        if !count.is_multiple_of(20) {
             return false;
         }
         let Some(dir) = screenshots_dir else {
@@ -2006,7 +2022,9 @@ async fn run_event_emitter(
             .await;
         }
 
-        emitter.ingest(worker.result, Some(worker.channel_log)).await;
+        emitter
+            .ingest(worker.result, Some(worker.channel_log))
+            .await;
     }
 
     emitter.finish().await
@@ -2035,14 +2053,15 @@ fn track_worker_signals(
     // Adaptive concurrency — track pressure signals
     let is_pressure_signal = if shared.status == ChannelStatus::Dead {
         // Timeout or rate limit errors are pressure signals
-        shared.error_reason.as_deref().map_or(false, |reason| {
-            reason == "Timeout" || reason.starts_with("HTTP 429")
-        })
+        shared
+            .error_reason
+            .as_deref()
+            .is_some_and(|reason| reason == "Timeout" || reason.starts_with("HTTP 429"))
     } else {
         false
     };
     // Retries indicate the server is under strain even if the channel eventually succeeded
-    let had_retries = shared.retry_count.map_or(false, |count| count > 0);
+    let had_retries = shared.retry_count.is_some_and(|count| count > 0);
 
     adaptive_throttle.record_outcome(is_pressure_signal || had_retries);
 }
@@ -2062,7 +2081,7 @@ fn build_channel_result(channel: &Channel, shared: &SharedUrlResult) -> ChannelR
         tvg_chno: channel.tvg_chno.clone(),
         url: channel.url.clone(),
         content_type: channel.content_type,
-        status: shared.status.clone(),
+        status: shared.status,
         codec: shared.codec.clone(),
         resolution: shared.resolution.clone(),
         width: shared.width,
@@ -2118,14 +2137,9 @@ async fn append_history_blocking(
     let config = config.clone();
     let summary = summary.clone();
     let _ = tokio::task::spawn_blocking(move || {
-        if let Err(error) = history::append_scan_history(
-            &app,
-            &run_id,
-            &config,
-            &summary,
-            results,
-            history_limit,
-        ) {
+        if let Err(error) =
+            history::append_scan_history(&app, &run_id, &config, &summary, results, history_limit)
+        {
             log::warn!("Failed to write scan history for {}: {}", run_id, error);
         }
     })
@@ -2353,18 +2367,11 @@ async fn execute_scan_run(
     ));
 
     let proxy_list = Arc::new(proxy_list);
-    let shared_url_results: Arc<
-        tokio::sync::Mutex<
-            HashMap<
-                String,
-                Arc<tokio::sync::OnceCell<Result<(SharedUrlResult, WorkerTiming), AppError>>>,
-            >,
-        >,
-    > = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let shared_url_results: SharedUrlResultCache =
+        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
     // Disk space tracking for screenshot pause
-    let disk_guard =
-        ScreenshotDiskGuard::new(using_custom_screenshots_dir, low_space_threshold_gb);
+    let disk_guard = ScreenshotDiskGuard::new(using_custom_screenshots_dir, low_space_threshold_gb);
 
     // Network connectivity tracking — consecutive network-level failures trigger a check
     let consecutive_net_failures = Arc::new(AtomicU32::new(0));
@@ -2871,7 +2878,7 @@ pub async fn quick_check_channel(
             &channel.url,
             settings.ffprobe_timeout_secs,
             settings.retries,
-            settings.retry_backoff.clone(),
+            settings.retry_backoff,
             None,
             ffprobe_ok,
             &cancel_token,
@@ -2883,7 +2890,7 @@ pub async fn quick_check_channel(
             &channel.url,
             settings.timeout,
             settings.retries,
-            settings.retry_backoff.clone(),
+            settings.retry_backoff,
             settings.extended_timeout,
             &settings.user_agent,
             &cancel_token,

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -16,8 +16,8 @@ use crate::models::backend_perf::BackendPerfSample;
 use crate::models::channel::{Channel, ChannelResult, ChannelStatus};
 use crate::models::playlist::PlaylistPreview;
 use crate::models::scan::{
-    PlaylistScore, RetryBackoff, ScanConfig, ScanErrorPayload, ScanEvent, ScanProgress,
-    ScanResultBatchPayload, ScanSummary,
+    RetryBackoff, ScanConfig, ScanErrorPayload, ScanEvent, ScanProgress, ScanResultBatchPayload,
+    ScanSummary,
 };
 use crate::models::scan_log::{ChannelDebugLog, ScanDebugLog};
 use crate::models::settings::ScreenshotFormat;
@@ -866,169 +866,6 @@ impl ScanCounters {
             playlist_score: None,
         }
     }
-}
-
-fn clamp_01(value: f64) -> f64 {
-    value.clamp(0.0, 1.0)
-}
-
-fn clamp_score_10(value: f64) -> f64 {
-    value.clamp(0.0, 10.0)
-}
-
-fn round_to_tenth(value: f64) -> f64 {
-    (value * 10.0).round() / 10.0
-}
-
-fn median_u64(values: &[u64]) -> Option<f64> {
-    if values.is_empty() {
-        return None;
-    }
-    let mut sorted = values.to_vec();
-    sorted.sort_unstable();
-    let mid = sorted.len() / 2;
-    if sorted.len() % 2 == 1 {
-        Some(sorted[mid] as f64)
-    } else {
-        Some((sorted[mid - 1] as f64 + sorted[mid] as f64) / 2.0)
-    }
-}
-
-fn is_hd_or_uhd(result: &ChannelResult) -> bool {
-    if let (Some(width), Some(height)) = (result.width, result.height) {
-        if width >= 1280 && height >= 720 {
-            return true;
-        }
-    }
-    if let Some(resolution) = result.resolution.as_ref() {
-        let normalized = resolution.to_ascii_lowercase();
-        return normalized.contains("720")
-            || normalized.contains("1080")
-            || normalized.contains("1440")
-            || normalized.contains("2160")
-            || normalized.contains("4k")
-            || normalized.contains("uhd");
-    }
-    false
-}
-
-fn codec_tier_score(codec: Option<&str>) -> f64 {
-    let Some(codec) = codec else {
-        return 0.4;
-    };
-    let normalized = codec.to_ascii_lowercase();
-    if normalized.contains("hevc") || normalized.contains("h265") || normalized.contains("h.265") {
-        return 1.0;
-    }
-    if normalized.contains("av1") {
-        return 1.0;
-    }
-    if normalized.contains("h264") || normalized.contains("h.264") || normalized.contains("avc") {
-        return 0.8;
-    }
-    if normalized.contains("mpeg") || normalized.contains("vp9") {
-        return 0.6;
-    }
-    0.5
-}
-
-fn compute_playlist_score(
-    results: &[ChannelResult],
-    total_channels: usize,
-) -> Option<PlaylistScore> {
-    if total_channels == 0 {
-        return None;
-    }
-
-    let alive_results = results
-        .iter()
-        .filter(|result| result.status == ChannelStatus::Alive)
-        .collect::<Vec<_>>();
-    let alive_count = alive_results.len();
-
-    let ping_score = {
-        let latencies = alive_results
-            .iter()
-            .filter_map(|result| result.latency_ms)
-            .collect::<Vec<_>>();
-        let p50 = median_u64(&latencies);
-        let raw = if let Some(p50) = p50 {
-            // 100ms ~= excellent (10), 1200ms ~= poor (0)
-            (1200.0 - p50) / 1100.0 * 10.0
-        } else {
-            0.0
-        };
-        clamp_score_10(raw)
-    };
-
-    let content_score = {
-        let alive_ratio = alive_count as f64 / total_channels as f64;
-        let unique_groups = results
-            .iter()
-            .map(|result| result.group.trim().to_ascii_lowercase())
-            .filter(|group| !group.is_empty())
-            .collect::<HashSet<_>>()
-            .len();
-        let diversity_ratio = clamp_01(unique_groups as f64 / 20.0);
-        let epg_covered = results
-            .iter()
-            .filter(|result| {
-                result
-                    .tvg_id
-                    .as_deref()
-                    .map(str::trim)
-                    .map(|value| !value.is_empty())
-                    .unwrap_or(false)
-            })
-            .count();
-        let epg_ratio = epg_covered as f64 / total_channels as f64;
-
-        clamp_score_10((alive_ratio * 0.6 + diversity_ratio * 0.2 + epg_ratio * 0.2) * 10.0)
-    };
-
-    let quality_score = {
-        if alive_results.is_empty() {
-            0.0
-        } else {
-            let hd_ratio = alive_results
-                .iter()
-                .filter(|result| is_hd_or_uhd(result))
-                .count() as f64
-                / alive_results.len() as f64;
-
-            let codec_avg = alive_results
-                .iter()
-                .map(|result| codec_tier_score(result.codec.as_deref()))
-                .sum::<f64>()
-                / alive_results.len() as f64;
-
-            let fps_known = alive_results
-                .iter()
-                .filter(|result| result.fps.is_some())
-                .count();
-            let fps_ratio = if fps_known == 0 {
-                0.0
-            } else {
-                alive_results
-                    .iter()
-                    .filter(|result| result.fps.unwrap_or_default() >= 25)
-                    .count() as f64
-                    / fps_known as f64
-            };
-
-            clamp_score_10((hd_ratio * 0.5 + codec_avg * 0.3 + fps_ratio * 0.2) * 10.0)
-        }
-    };
-
-    let overall_score =
-        clamp_score_10(ping_score * 0.25 + content_score * 0.40 + quality_score * 0.35);
-
-    Some(PlaylistScore {
-        overall: round_to_tenth(overall_score),
-        ping: round_to_tenth(ping_score),
-        content: round_to_tenth(content_score),
-        quality: round_to_tenth(quality_score),
-    })
 }
 
 fn filter_channels_by_selection(
@@ -2620,7 +2457,10 @@ async fn execute_scan_run(
     };
 
     let mut summary = completed_scan.summary.clone();
-    summary.playlist_score = compute_playlist_score(&completed_scan.results, summary.total);
+    summary.playlist_score = crate::engine::playlist_score::compute_playlist_score(
+        &completed_scan.results,
+        summary.total,
+    );
     if cancel_token.is_cancelled() {
         let _ = app.emit(
             "scan://cancelled",
@@ -3193,44 +3033,6 @@ mod tests {
         assert_eq!(summary.low_framerate, 1);
         assert_eq!(summary.mislabeled, 1);
         assert!(summary.playlist_score.is_none());
-    }
-
-    #[test]
-    fn compute_playlist_score_builds_weighted_subscores() {
-        let mut first = make_result(0, ChannelStatus::Alive, false, false);
-        first.group = "Sports".to_string();
-        first.latency_ms = Some(150);
-        first.tvg_id = Some("epg-a".to_string());
-        first.width = Some(1920);
-        first.height = Some(1080);
-        first.codec = Some("h264".to_string());
-        first.fps = Some(30);
-
-        let mut second = make_result(1, ChannelStatus::Alive, false, false);
-        second.group = "Movies".to_string();
-        second.latency_ms = Some(300);
-        second.tvg_id = Some("epg-b".to_string());
-        second.width = Some(3840);
-        second.height = Some(2160);
-        second.codec = Some("hevc".to_string());
-        second.fps = Some(50);
-
-        let mut third = make_result(2, ChannelStatus::Dead, false, false);
-        third.group = "Kids".to_string();
-
-        let score = compute_playlist_score(&[first, second, third], 3)
-            .expect("score should be present for non-empty scans");
-
-        assert!(score.ping > 0.0);
-        assert!(score.content > 0.0);
-        assert!(score.quality > 0.0);
-        assert!(score.overall > 0.0);
-        assert!(score.overall <= 10.0);
-    }
-
-    #[test]
-    fn compute_playlist_score_returns_none_for_empty_scans() {
-        assert!(compute_playlist_score(&[], 0).is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/server_test.rs
+++ b/src-tauri/src/commands/server_test.rs
@@ -711,7 +711,7 @@ async fn test_xtream_servers_inner(
                     r.trim_end_matches('p')
                         .parse::<u32>()
                         .ok()
-                        .or_else(|| r.split('x').last()?.parse::<u32>().ok())
+                        .or_else(|| r.split('x').next_back()?.parse::<u32>().ok())
                 })
             })
             .max()

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -732,7 +732,15 @@ pub async fn update_settings(app: tauri::AppHandle, settings: AppSettings) -> Re
         settings.level_filter() as usize,
         std::sync::atomic::Ordering::Relaxed,
     );
+    let update_checks_enabled = settings.automatic_update_checks && !current.automatic_update_checks;
     *current = settings.clone();
+    drop(current);
+
+    // Switching automatic checks back on should discover an update now rather
+    // than at the end of the current six-hour interval.
+    if update_checks_enabled {
+        state.update_check_wake.notify_one();
+    }
 
     // Persist to store
     if let Ok(store) = app.store("settings.json") {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -197,7 +197,7 @@ fn save_scan_presets(app: &tauri::AppHandle, presets: &ScanPresetCollection) {
     }
 }
 
-fn sort_scan_presets(presets: &mut Vec<ScanSettingsPreset>) {
+fn sort_scan_presets(presets: &mut [ScanSettingsPreset]) {
     presets.sort_by(|left, right| {
         left.name
             .to_ascii_lowercase()
@@ -732,7 +732,8 @@ pub async fn update_settings(app: tauri::AppHandle, settings: AppSettings) -> Re
         settings.level_filter() as usize,
         std::sync::atomic::Ordering::Relaxed,
     );
-    let update_checks_enabled = settings.automatic_update_checks && !current.automatic_update_checks;
+    let update_checks_enabled =
+        settings.automatic_update_checks && !current.automatic_update_checks;
     *current = settings.clone();
     drop(current);
 
@@ -925,7 +926,7 @@ pub fn evict_old_screenshot_dirs(
 
     for (_source, mut dirs) in by_source {
         // Sort newest first
-        dirs.sort_by(|a, b| b.1.cmp(&a.1));
+        dirs.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         // Keep `retention_count`, evict the rest
         for (path, _ts) in dirs.into_iter().skip(retention_count as usize) {
             if let Ok((bytes, _)) = collect_dir_stats(&path) {
@@ -989,7 +990,7 @@ pub fn evict_for_disk_space(
             let ts = read_scan_meta(&path)
                 .map(|m| m.scan_started_at_epoch_ms)
                 .unwrap_or(0);
-            if oldest.as_ref().map_or(true, |o| ts < o.1) {
+            if oldest.as_ref().is_none_or(|o| ts < o.1) {
                 oldest = Some((path, ts));
             }
         }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -231,7 +231,15 @@ fn current_bundle_on_read_only_volume() -> bool {
     stat.f_flags & libc::MNT_RDONLY as u32 != 0
 }
 
+/// Detection spawns up to three subprocesses on Linux and stats the volume on
+/// macOS, and the answer cannot change while the process runs.
+static INSTALL_SOURCE: std::sync::OnceLock<InstallSource> = std::sync::OnceLock::new();
+
 fn current_install_source() -> InstallSource {
+    *INSTALL_SOURCE.get_or_init(detect_install_source)
+}
+
+fn detect_install_source() -> InstallSource {
     #[cfg(target_os = "linux")]
     {
         linux_install_source(

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -25,10 +25,12 @@ const AUR_PACKAGE_URL: &str = "https://aur.archlinux.org/packages/iptv-checker-g
 
 /// How this particular installation receives updates.
 ///
-/// Only `SelfUpdatable` is reachable on every platform; the rest are each
-/// constructed on one OS. The enum stays platform-independent so the mapping to
-/// install modes is unit-testable everywhere.
-#[cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(dead_code))]
+/// Each variant besides `SelfUpdatable` is constructed on exactly one OS, so
+/// every target build leaves at least one unconstructed — hence the blanket
+/// allow rather than a per-platform one. The enum stays platform-independent so
+/// the mapping to install modes is unit-testable everywhere, and the tests do
+/// exercise every variant.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InstallSource {
     /// The app can replace itself: macOS `.app`, an installed Windows copy, or

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -25,20 +25,24 @@ const AUR_PACKAGE_URL: &str = "https://aur.archlinux.org/packages/iptv-checker-g
 
 /// How this particular installation receives updates.
 ///
-/// `Aur` and `SystemPackage` are only ever constructed on Linux, but the enum
-/// stays platform-independent so the mapping to install modes is unit-testable
-/// on every platform.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+/// Only `SelfUpdatable` is reachable on every platform; the rest are each
+/// constructed on one OS. The enum stays platform-independent so the mapping to
+/// install modes is unit-testable everywhere.
+#[cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(dead_code))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InstallSource {
-    /// The app can replace itself: macOS `.app`, Windows installer, Linux
-    /// AppImage.
+    /// The app can replace itself: macOS `.app`, an installed Windows copy, or
+    /// a Linux AppImage.
     SelfUpdatable,
     /// Installed from the AUR, so pacman owns the files.
     Aur,
     /// Installed from the `.deb`/`.rpm`, owned by apt/dnf. Tauri's updater only
     /// supports AppImage on Linux, so it cannot install these either.
     SystemPackage,
+    /// The Windows portable `.zip`. Tauri would run the NSIS installer, which
+    /// updates a *separate* installed copy and leaves the portable executable
+    /// the user launched untouched — so it must not be offered.
+    WindowsPortable,
 }
 
 impl InstallSource {
@@ -49,7 +53,7 @@ impl InstallSource {
             Self::Aur => Some(AUR_PACKAGE_URL),
             #[cfg(not(target_os = "linux"))]
             Self::Aur => Some(RELEASES_URL),
-            Self::SystemPackage => Some(RELEASES_URL),
+            Self::SystemPackage | Self::WindowsPortable => Some(RELEASES_URL),
         }
     }
 }
@@ -103,6 +107,15 @@ impl UpdateInstallMode {
                         .into(),
                 ),
             },
+            InstallSource::WindowsPortable => Self {
+                kind: UpdateInstallKind::Manual,
+                button_label: Some("Open the releases page".into()),
+                instructions: Some(
+                    "This is the portable build. Download the new portable .zip and \
+                     replace this copy."
+                        .into(),
+                ),
+            },
         }
     }
 
@@ -153,52 +166,81 @@ fn linux_install_source(pacman_owned: bool, running_as_appimage: bool) -> Instal
     }
 }
 
-fn current_install_mode() -> UpdateInstallMode {
-    #[cfg(target_os = "linux")]
-    {
-        let source = linux_install_source(
-            pacman_owns_current_executable(),
-            std::env::var_os("APPIMAGE").is_some(),
-        );
-        UpdateInstallMode::from_source(
-            source,
-            source == InstallSource::Aur && command_available("paru"),
-            source == InstallSource::Aur && command_available("yay"),
-        )
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        UpdateInstallMode::from_source(InstallSource::SelfUpdatable, false, false)
+/// Tauri's NSIS installer writes `uninstall.exe` next to the app executable
+/// (`WriteUninstaller "$INSTDIR\uninstall.exe"`), while the portable `.zip`
+/// ships only the app and its ffmpeg sidecars — so the marker distinguishes an
+/// installed copy from a portable one.
+#[cfg(any(target_os = "windows", test))]
+fn windows_install_source(has_uninstaller: bool) -> InstallSource {
+    if has_uninstaller {
+        InstallSource::SelfUpdatable
+    } else {
+        InstallSource::WindowsPortable
     }
 }
 
-fn current_manual_url() -> Option<&'static str> {
+#[cfg(target_os = "windows")]
+fn uninstaller_beside_current_exe() -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join("uninstall.exe")))
+        .is_some_and(|marker| marker.is_file())
+}
+
+fn current_install_source() -> InstallSource {
     #[cfg(target_os = "linux")]
     {
         linux_install_source(
             pacman_owns_current_executable(),
             std::env::var_os("APPIMAGE").is_some(),
         )
-        .manual_url()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        windows_install_source(uninstaller_beside_current_exe())
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        InstallSource::SelfUpdatable
+    }
+}
+
+fn current_install_mode() -> UpdateInstallMode {
+    let source = current_install_source();
+    let is_aur = source == InstallSource::Aur;
+    #[cfg(target_os = "linux")]
+    {
+        UpdateInstallMode::from_source(
+            source,
+            is_aur && command_available("paru"),
+            is_aur && command_available("yay"),
+        )
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        InstallSource::SelfUpdatable.manual_url()
+        let _ = is_aur;
+        UpdateInstallMode::from_source(source, false, false)
     }
 }
 
-/// Detection shells out on Linux, so keep it off the main thread there.
+fn current_manual_url() -> Option<&'static str> {
+    current_install_source().manual_url()
+}
+
+/// Detection shells out to pacman on Linux and stats the install directory on
+/// Windows, so keep it off the main thread on both.
 async fn current_install_mode_off_main() -> Result<UpdateInstallMode, AppError> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
         tauri::async_runtime::spawn_blocking(current_install_mode)
             .await
             .map_err(|error| AppError::Other(format!("update install mode worker failed: {error}")))
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     {
         Ok(current_install_mode())
     }
@@ -501,6 +543,23 @@ mod tests {
         assert_eq!(linux_install_source(true, false), InstallSource::Aur);
         // An AUR helper that runs the AppImage would still be pacman-owned.
         assert_eq!(linux_install_source(true, true), InstallSource::Aur);
+    }
+
+    #[test]
+    fn windows_portable_copies_are_manual() {
+        // Tauri would run the NSIS installer, updating a separate installed
+        // copy while the running portable .exe stays on the old version.
+        let portable = windows_install_source(false);
+        assert_eq!(portable, InstallSource::WindowsPortable);
+        let mode = UpdateInstallMode::from_source(portable, false, false);
+        assert!(mode.is_manual());
+        assert_eq!(portable.manual_url(), Some(RELEASES_URL));
+    }
+
+    #[test]
+    fn installed_windows_copies_update_themselves() {
+        // uninstall.exe beside the executable is written only by the installer.
+        assert_eq!(windows_install_source(true), InstallSource::SelfUpdatable);
     }
 
     #[test]

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -226,12 +226,22 @@ fn current_install_mode() -> UpdateInstallMode {
     }
 }
 
-fn current_manual_url() -> Option<&'static str> {
-    current_install_source().manual_url()
+/// Detection shells out to pacman on Linux and stats the install directory on
+/// Windows, so keep it off the async runtime thread on both.
+async fn current_install_source_off_main() -> Result<InstallSource, AppError> {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        tauri::async_runtime::spawn_blocking(current_install_source)
+            .await
+            .map_err(|error| AppError::Other(format!("install source worker failed: {error}")))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        Ok(current_install_source())
+    }
 }
 
-/// Detection shells out to pacman on Linux and stats the install directory on
-/// Windows, so keep it off the main thread on both.
 async fn current_install_mode_off_main() -> Result<UpdateInstallMode, AppError> {
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
@@ -351,12 +361,13 @@ pub async fn update_install_mode() -> Result<UpdateInstallMode, AppError> {
 /// accepted from the webview.
 #[tauri::command]
 pub async fn open_manual_update(app: AppHandle) -> Result<(), AppError> {
-    if !current_install_mode_off_main().await?.is_manual() {
+    // One detection for both the check and the URL: re-deriving the URL would
+    // run pacman again, and directly on the async runtime thread.
+    let Some(url) = current_install_source_off_main().await?.manual_url() else {
         return Err(AppError::Validation(
             "This installation supports built-in updates.".into(),
         ));
-    }
-    let url = current_manual_url().unwrap_or(RELEASES_URL);
+    };
     app.opener()
         .open_url(url, None::<&str>)
         .map_err(|e| AppError::Other(format!("could not open {url}: {e}")))

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,562 @@
+//! Signed in-app updates.
+//!
+//! Discovery is deliberately separate from installation: a check never
+//! downloads or replaces anything, so the UI can ask for explicit confirmation
+//! before an update swaps out the running application and restarts it.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_notification::NotificationExt;
+use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+const AUTOMATIC_UPDATE_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+/// Consumed by `hooks/useUpdateCheck.ts`.
+const UPDATE_AVAILABLE_EVENT: &str = "updater://update-available";
+const RELEASES_URL: &str = "https://github.com/kristofferR/IPTVChecker/releases/latest";
+#[cfg(target_os = "linux")]
+const AUR_PACKAGE_URL: &str = "https://aur.archlinux.org/packages/iptv-checker-gui";
+
+/// How this particular installation receives updates.
+///
+/// `Aur` and `SystemPackage` are only ever constructed on Linux, but the enum
+/// stays platform-independent so the mapping to install modes is unit-testable
+/// on every platform.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InstallSource {
+    /// The app can replace itself: macOS `.app`, Windows installer, Linux
+    /// AppImage.
+    SelfUpdatable,
+    /// Installed from the AUR, so pacman owns the files.
+    Aur,
+    /// Installed from the `.deb`/`.rpm`, owned by apt/dnf. Tauri's updater only
+    /// supports AppImage on Linux, so it cannot install these either.
+    SystemPackage,
+}
+
+impl InstallSource {
+    fn manual_url(self) -> Option<&'static str> {
+        match self {
+            Self::SelfUpdatable => None,
+            #[cfg(target_os = "linux")]
+            Self::Aur => Some(AUR_PACKAGE_URL),
+            #[cfg(not(target_os = "linux"))]
+            Self::Aur => Some(RELEASES_URL),
+            Self::SystemPackage => Some(RELEASES_URL),
+        }
+    }
+}
+
+/// The install affordance the UI should offer. `button_label` and
+/// `instructions` are only set for installations that must be updated by their
+/// own package manager.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInstallMode {
+    kind: UpdateInstallKind,
+    button_label: Option<String>,
+    instructions: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum UpdateInstallKind {
+    BuiltIn,
+    Manual,
+}
+
+impl UpdateInstallMode {
+    fn from_source(source: InstallSource, has_paru: bool, has_yay: bool) -> Self {
+        match source {
+            InstallSource::SelfUpdatable => Self {
+                kind: UpdateInstallKind::BuiltIn,
+                button_label: None,
+                instructions: None,
+            },
+            InstallSource::Aur => {
+                let instructions = if has_paru {
+                    "Run paru -S iptv-checker-gui to update."
+                } else if has_yay {
+                    "Run yay -S iptv-checker-gui to update."
+                } else {
+                    "Update the iptv-checker-gui package with your AUR helper."
+                };
+                Self {
+                    kind: UpdateInstallKind::Manual,
+                    button_label: Some("Open IPTV Checker on AUR".into()),
+                    instructions: Some(instructions.into()),
+                }
+            }
+            InstallSource::SystemPackage => Self {
+                kind: UpdateInstallKind::Manual,
+                button_label: Some("Open the releases page".into()),
+                instructions: Some(
+                    "This copy was installed from a system package. Download the new \
+                     .deb/.rpm and install it with your package manager."
+                        .into(),
+                ),
+            },
+        }
+    }
+
+    fn is_manual(&self) -> bool {
+        self.kind == UpdateInstallKind::Manual
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn command_available(program: &str) -> bool {
+    std::process::Command::new(program)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(target_os = "linux")]
+fn pacman_owns_current_executable() -> bool {
+    let Ok(executable) = std::env::current_exe() else {
+        return false;
+    };
+    std::process::Command::new("pacman")
+        .arg("-Qo")
+        .arg(executable)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// AUR packages reuse the signed `.deb` payload but are owned by pacman, so
+/// letting Tauri run `dpkg` would fail and would bypass pacman's ownership
+/// database if forced. Everything that is not a running AppImage is likewise
+/// owned by a system package manager — Tauri's Linux updater only knows how to
+/// replace an AppImage.
+#[cfg(any(target_os = "linux", test))]
+fn linux_install_source(pacman_owned: bool, running_as_appimage: bool) -> InstallSource {
+    if pacman_owned {
+        InstallSource::Aur
+    } else if running_as_appimage {
+        InstallSource::SelfUpdatable
+    } else {
+        InstallSource::SystemPackage
+    }
+}
+
+fn current_install_mode() -> UpdateInstallMode {
+    #[cfg(target_os = "linux")]
+    {
+        let source = linux_install_source(
+            pacman_owns_current_executable(),
+            std::env::var_os("APPIMAGE").is_some(),
+        );
+        UpdateInstallMode::from_source(
+            source,
+            source == InstallSource::Aur && command_available("paru"),
+            source == InstallSource::Aur && command_available("yay"),
+        )
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        UpdateInstallMode::from_source(InstallSource::SelfUpdatable, false, false)
+    }
+}
+
+fn current_manual_url() -> Option<&'static str> {
+    #[cfg(target_os = "linux")]
+    {
+        linux_install_source(
+            pacman_owns_current_executable(),
+            std::env::var_os("APPIMAGE").is_some(),
+        )
+        .manual_url()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        InstallSource::SelfUpdatable.manual_url()
+    }
+}
+
+/// Detection shells out on Linux, so keep it off the main thread there.
+async fn current_install_mode_off_main() -> Result<UpdateInstallMode, AppError> {
+    #[cfg(target_os = "linux")]
+    {
+        tauri::async_runtime::spawn_blocking(current_install_mode)
+            .await
+            .map_err(|error| AppError::Other(format!("update install mode worker failed: {error}")))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(current_install_mode())
+    }
+}
+
+async fn available_update_unlocked(app: &AppHandle) -> Result<Option<Update>, AppError> {
+    let updater = app
+        .updater()
+        .map_err(|e| AppError::Other(format!("updater unavailable: {e}")))?;
+    updater
+        .check()
+        .await
+        .map_err(|e| AppError::Other(format!("update check failed: {e}")))
+}
+
+async fn available_update(app: &AppHandle) -> Result<Option<Update>, AppError> {
+    let state = app.state::<std::sync::Arc<AppState>>();
+    let _operation_guard = state.update_checking.lock().await;
+    available_update_unlocked(app).await
+}
+
+fn should_surface_update(remembered: Option<&str>, discovered: Option<&str>) -> bool {
+    discovered.is_some() && remembered != discovered
+}
+
+/// Stores the discovery and reports whether it is new (so a background check
+/// only notifies once per version).
+async fn remember_available_update(app: &AppHandle, update: Option<Update>) -> bool {
+    let state = app.state::<std::sync::Arc<AppState>>();
+    let mut remembered = state.update_available.lock().await;
+    let is_new = should_surface_update(
+        remembered.as_ref().map(|update| update.version.as_str()),
+        update.as_ref().map(|update| update.version.as_str()),
+    );
+    *remembered = update;
+    is_new
+}
+
+/// Rejects a second install immediately rather than letting it queue.
+struct UpdateInstallGuard<'a>(&'a AtomicBool);
+
+impl<'a> UpdateInstallGuard<'a> {
+    fn acquire(flag: &'a AtomicBool) -> Result<Self, AppError> {
+        flag.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| Self(flag))
+            .map_err(|_| AppError::State("An update install is already in progress.".into()))
+    }
+}
+
+impl Drop for UpdateInstallGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+/// Result of a discovery request. `version` is `None` when already up to date.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateCheckResult {
+    pub version: Option<String>,
+    pub notes: Option<String>,
+}
+
+/// Check for a newer signed release without downloading or installing anything.
+#[tauri::command]
+pub async fn check_for_updates(app: AppHandle) -> Result<UpdateCheckResult, AppError> {
+    if app
+        .state::<std::sync::Arc<AppState>>()
+        .update_installing
+        .load(Ordering::Acquire)
+    {
+        return Err(AppError::State(
+            "An update install is already in progress.".into(),
+        ));
+    }
+
+    let update = available_update(&app).await?;
+    let result = UpdateCheckResult {
+        version: update.as_ref().map(|u| u.version.clone()),
+        notes: update.as_ref().and_then(|u| u.body.clone()),
+    };
+    remember_available_update(&app, update).await;
+    Ok(result)
+}
+
+/// The version found by the last check, without another network request. Lets
+/// the UI label its update control as soon as it opens.
+#[tauri::command]
+pub async fn discovered_update(
+    state: State<'_, std::sync::Arc<AppState>>,
+) -> Result<Option<String>, AppError> {
+    Ok(state
+        .update_available
+        .lock()
+        .await
+        .as_ref()
+        .map(|update| update.version.clone()))
+}
+
+/// Whether this installation can safely replace itself.
+#[tauri::command]
+pub async fn update_install_mode() -> Result<UpdateInstallMode, AppError> {
+    current_install_mode_off_main().await
+}
+
+/// Open the distribution-owned update page for installations that must stay
+/// under their system package manager. The URL is resolved here rather than
+/// accepted from the webview.
+#[tauri::command]
+pub async fn open_manual_update(app: AppHandle) -> Result<(), AppError> {
+    if !current_install_mode_off_main().await?.is_manual() {
+        return Err(AppError::Validation(
+            "This installation supports built-in updates.".into(),
+        ));
+    }
+    let url = current_manual_url().unwrap_or(RELEASES_URL);
+    app.opener()
+        .open_url(url, None::<&str>)
+        .map_err(|e| AppError::Other(format!("could not open {url}: {e}")))
+}
+
+async fn remembered_or_latest_update(app: &AppHandle) -> Result<Option<Update>, AppError> {
+    let remembered = app
+        .state::<std::sync::Arc<AppState>>()
+        .update_available
+        .lock()
+        .await
+        .clone();
+    match remembered {
+        Some(update) => Ok(Some(update)),
+        None => available_update_unlocked(app).await,
+    }
+}
+
+/// Download and install the discovered update. The caller is responsible for
+/// having obtained explicit confirmation first.
+#[cfg(not(target_os = "macos"))]
+async fn run_update_install(app: &AppHandle) -> Result<bool, AppError> {
+    let state = app.state::<std::sync::Arc<AppState>>();
+    // Hold discovery out for the whole download/install. The atomic guard has
+    // already rejected any second install, so nothing waits here for long.
+    let _operation_guard = state.update_checking.lock().await;
+    match remembered_or_latest_update(app).await? {
+        Some(update) => {
+            update
+                .download_and_install(|_, _| {}, || {})
+                .await
+                .map_err(|e| AppError::Other(format!("update install failed: {e}")))?;
+            app.restart();
+        }
+        None => Ok(false),
+    }
+}
+
+/// Download the verified `.dmg` and install it. See `engine::macos_dmg_update`
+/// for why macOS does not use Tauri's stock installer.
+#[cfg(target_os = "macos")]
+async fn run_update_install(app: &AppHandle) -> Result<bool, AppError> {
+    use crate::engine::macos_dmg_update;
+
+    let state = app.state::<std::sync::Arc<AppState>>();
+    let _operation_guard = state.update_checking.lock().await;
+    match remembered_or_latest_update(app).await? {
+        Some(update) => {
+            let bytes = update
+                .download(|_, _| {}, || {})
+                .await
+                .map_err(|e| AppError::Other(format!("update download failed: {e}")))?;
+            let installed_app = tauri::async_runtime::spawn_blocking(move || {
+                let installed = macos_dmg_update::install_dmg(&bytes)?;
+                macos_dmg_update::schedule_relaunch(&installed)?;
+                Ok::<_, String>(installed)
+            })
+            .await
+            .map_err(|e| AppError::Other(format!("update install worker failed: {e}")))?
+            .map_err(AppError::Other)?;
+            log::info!("installed update into {}", installed_app.display());
+            // `app.restart()` resolves the running executable after its bundle
+            // has been moved aside, so it would exit without reopening. The
+            // detached helper scheduled above waits for this process to
+            // disappear and then reopens the new bundle.
+            app.exit(0);
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Install the discovered update and restart. Returns `false` if there was
+/// nothing to install after all.
+#[tauri::command]
+pub async fn install_update(
+    app: AppHandle,
+    state: State<'_, std::sync::Arc<AppState>>,
+) -> Result<bool, AppError> {
+    if let Some(instructions) = current_install_mode_off_main().await?.instructions {
+        return Err(AppError::Validation(instructions));
+    }
+    let _guard = UpdateInstallGuard::acquire(&state.update_installing)?;
+    let result = run_update_install(&app).await;
+    if let Err(error) = &result {
+        log::warn!("update install failed: {error}");
+    }
+    result
+}
+
+async fn run_automatic_update_check(app: &AppHandle) {
+    let state = app.state::<std::sync::Arc<AppState>>();
+    if state.update_installing.load(Ordering::Acquire) {
+        return;
+    }
+
+    match available_update(app).await {
+        Ok(Some(update)) => {
+            // The preference may have been switched off, or an install may have
+            // started, while the request was in flight. Honour both before
+            // showing anything.
+            if state.update_installing.load(Ordering::Acquire)
+                || !state.settings.lock().await.automatic_update_checks
+            {
+                return;
+            }
+            let version = update.version.clone();
+            if remember_available_update(app, Some(update)).await {
+                // Surface it in the running window immediately; the frontend
+                // otherwise only learns about updates when the user checks.
+                if let Err(error) = app.emit(UPDATE_AVAILABLE_EVENT, version.clone()) {
+                    log::warn!("failed to emit {UPDATE_AVAILABLE_EVENT}: {error}");
+                }
+                let body = match current_install_mode_off_main().await {
+                    Ok(mode) if mode.is_manual() => format!(
+                        "IPTV Checker {version} is available. Open Settings for \
+                         package-manager instructions."
+                    ),
+                    Ok(_) => format!(
+                        "IPTV Checker {version} is available. Open Settings to review and \
+                         install it."
+                    ),
+                    Err(error) => {
+                        log::warn!("failed to detect the update install mode: {error}");
+                        format!("IPTV Checker {version} is available.")
+                    }
+                };
+                if let Err(error) = app
+                    .notification()
+                    .builder()
+                    .title("IPTV Checker update available")
+                    .body(body)
+                    .show()
+                {
+                    log::warn!("failed to surface available update: {error}");
+                }
+            }
+        }
+        Ok(None) => {
+            remember_available_update(app, None).await;
+        }
+        Err(error) => {
+            // Discovery is best-effort and must never interrupt a scan or
+            // startup. Manual checks still return their errors to the UI.
+            log::warn!("automatic update check failed: {error}");
+        }
+    }
+}
+
+/// Check once at startup, then every six hours while the preference is on.
+/// Enabling the preference wakes the loop instead of waiting for the next tick.
+pub fn spawn_automatic_update_checks(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let state = app.state::<std::sync::Arc<AppState>>();
+            let enabled = state.settings.lock().await.automatic_update_checks;
+            if enabled {
+                run_automatic_update_check(&app).await;
+            }
+
+            let _ = tokio::time::timeout(
+                AUTOMATIC_UPDATE_INTERVAL,
+                state.update_check_wake.notified(),
+            )
+            .await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appimage_installs_update_themselves() {
+        assert_eq!(
+            linux_install_source(false, true),
+            InstallSource::SelfUpdatable
+        );
+    }
+
+    #[test]
+    fn pacman_owned_installs_defer_to_the_aur() {
+        assert_eq!(linux_install_source(true, false), InstallSource::Aur);
+        // An AUR helper that runs the AppImage would still be pacman-owned.
+        assert_eq!(linux_install_source(true, true), InstallSource::Aur);
+    }
+
+    #[test]
+    fn deb_and_rpm_installs_are_manual() {
+        // Tauri's Linux updater only replaces AppImages, so a non-AppImage,
+        // non-pacman install must never offer the built-in path.
+        let source = linux_install_source(false, false);
+        assert_eq!(source, InstallSource::SystemPackage);
+        assert!(UpdateInstallMode::from_source(source, false, false).is_manual());
+        assert_eq!(source.manual_url(), Some(RELEASES_URL));
+    }
+
+    #[test]
+    fn aur_instructions_name_the_available_helper() {
+        let paru = UpdateInstallMode::from_source(InstallSource::Aur, true, true);
+        assert_eq!(
+            paru.instructions.as_deref(),
+            Some("Run paru -S iptv-checker-gui to update.")
+        );
+        let yay = UpdateInstallMode::from_source(InstallSource::Aur, false, true);
+        assert_eq!(
+            yay.instructions.as_deref(),
+            Some("Run yay -S iptv-checker-gui to update.")
+        );
+        let neither = UpdateInstallMode::from_source(InstallSource::Aur, false, false);
+        assert_eq!(
+            neither.instructions.as_deref(),
+            Some("Update the iptv-checker-gui package with your AUR helper.")
+        );
+    }
+
+    #[test]
+    fn built_in_mode_carries_no_manual_copy() {
+        let mode = UpdateInstallMode::from_source(InstallSource::SelfUpdatable, true, true);
+        assert!(!mode.is_manual());
+        assert!(mode.button_label.is_none());
+        assert!(mode.instructions.is_none());
+        assert!(InstallSource::SelfUpdatable.manual_url().is_none());
+    }
+
+    #[test]
+    fn only_a_changed_version_is_surfaced_again() {
+        assert!(should_surface_update(None, Some("1.7.0")));
+        assert!(should_surface_update(Some("1.6.0"), Some("1.7.0")));
+        assert!(!should_surface_update(Some("1.7.0"), Some("1.7.0")));
+        // Going back to "up to date" must not raise a notification.
+        assert!(!should_surface_update(Some("1.7.0"), None));
+        assert!(!should_surface_update(None, None));
+    }
+
+    #[test]
+    fn install_guard_rejects_a_concurrent_install() {
+        let flag = AtomicBool::new(false);
+        let first = UpdateInstallGuard::acquire(&flag).expect("first install should start");
+        assert!(UpdateInstallGuard::acquire(&flag).is_err());
+        drop(first);
+        assert!(UpdateInstallGuard::acquire(&flag).is_ok());
+    }
+}

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -45,6 +45,11 @@ enum InstallSource {
     /// updates a *separate* installed copy and leaves the portable executable
     /// the user launched untouched — so it must not be offered.
     WindowsPortable,
+    /// A macOS bundle running from a read-only volume: straight from the
+    /// mounted `.dmg`, or from an App Translocation path. The bundle cannot be
+    /// replaced in place, and elevating to admin cannot make the mount
+    /// writable, so the install would always fail.
+    MacosReadOnly,
 }
 
 impl InstallSource {
@@ -55,7 +60,7 @@ impl InstallSource {
             Self::Aur => Some(AUR_PACKAGE_URL),
             #[cfg(not(target_os = "linux"))]
             Self::Aur => Some(RELEASES_URL),
-            Self::SystemPackage | Self::WindowsPortable => Some(RELEASES_URL),
+            Self::SystemPackage | Self::WindowsPortable | Self::MacosReadOnly => Some(RELEASES_URL),
         }
     }
 }
@@ -106,6 +111,15 @@ impl UpdateInstallMode {
                 instructions: Some(
                     "This copy was installed from a system package. Download the new \
                      .deb/.rpm and install it with your package manager."
+                        .into(),
+                ),
+            },
+            InstallSource::MacosReadOnly => Self {
+                kind: UpdateInstallKind::Manual,
+                button_label: Some("Open the releases page".into()),
+                instructions: Some(
+                    "IPTV Checker is running from a read-only volume. Drag it to your \
+                     Applications folder and reopen it to enable in-app updates."
                         .into(),
                 ),
             },
@@ -189,6 +203,34 @@ fn uninstaller_beside_current_exe() -> bool {
         .is_some_and(|marker| marker.is_file())
 }
 
+/// True when the running `.app` sits on a read-only mount. Distinguishes the
+/// DMG/translocation case from an ordinary permission problem on
+/// `/Applications`, which the privileged copy path does handle.
+#[cfg(any(target_os = "macos", test))]
+fn macos_install_source(on_read_only_volume: bool) -> InstallSource {
+    if on_read_only_volume {
+        InstallSource::MacosReadOnly
+    } else {
+        InstallSource::SelfUpdatable
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn current_bundle_on_read_only_volume() -> bool {
+    let Ok(bundle) = crate::engine::macos_dmg_update::current_app_bundle() else {
+        // Not running from a bundle at all (e.g. `cargo run`); nothing to guard.
+        return false;
+    };
+    let Ok(path) = std::ffi::CString::new(bundle.as_os_str().as_encoded_bytes()) else {
+        return false;
+    };
+    let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut stat) } != 0 {
+        return false;
+    }
+    stat.f_flags & libc::MNT_RDONLY as u32 != 0
+}
+
 fn current_install_source() -> InstallSource {
     #[cfg(target_os = "linux")]
     {
@@ -203,7 +245,12 @@ fn current_install_source() -> InstallSource {
         windows_install_source(uninstaller_beside_current_exe())
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(target_os = "macos")]
+    {
+        macos_install_source(current_bundle_on_read_only_volume())
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
         InstallSource::SelfUpdatable
     }
@@ -231,28 +278,28 @@ fn current_install_mode() -> UpdateInstallMode {
 /// Detection shells out to pacman on Linux and stats the install directory on
 /// Windows, so keep it off the async runtime thread on both.
 async fn current_install_source_off_main() -> Result<InstallSource, AppError> {
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     {
         tauri::async_runtime::spawn_blocking(current_install_source)
             .await
             .map_err(|error| AppError::Other(format!("install source worker failed: {error}")))
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
         Ok(current_install_source())
     }
 }
 
 async fn current_install_mode_off_main() -> Result<UpdateInstallMode, AppError> {
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     {
         tauri::async_runtime::spawn_blocking(current_install_mode)
             .await
             .map_err(|error| AppError::Other(format!("update install mode worker failed: {error}")))
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
         Ok(current_install_mode())
     }
@@ -567,6 +614,19 @@ mod tests {
         let mode = UpdateInstallMode::from_source(portable, false, false);
         assert!(mode.is_manual());
         assert_eq!(portable.manual_url(), Some(RELEASES_URL));
+    }
+
+    #[test]
+    fn macos_bundles_on_read_only_volumes_are_manual() {
+        // Running from the mounted .dmg or a translocated path: elevating to
+        // admin cannot make the mount writable, so the install would fail.
+        let mounted = macos_install_source(true);
+        assert_eq!(mounted, InstallSource::MacosReadOnly);
+        assert!(UpdateInstallMode::from_source(mounted, false, false).is_manual());
+        assert_eq!(mounted.manual_url(), Some(RELEASES_URL));
+
+        // A normal /Applications install is writable-or-elevatable.
+        assert_eq!(macos_install_source(false), InstallSource::SelfUpdatable);
     }
 
     #[test]

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -39,7 +39,9 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use crate::engine::ffmpeg::{configure_background_process, graceful_kill, resolve_binary, GRACEFUL_KILL_TIMEOUT};
+use crate::engine::ffmpeg::{
+    configure_background_process, graceful_kill, resolve_binary, GRACEFUL_KILL_TIMEOUT,
+};
 use crate::engine::proxy_common::{read_capped, ReadCappedError};
 use crate::engine::stream_proxy::redact_url;
 use crate::error::AppError;
@@ -164,9 +166,7 @@ pub async fn start(
     let lan_ip = detect_lan_ip()
         .ok_or_else(|| AppError::Other("Could not determine LAN IP for cast proxy".to_string()))?;
 
-    let listener = TcpListener::bind("0.0.0.0:0")
-        .await
-        .map_err(AppError::Io)?;
+    let listener = TcpListener::bind("0.0.0.0:0").await.map_err(AppError::Io)?;
     let port = listener.local_addr().map_err(AppError::Io)?.port();
 
     let cancel = CancellationToken::new();
@@ -564,8 +564,13 @@ async fn start_remux(
     // Wait for the manifest to actually be written so the Cast device's first
     // GET doesn't 404. On failure, trip the cancel so the spawned ffmpeg
     // worker terminates and removes the temp dir.
-    if let Err(err) =
-        wait_for_manifest(&manifest_path, is_hevc, REMUX_PLAYLIST_READY_TIMEOUT, &cancel).await
+    if let Err(err) = wait_for_manifest(
+        &manifest_path,
+        is_hevc,
+        REMUX_PLAYLIST_READY_TIMEOUT,
+        &cancel,
+    )
+    .await
     {
         cancel.cancel();
         return Err(err);
@@ -673,10 +678,7 @@ fn spawn_upstream_pump(
             } else {
                 format!("reconnect #{reconnects}")
             };
-            log::info!(
-                "[CastProxy/pump] {label} for {}",
-                redact_url(&upstream_url)
-            );
+            log::info!("[CastProxy/pump] {label} for {}", redact_url(&upstream_url));
 
             let response_result = tokio::select! {
                 _ = cancel.cancelled() => break 'session,
@@ -854,7 +856,11 @@ async fn probe_codecs(
                 .next()
                 .unwrap_or("")
                 .to_ascii_lowercase();
-            if codec.is_empty() { None } else { Some(codec) }
+            if codec.is_empty() {
+                None
+            } else {
+                Some(codec)
+            }
         }
     };
 
@@ -945,14 +951,8 @@ async fn handle_connection(
             let _ = write_simple(&mut socket, 503, "text/plain", b"Remux not ready").await;
             return Ok(());
         };
-        return serve_remux_file(
-            &mut socket,
-            &tmpdir,
-            rest,
-            &method,
-            range_header.as_deref(),
-        )
-        .await;
+        return serve_remux_file(&mut socket, &tmpdir, rest, &method, range_header.as_deref())
+            .await;
     }
 
     // Pass-through mode: entrypoint or rewritten manifest segment.
@@ -1540,14 +1540,16 @@ fn decode_segment(encoded: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::io::AsyncReadExt;
     use super::*;
+    use tokio::io::AsyncReadExt;
 
     #[test]
     fn token_is_url_safe_and_long() {
         let token = generate_token();
         assert!(token.len() >= 40, "token too short: {token}");
-        assert!(token.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 
     #[test]
@@ -1567,7 +1569,10 @@ seg-2.ts
             "/cast/abc/seg/{}",
             encode_segment("http://iptv.example.com/live/720p/seg-1.ts")
         );
-        assert!(rewritten.contains(&expected), "missing rewritten seg-1: {rewritten}");
+        assert!(
+            rewritten.contains(&expected),
+            "missing rewritten seg-1: {rewritten}"
+        );
     }
 
     #[test]
@@ -1649,11 +1654,7 @@ http://iptv.example.com/live/720p/seg-2.ts
     /// Mirrors the segment-fetch acceptance logic in `handle_connection`. We
     /// keep it as a test-local helper so the pairwise check is exercised
     /// without spinning up sockets.
-    fn segment_accepted(
-        resolved: Option<&Url>,
-        upstream: Option<&Url>,
-        decoded: &Url,
-    ) -> bool {
+    fn segment_accepted(resolved: Option<&Url>, upstream: Option<&Url>, decoded: &Url) -> bool {
         match (resolved, upstream) {
             (Some(r), Some(u)) => is_target_allowed(r, decoded) || is_target_allowed(u, decoded),
             (Some(r), None) => is_target_allowed(r, decoded),
@@ -1679,17 +1680,29 @@ http://iptv.example.com/live/720p/seg-2.ts
         // With resolved_origin populated by the manifest fetch, the CDN
         // segment is accepted — this is the regression the redirect-aware
         // allowlist exists to fix.
-        assert!(segment_accepted(Some(&resolved), Some(&upstream), &cdn_segment));
+        assert!(segment_accepted(
+            Some(&resolved),
+            Some(&upstream),
+            &cdn_segment
+        ));
 
         // A segment on the operator host (still legitimate during transition)
         // is accepted as long as either origin matches.
         let provider_segment = Url::parse("http://provider.example/seg-2.ts").unwrap();
-        assert!(segment_accepted(Some(&resolved), Some(&upstream), &provider_segment));
+        assert!(segment_accepted(
+            Some(&resolved),
+            Some(&upstream),
+            &provider_segment
+        ));
 
         // A loopback or unrelated host is still rejected even with both
         // origins populated.
         let loopback = Url::parse("http://127.0.0.1:9000/x.ts").unwrap();
-        assert!(!segment_accepted(Some(&resolved), Some(&upstream), &loopback));
+        assert!(!segment_accepted(
+            Some(&resolved),
+            Some(&upstream),
+            &loopback
+        ));
     }
 
     #[test]
@@ -1698,7 +1711,10 @@ http://iptv.example.com/live/720p/seg-2.ts
             redact_cast_path("/cast/abc123token/hls/playlist.m3u8"),
             "/cast/<redacted>/hls/playlist.m3u8"
         );
-        assert_eq!(redact_cast_path("/cast/tok/stream"), "/cast/<redacted>/stream");
+        assert_eq!(
+            redact_cast_path("/cast/tok/stream"),
+            "/cast/<redacted>/stream"
+        );
     }
 
     #[test]
@@ -1866,7 +1882,9 @@ seg-1.ts
         let body = b"#EXTM3U\n#EXT-X-TARGETDURATION:6\n".to_vec();
         let url = spawn_chunked_server(body.clone()).await;
         let resp = reqwest::get(&url).await.unwrap();
-        let bytes = read_capped(resp, 2 * 1024 * 1024).await.expect("within cap");
+        let bytes = read_capped(resp, 2 * 1024 * 1024)
+            .await
+            .expect("within cap");
         assert_eq!(bytes, body);
     }
 

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -329,7 +329,7 @@ fn detect_hls_drm_system(playlist_body: &str) -> Option<String> {
         if let Some(method_start) = trimmed.find("method=") {
             let after_method = &trimmed[method_start + 7..];
             let method_value = after_method
-                .split(|c: char| c == ',' || c == '"')
+                .split([',', '"'])
                 .find(|s| !s.is_empty())
                 .unwrap_or("");
             // AES-128 and NONE are not DRM

--- a/src-tauri/src/engine/chromecast.rs
+++ b/src-tauri/src/engine/chromecast.rs
@@ -240,10 +240,7 @@ pub async fn start_session(
         .await
         .map_err(|_| AppError::Other("Cast worker exited before ready".to_string()))??;
 
-    log::info!(
-        "[Chromecast] Session ready on '{}'",
-        device.friendly_name
-    );
+    log::info!("[Chromecast] Session ready on '{}'", device.friendly_name);
 
     let session = CastSession {
         device_id: device.id.clone(),

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -552,10 +552,9 @@ pub fn sanitize_screenshot_stem(raw: &str) -> String {
 
     for ch in raw.chars() {
         let normalized = if ch.is_control()
+            || ch.is_whitespace()
             || matches!(ch, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
         {
-            '-'
-        } else if ch.is_whitespace() {
             '-'
         } else {
             ch
@@ -1464,12 +1463,6 @@ pub async fn capture_screenshot(
     }
 }
 
-/// Profile approximate video bitrate by sampling the stream for 10 seconds.
-///
-/// This spawns ffmpeg directly instead of using `run_tool_command` because:
-/// - ffmpeg with `-t 10` on live streams normally exits non-zero (the stream is
-///   still sending when the time limit is hit), which `run_tool_command` treats as error.
-/// - We only need the "Statistics:" line from stderr, regardless of exit code.
 /// Spawn a task that drains a child's stderr (so the child can't block on a
 /// full pipe) while retaining only the final 1 MB — the Statistics/error
 /// lines we parse are written near process exit.
@@ -1503,6 +1496,13 @@ fn spawn_stderr_tail_reader(
     })
 }
 
+/// Profile approximate video bitrate by sampling the stream for 10 seconds.
+///
+/// This spawns ffmpeg directly instead of using `run_tool_command` because:
+/// - ffmpeg with `-t 10` on live streams normally exits non-zero (the stream is
+///   still sending when the time limit is hit), which `run_tool_command` treats
+///   as an error.
+/// - We only need the "Statistics:" line from stderr, regardless of exit code.
 pub async fn profile_bitrate(
     app: &AppHandle,
     url: &str,
@@ -1627,6 +1627,17 @@ pub struct CombinedDiagnostics {
 
 /// Parse stream metadata from ffmpeg verbose stderr output.
 ///
+/// The best video stream seen so far while scanning ffmpeg's stderr:
+/// `(codec, width, height, fps, pixels, hdr_format)`. Ranked by `pixels`.
+type BestVideoCandidate = (
+    String,
+    Option<u32>,
+    Option<u32>,
+    Option<u32>,
+    u64,
+    Option<String>,
+);
+
 /// Extracts codec, resolution, fps, audio info, and format bitrate from
 /// `Stream #` and `Duration:` lines that ffmpeg prints with `-v verbose`.
 fn parse_ffmpeg_stderr(
@@ -1638,14 +1649,7 @@ fn parse_ffmpeg_stderr(
     Option<u32>,
 ) {
     let mut presence = StreamTrackPresence::default();
-    let mut best_video: Option<(
-        String,
-        Option<u32>,
-        Option<u32>,
-        Option<u32>,
-        u64,
-        Option<String>,
-    )> = None; // (codec, w, h, fps, pixels, hdr)
+    let mut best_video: Option<BestVideoCandidate> = None;
     let mut audio_info: Option<AudioInfo> = None;
     let mut format_bitrate_kbps: Option<u32> = None;
 
@@ -2270,7 +2274,7 @@ mod tests {
 
         assert!(args.windows(2).any(|pair| pair == ["-update", "1"]));
         assert!(args.windows(2).any(|pair| pair == ["-pix_fmt", "rgb24"]));
-        assert!(!args.iter().any(|arg| *arg == "libwebp"));
+        assert!(!args.contains(&"libwebp"));
         assert_eq!(args.last(), Some(&"/tmp/frame.png"));
     }
 
@@ -2511,7 +2515,7 @@ mod tests {
     #[test]
     fn label_mismatch_hd_word_boundary() {
         // "HD" as standalone word should trigger mismatch
-        assert!(!check_label_mismatch("Sports HD", "1080p").is_empty() == false);
+        assert!(check_label_mismatch("Sports HD", "1080p").is_empty());
         assert!(check_label_mismatch("Sports HD", "480p").len() == 1);
 
         // "hd" as part of a name should NOT trigger mismatch

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -2514,7 +2514,8 @@ mod tests {
 
     #[test]
     fn label_mismatch_hd_word_boundary() {
-        // "HD" as standalone word should trigger mismatch
+        // "HD" as a standalone word is checked against the resolution: 1080p
+        // matches the label, 480p contradicts it.
         assert!(check_label_mismatch("Sports HD", "1080p").is_empty());
         assert!(check_label_mismatch("Sports HD", "480p").len() == 1);
 

--- a/src-tauri/src/engine/macos_dmg_update.rs
+++ b/src-tauri/src/engine/macos_dmg_update.rs
@@ -43,7 +43,10 @@ pub fn install_dmg(bytes: &[u8]) -> Result<PathBuf, String> {
     ));
 
     let result = (|| {
-        fs::create_dir_all(&work_dir).map_err(|e| e.to_string())?;
+        // create_dir, not create_dir_all: an existing directory or symlink at
+        // this path must not be silently reused, since whatever .app is found
+        // under it gets copied over the installed bundle, possibly as admin.
+        fs::create_dir(&work_dir).map_err(|e| e.to_string())?;
         let dmg_path = work_dir.join("IPTV-Checker-update.dmg");
         fs::write(&dmg_path, bytes).map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/engine/macos_dmg_update.rs
+++ b/src-tauri/src/engine/macos_dmg_update.rs
@@ -147,7 +147,15 @@ fn replace_app_bundle(
                 return Err(err);
             }
         }
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+        // PermissionDenied: the destination needs an admin copy. CrossesDevices:
+        // the app lives on a different volume from the scratch dir, so it cannot
+        // be renamed aside at all. Both fall back to the copy-based install.
+        Err(err)
+            if matches!(
+                err.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::CrossesDevices
+            ) =>
+        {
             install_with_admin_privileges(source_app, destination_app)?;
         }
         Err(err) => return Err(err.to_string()),

--- a/src-tauri/src/engine/macos_dmg_update.rs
+++ b/src-tauri/src/engine/macos_dmg_update.rs
@@ -1,0 +1,227 @@
+//! macOS in-place update from a verified `.dmg`.
+//!
+//! Tauri's stock macOS updater expects an `.app.tar.gz` payload. IPTV Checker
+//! publishes only the user-facing `.dmg` (which is the artifact that gets
+//! notarized and stapled), so the release workflow points `latest.json` at the
+//! `.dmg` and this module performs the install: mount, copy the bundle over the
+//! running one, then relaunch. Tauri still does the download and minisign
+//! verification, so the bytes handed to `install_dmg` are already trusted.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const APP_BUNDLE_NAME: &str = "IPTV Checker.app";
+
+/// Unmounts on drop so an early return can't leave the DMG attached.
+struct MountedDmg {
+    mountpoint: PathBuf,
+}
+
+impl Drop for MountedDmg {
+    fn drop(&mut self) {
+        let _ = Command::new("hdiutil")
+            .arg("detach")
+            .arg(&self.mountpoint)
+            .arg("-quiet")
+            .status();
+    }
+}
+
+/// Writes the verified DMG to a scratch directory, mounts it, and replaces the
+/// running `.app` with the one inside. Returns the path that was replaced.
+pub fn install_dmg(bytes: &[u8]) -> Result<PathBuf, String> {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_millis();
+    let work_dir =
+        std::env::temp_dir().join(format!("iptv-checker-update-{}-{nonce}", std::process::id()));
+
+    let result = (|| {
+        fs::create_dir_all(&work_dir).map_err(|e| e.to_string())?;
+        let dmg_path = work_dir.join("IPTV-Checker-update.dmg");
+        fs::write(&dmg_path, bytes).map_err(|e| e.to_string())?;
+
+        let mountpoint = work_dir.join("mount");
+        fs::create_dir(&mountpoint).map_err(|e| e.to_string())?;
+        let mut attach = Command::new("hdiutil");
+        attach
+            .arg("attach")
+            .arg("-nobrowse")
+            .arg("-readonly")
+            .arg("-mountpoint")
+            .arg(&mountpoint)
+            .arg(&dmg_path);
+        run_command(&mut attach)?;
+        let _mounted = MountedDmg {
+            mountpoint: mountpoint.clone(),
+        };
+
+        let source_app = find_app_bundle(&mountpoint)?;
+        let destination_app = current_app_bundle()?;
+        replace_app_bundle(&source_app, &destination_app, &work_dir)?;
+        Ok(destination_app)
+    })();
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+    result
+}
+
+// Waits for the old process to exit before reopening, so LaunchServices doesn't
+// find the bundle mid-replacement.
+const RELAUNCH_SCRIPT: &str =
+    "while kill -0 \"$1\" 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n \"$2\"";
+
+fn relaunch_command(pid: u32, installed_app: &Path) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg(RELAUNCH_SCRIPT)
+        .arg("iptv-checker-update-relaunch")
+        .arg(pid.to_string())
+        .arg(installed_app);
+    command
+}
+
+/// Spawns the detached helper that reopens the app once this process exits.
+/// Call this *before* exiting: `AppHandle::restart` resolves the running
+/// executable after its bundle has been moved aside, so it would quit without
+/// reopening.
+pub fn schedule_relaunch(installed_app: &Path) -> Result<(), String> {
+    relaunch_command(std::process::id(), installed_app)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("Could not schedule IPTV Checker to reopen after the update: {error}"))
+}
+
+/// The `.app` bundle this process is running from.
+pub fn current_app_bundle() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    for ancestor in exe.ancestors() {
+        if ancestor.extension().is_some_and(|ext| ext == "app") {
+            return Ok(ancestor.to_path_buf());
+        }
+    }
+    Err("Could not locate the running .app bundle.".into())
+}
+
+fn find_app_bundle(mountpoint: &Path) -> Result<PathBuf, String> {
+    let mut fallback = None;
+    for entry in std::fs::read_dir(mountpoint).map_err(|e| e.to_string())? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.extension().is_some_and(|ext| ext == "app") {
+            if path.file_name().is_some_and(|name| name == APP_BUNDLE_NAME) {
+                return Ok(path);
+            }
+            fallback = Some(path);
+        }
+    }
+    fallback.ok_or_else(|| "The update DMG did not contain an app bundle.".into())
+}
+
+fn replace_app_bundle(
+    source_app: &Path,
+    destination_app: &Path,
+    work_dir: &Path,
+) -> Result<(), String> {
+    let backup_dir = work_dir.join("backup");
+    std::fs::create_dir(&backup_dir).map_err(|e| e.to_string())?;
+    let backup_app = backup_dir.join(APP_BUNDLE_NAME);
+
+    match std::fs::rename(destination_app, &backup_app) {
+        Ok(()) => {
+            if let Err(err) = ditto(source_app, destination_app) {
+                let _ = std::fs::remove_dir_all(destination_app);
+                let _ = std::fs::rename(&backup_app, destination_app);
+                return Err(err);
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            install_with_admin_privileges(source_app, destination_app)?;
+        }
+        Err(err) => return Err(err.to_string()),
+    }
+
+    // Refresh the bundle's mtime so LaunchServices re-reads its Info.plist.
+    let _ = Command::new("touch").arg(destination_app).status();
+    Ok(())
+}
+
+fn ditto(source: &Path, destination: &Path) -> Result<(), String> {
+    let mut command = Command::new("ditto");
+    command.arg(source).arg(destination);
+    run_command(&mut command)
+}
+
+fn install_with_admin_privileges(source_app: &Path, destination_app: &Path) -> Result<(), String> {
+    // Back up the current bundle to a sibling path (same volume, so the move is
+    // atomic) before overwriting, and restore it if `ditto` fails — otherwise a
+    // failed privileged copy (disk full, interrupted read) would leave the user
+    // with no app at all. This mirrors the rename/rollback the non-privileged
+    // branch does, and the whole sequence runs inside one privileged shell so
+    // the rollback is itself privileged.
+    let script = format!(
+        concat!(
+            "do shell script \"",
+            "rm -rf \" & quoted form of {backup} & \" ; ",
+            "mv \" & quoted form of {destination} & \" \" & quoted form of {backup} & \" || exit 1 ; ",
+            "if ditto \" & quoted form of {source} & \" \" & quoted form of {destination} & \" ; ",
+            "then rm -rf \" & quoted form of {backup} & \" ; ",
+            "else rm -rf \" & quoted form of {destination} & \" ; ",
+            "mv \" & quoted form of {backup} & \" \" & quoted form of {destination} & \" ; exit 1 ; fi",
+            "\" with administrator privileges"
+        ),
+        source = applescript_string(&source_app.display().to_string()),
+        destination = applescript_string(&destination_app.display().to_string()),
+        backup = applescript_string(&format!("{}.iptv-checker-backup", destination_app.display())),
+    );
+    let mut command = Command::new("osascript");
+    command.arg("-e").arg(script);
+    run_command(&mut command)
+}
+
+fn applescript_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn run_command(command: &mut Command) -> Result<(), String> {
+    let program = command.get_program().to_string_lossy().into_owned();
+    let output = command.output().map_err(|e| e.to_string())?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let details = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    Err(format!("{program} failed: {details}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applescript_string_escapes_quotes_and_backslashes() {
+        assert_eq!(applescript_string(r#"/a "b"\c"#), r#""/a \"b\"\\c""#);
+    }
+
+    #[test]
+    fn relaunch_command_waits_for_the_old_pid_then_opens_the_bundle() {
+        let command = relaunch_command(4321, Path::new("/Applications/IPTV Checker.app"));
+        let args: Vec<_> = command.get_args().map(|a| a.to_string_lossy()).collect();
+        assert_eq!(args[0], "-c");
+        assert_eq!(args[1], RELAUNCH_SCRIPT);
+        assert_eq!(args[3], "4321");
+        assert_eq!(args[4], "/Applications/IPTV Checker.app");
+    }
+}

--- a/src-tauri/src/engine/macos_dmg_update.rs
+++ b/src-tauri/src/engine/macos_dmg_update.rs
@@ -37,8 +37,10 @@ pub fn install_dmg(bytes: &[u8]) -> Result<PathBuf, String> {
         .duration_since(UNIX_EPOCH)
         .map_err(|e| e.to_string())?
         .as_millis();
-    let work_dir =
-        std::env::temp_dir().join(format!("iptv-checker-update-{}-{nonce}", std::process::id()));
+    let work_dir = std::env::temp_dir().join(format!(
+        "iptv-checker-update-{}-{nonce}",
+        std::process::id()
+    ));
 
     let result = (|| {
         fs::create_dir_all(&work_dir).map_err(|e| e.to_string())?;
@@ -97,7 +99,9 @@ pub fn schedule_relaunch(installed_app: &Path) -> Result<(), String> {
         .stderr(Stdio::null())
         .spawn()
         .map(|_| ())
-        .map_err(|error| format!("Could not schedule IPTV Checker to reopen after the update: {error}"))
+        .map_err(|error| {
+            format!("Could not schedule IPTV Checker to reopen after the update: {error}")
+        })
 }
 
 /// The `.app` bundle this process is running from.

--- a/src-tauri/src/engine/macos_dmg_update.rs
+++ b/src-tauri/src/engine/macos_dmg_update.rs
@@ -73,9 +73,10 @@ pub fn install_dmg(bytes: &[u8]) -> Result<PathBuf, String> {
 }
 
 // Waits for the old process to exit before reopening, so LaunchServices doesn't
-// find the bundle mid-replacement.
-const RELAUNCH_SCRIPT: &str =
-    "while kill -0 \"$1\" 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n \"$2\"";
+// find the bundle mid-replacement. The wait is capped at ~60s so a process that
+// hangs on quit leaves the new version openable instead of an immortal poller.
+const RELAUNCH_SCRIPT: &str = "i=0; while [ \"$i\" -lt 600 ] && kill -0 \"$1\" 2>/dev/null; \
+     do sleep 0.1; i=$((i+1)); done; exec /usr/bin/open -n \"$2\"";
 
 fn relaunch_command(pid: u32, installed_app: &Path) -> Command {
     let mut command = Command::new("/bin/sh");

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -4,6 +4,8 @@ pub mod chromecast;
 pub mod connectivity;
 pub mod disk;
 pub mod ffmpeg;
+#[cfg(target_os = "macos")]
+pub mod macos_dmg_update;
 pub mod parser;
 pub mod proxy;
 pub mod proxy_common;

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -7,6 +7,7 @@ pub mod ffmpeg;
 #[cfg(target_os = "macos")]
 pub mod macos_dmg_update;
 pub mod parser;
+pub mod playlist_score;
 pub mod proxy;
 pub mod proxy_common;
 pub mod remote_cache;

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -470,6 +470,10 @@ pub struct ParseProgress {
     pub series_found: usize,
 }
 
+/// An `#EXTINF` line awaiting its URL: `(raw line, parsed attributes, group)`.
+/// Attributes are parsed once here rather than again per channel.
+type PendingExtinf = (String, Vec<(String, String)>, String);
+
 fn parse_playlist_reader<R: BufRead>(
     reader: R,
     file_path: &str,
@@ -485,8 +489,7 @@ fn parse_playlist_reader<R: BufRead>(
     let mut movie_found = 0usize;
     let mut series_found = 0usize;
     let mut pending_channel = false;
-    // (extinf line, parsed attributes, group name) — parsed once per EXTINF.
-    let mut pending_extinf: Option<(String, Vec<(String, String)>, String)> = None;
+    let mut pending_extinf: Option<PendingExtinf> = None;
     let mut pending_metadata: Vec<String> = Vec::new();
     let mut orphaned_extinf = 0u32;
 

--- a/src-tauri/src/engine/playlist_score.rs
+++ b/src-tauri/src/engine/playlist_score.rs
@@ -1,0 +1,301 @@
+//! Playlist health scoring.
+//!
+//! Pure functions over finished scan results: no IO, no app state. Kept out of
+//! the scan orchestrator so the weightings can be read and tested on their own.
+//!
+//! The score has three components, combined as
+//! `0.25 * ping + 0.40 * content + 0.35 * quality`, each on a 0..10 scale.
+
+use std::collections::HashSet;
+
+use crate::models::channel::{ChannelResult, ChannelStatus};
+use crate::models::scan::PlaylistScore;
+
+fn clamp_01(value: f64) -> f64 {
+    value.clamp(0.0, 1.0)
+}
+
+fn clamp_score_10(value: f64) -> f64 {
+    value.clamp(0.0, 10.0)
+}
+
+fn round_to_tenth(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}
+
+fn median_u64(values: &[u64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        Some(sorted[mid] as f64)
+    } else {
+        Some((sorted[mid - 1] as f64 + sorted[mid] as f64) / 2.0)
+    }
+}
+
+fn is_hd_or_uhd(result: &ChannelResult) -> bool {
+    if let (Some(width), Some(height)) = (result.width, result.height) {
+        if width >= 1280 && height >= 720 {
+            return true;
+        }
+    }
+    if let Some(resolution) = result.resolution.as_ref() {
+        let normalized = resolution.to_ascii_lowercase();
+        return normalized.contains("720")
+            || normalized.contains("1080")
+            || normalized.contains("1440")
+            || normalized.contains("2160")
+            || normalized.contains("4k")
+            || normalized.contains("uhd");
+    }
+    false
+}
+
+fn codec_tier_score(codec: Option<&str>) -> f64 {
+    let Some(codec) = codec else {
+        return 0.4;
+    };
+    let normalized = codec.to_ascii_lowercase();
+    if normalized.contains("hevc") || normalized.contains("h265") || normalized.contains("h.265") {
+        return 1.0;
+    }
+    if normalized.contains("av1") {
+        return 1.0;
+    }
+    if normalized.contains("h264") || normalized.contains("h.264") || normalized.contains("avc") {
+        return 0.8;
+    }
+    if normalized.contains("mpeg") || normalized.contains("vp9") {
+        return 0.6;
+    }
+    0.5
+}
+
+pub fn compute_playlist_score(
+    results: &[ChannelResult],
+    total_channels: usize,
+) -> Option<PlaylistScore> {
+    if total_channels == 0 {
+        return None;
+    }
+
+    let alive_results = results
+        .iter()
+        .filter(|result| result.status == ChannelStatus::Alive)
+        .collect::<Vec<_>>();
+    let alive_count = alive_results.len();
+
+    let ping_score = {
+        let latencies = alive_results
+            .iter()
+            .filter_map(|result| result.latency_ms)
+            .collect::<Vec<_>>();
+        let p50 = median_u64(&latencies);
+        let raw = if let Some(p50) = p50 {
+            // 100ms ~= excellent (10), 1200ms ~= poor (0)
+            (1200.0 - p50) / 1100.0 * 10.0
+        } else {
+            0.0
+        };
+        clamp_score_10(raw)
+    };
+
+    let content_score = {
+        let alive_ratio = alive_count as f64 / total_channels as f64;
+        let unique_groups = results
+            .iter()
+            .map(|result| result.group.trim().to_ascii_lowercase())
+            .filter(|group| !group.is_empty())
+            .collect::<HashSet<_>>()
+            .len();
+        let diversity_ratio = clamp_01(unique_groups as f64 / 20.0);
+        let epg_covered = results
+            .iter()
+            .filter(|result| {
+                result
+                    .tvg_id
+                    .as_deref()
+                    .map(str::trim)
+                    .map(|value| !value.is_empty())
+                    .unwrap_or(false)
+            })
+            .count();
+        let epg_ratio = epg_covered as f64 / total_channels as f64;
+
+        clamp_score_10((alive_ratio * 0.6 + diversity_ratio * 0.2 + epg_ratio * 0.2) * 10.0)
+    };
+
+    let quality_score = {
+        if alive_results.is_empty() {
+            0.0
+        } else {
+            let hd_ratio = alive_results
+                .iter()
+                .filter(|result| is_hd_or_uhd(result))
+                .count() as f64
+                / alive_results.len() as f64;
+
+            let codec_avg = alive_results
+                .iter()
+                .map(|result| codec_tier_score(result.codec.as_deref()))
+                .sum::<f64>()
+                / alive_results.len() as f64;
+
+            let fps_known = alive_results
+                .iter()
+                .filter(|result| result.fps.is_some())
+                .count();
+            let fps_ratio = if fps_known == 0 {
+                0.0
+            } else {
+                alive_results
+                    .iter()
+                    .filter(|result| result.fps.unwrap_or_default() >= 25)
+                    .count() as f64
+                    / fps_known as f64
+            };
+
+            clamp_score_10((hd_ratio * 0.5 + codec_avg * 0.3 + fps_ratio * 0.2) * 10.0)
+        }
+    };
+
+    let overall_score =
+        clamp_score_10(ping_score * 0.25 + content_score * 0.40 + quality_score * 0.35);
+
+    Some(PlaylistScore {
+        overall: round_to_tenth(overall_score),
+        ping: round_to_tenth(ping_score),
+        content: round_to_tenth(content_score),
+        quality: round_to_tenth(quality_score),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::channel::ContentType;
+
+    /// Minimal alive/dead result; each test sets only the fields it scores on.
+    fn result(index: usize, status: ChannelStatus, group: &str) -> ChannelResult {
+        ChannelResult {
+            index,
+            playlist: "fixture.m3u8".to_string(),
+            name: format!("Channel {index}"),
+            group: group.to_string(),
+            language: None,
+            tvg_id: None,
+            tvg_name: None,
+            tvg_logo: None,
+            tvg_chno: None,
+            url: format!("http://example.com/{index}.m3u8"),
+            content_type: ContentType::Live,
+            status,
+            codec: None,
+            resolution: None,
+            width: None,
+            height: None,
+            fps: None,
+            latency_ms: None,
+            hdr_format: None,
+            video_bitrate: None,
+            audio_bitrate: None,
+            audio_codec: None,
+            audio_channel_layout: None,
+            audio_only: false,
+            screenshot_path: None,
+            screenshot_error_reason: None,
+            label_mismatches: Vec::new(),
+            low_framerate: false,
+            error_message: None,
+            channel_id: "id".to_string(),
+            extinf_line: "#EXTINF:-1,Test".to_string(),
+            metadata_lines: Vec::new(),
+            stream_url: None,
+            retry_count: None,
+            error_reason: None,
+            drm_system: None,
+        }
+    }
+
+    #[test]
+    fn returns_none_for_empty_scans() {
+        assert!(compute_playlist_score(&[], 0).is_none());
+    }
+
+    #[test]
+    fn builds_weighted_subscores() {
+        let mut first = result(0, ChannelStatus::Alive, "Sports");
+        first.latency_ms = Some(150);
+        first.tvg_id = Some("epg-a".to_string());
+        first.width = Some(1920);
+        first.height = Some(1080);
+        first.codec = Some("h264".to_string());
+        first.fps = Some(30);
+
+        let mut second = result(1, ChannelStatus::Alive, "Movies");
+        second.latency_ms = Some(300);
+        second.tvg_id = Some("epg-b".to_string());
+        second.width = Some(3840);
+        second.height = Some(2160);
+        second.codec = Some("hevc".to_string());
+        second.fps = Some(50);
+
+        let third = result(2, ChannelStatus::Dead, "Kids");
+
+        let score = compute_playlist_score(&[first, second, third], 3)
+            .expect("score should be present for non-empty scans");
+
+        // p50 latency of 150/300 is 225ms -> (1200-225)/1100*10.
+        assert_eq!(score.ping, round_to_tenth((1200.0 - 225.0) / 1100.0 * 10.0));
+        // 2/3 alive, 3 groups of the 20 needed for full diversity, 2/3 with EPG.
+        let expected_content = ((2.0 / 3.0) * 0.6 + (3.0 / 20.0) * 0.2 + (2.0 / 3.0) * 0.2) * 10.0;
+        assert_eq!(score.content, round_to_tenth(expected_content));
+        // Both alive channels are HD+, h264 (0.8) and hevc (1.0), both >= 25fps.
+        let expected_quality = (1.0 * 0.5 + 0.9 * 0.3 + 1.0 * 0.2) * 10.0;
+        assert_eq!(score.quality, round_to_tenth(expected_quality));
+        assert!(score.overall > 0.0 && score.overall <= 10.0);
+    }
+
+    #[test]
+    fn dead_only_scans_score_zero_on_ping_and_quality() {
+        let results = [result(0, ChannelStatus::Dead, "News")];
+        let score = compute_playlist_score(&results, 1).expect("score for a non-empty scan");
+        assert_eq!(score.ping, 0.0);
+        assert_eq!(score.quality, 0.0);
+    }
+
+    #[test]
+    fn resolution_text_stands_in_for_missing_dimensions() {
+        let mut tagged = result(0, ChannelStatus::Alive, "News");
+        tagged.resolution = Some("1080p".to_string());
+        assert!(is_hd_or_uhd(&tagged));
+
+        let mut sd = result(1, ChannelStatus::Alive, "News");
+        sd.resolution = Some("480p".to_string());
+        assert!(!is_hd_or_uhd(&sd));
+    }
+
+    #[test]
+    fn codec_tiers_rank_modern_codecs_higher() {
+        assert_eq!(codec_tier_score(Some("hevc")), 1.0);
+        assert_eq!(codec_tier_score(Some("AV1")), 1.0);
+        assert_eq!(codec_tier_score(Some("h.264")), 0.8);
+        assert_eq!(codec_tier_score(Some("mpeg2video")), 0.6);
+        assert_eq!(codec_tier_score(Some("something-else")), 0.5);
+        // An unreported codec scores below every known one.
+        assert_eq!(codec_tier_score(None), 0.4);
+    }
+
+    #[test]
+    fn median_handles_even_and_odd_lengths() {
+        assert_eq!(median_u64(&[]), None);
+        assert_eq!(median_u64(&[5]), Some(5.0));
+        assert_eq!(median_u64(&[10, 20]), Some(15.0));
+        // Input order must not matter.
+        assert_eq!(median_u64(&[30, 10, 20]), Some(20.0));
+    }
+}

--- a/src-tauri/src/engine/proxy_common.rs
+++ b/src-tauri/src/engine/proxy_common.rs
@@ -85,12 +85,10 @@ fn rewrite_tag_uri(line: &str, base: &Url, map_uri: &dyn Fn(&Url) -> Option<Stri
 
     let after_uri_eq = &line[uri_pos + 4..];
 
-    let (quote, uri_start, uri_end) = if after_uri_eq.starts_with('"') {
-        let inner = &after_uri_eq[1..];
+    let (quote, uri_start, uri_end) = if let Some(inner) = after_uri_eq.strip_prefix('"') {
         let end = inner.find('"').unwrap_or(inner.len());
         (Some('"'), 1, 1 + end)
-    } else if after_uri_eq.starts_with('\'') {
-        let inner = &after_uri_eq[1..];
+    } else if let Some(inner) = after_uri_eq.strip_prefix('\'') {
         let end = inner.find('\'').unwrap_or(inner.len());
         (Some('\''), 1, 1 + end)
     } else {

--- a/src-tauri/src/engine/resume.rs
+++ b/src-tauri/src/engine/resume.rs
@@ -75,6 +75,11 @@ struct PersistedCheckpointEntry {
     channel_log: Option<ChannelDebugLog>,
 }
 
+// Both variants wrap a ChannelResult, so they are inherently ~1 KB and the size
+// difference between them is just the optional log. Boxing to satisfy
+// `large_enum_variant` would add an allocation per checkpoint line for a value
+// that is destructured immediately after deserializing.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(untagged)]
 enum PersistedCheckpointLine {
@@ -181,7 +186,7 @@ pub fn load_processed_channels(log_file: &str) -> (HashSet<String>, usize) {
         }
         // Extract index for last_index tracking
         if let Some((index_part, _)) = line.split_once(" - ") {
-            let index_str = index_part.trim().split_whitespace().next().unwrap_or("");
+            let index_str = index_part.split_whitespace().next().unwrap_or("");
             if let Ok(idx) = index_str.parse::<usize>() {
                 last_index = last_index.max(idx);
             }

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -419,33 +419,31 @@ pub async fn handle_proxy_request(
         .unwrap_or("")
         .to_string();
 
-    let body = match crate::engine::proxy_common::read_capped(
-        upstream_response,
-        PROXY_BUFFERED_MAX_BYTES,
-    )
-    .await
-    {
-        Ok(bytes) => bytes,
-        Err(crate::engine::proxy_common::ReadCappedError::TooLarge) => {
-            log::warn!(
-                "Stream proxy: upstream body for {} exceeded {} bytes; refusing to buffer",
-                redact_url(&original_url),
-                PROXY_BUFFERED_MAX_BYTES
-            );
-            return error_response(502, "Upstream response too large");
-        }
-        Err(crate::engine::proxy_common::ReadCappedError::Read(err)) => {
-            log::warn!(
-                "Stream proxy: failed to read buffered upstream body for {} ({})",
-                redact_url(&original_url),
-                reqwest_error_kind(&err)
-            );
-            if err.is_timeout() {
-                return error_response(504, "Upstream response timed out");
+    let body =
+        match crate::engine::proxy_common::read_capped(upstream_response, PROXY_BUFFERED_MAX_BYTES)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(crate::engine::proxy_common::ReadCappedError::TooLarge) => {
+                log::warn!(
+                    "Stream proxy: upstream body for {} exceeded {} bytes; refusing to buffer",
+                    redact_url(&original_url),
+                    PROXY_BUFFERED_MAX_BYTES
+                );
+                return error_response(502, "Upstream response too large");
             }
-            return error_response(502, "Failed to read upstream response");
-        }
-    };
+            Err(crate::engine::proxy_common::ReadCappedError::Read(err)) => {
+                log::warn!(
+                    "Stream proxy: failed to read buffered upstream body for {} ({})",
+                    redact_url(&original_url),
+                    reqwest_error_kind(&err)
+                );
+                if err.is_timeout() {
+                    return error_response(504, "Upstream response timed out");
+                }
+                return error_response(502, "Failed to read upstream response");
+            }
+        };
 
     // Rewrite M3U8 manifests so internal URLs also go through the proxy
     let looks_like_m3u8 =
@@ -903,7 +901,7 @@ fn latest_transport_stream_pcr(data: &[u8], preferred_pid: Option<u16>) -> Optio
     while offset + MPEG_TS_PACKET_SIZE <= data.len() {
         let packet = &data[offset..offset + MPEG_TS_PACKET_SIZE];
         if let Some(pid) = transport_stream_packet_pid(packet) {
-            if preferred_pid.map_or(true, |preferred| preferred == pid) {
+            if preferred_pid.is_none_or(|preferred| preferred == pid) {
                 if let Some(pcr) = transport_stream_packet_pcr(packet) {
                     latest = Some((pid, pcr));
                 }
@@ -1113,15 +1111,13 @@ pub async fn start_streaming_proxy(app: tauri::AppHandle) -> std::io::Result<u16
             tokio::spawn(async move {
                 // Read the full request head to extract the URL — the
                 // request line and headers can arrive split across segments.
-                let request_bytes = match crate::engine::proxy_common::read_http_request_head(
-                    &mut socket,
-                    8192,
-                )
-                .await
-                {
-                    Ok(Some(bytes)) => bytes,
-                    Ok(None) | Err(_) => return,
-                };
+                let request_bytes =
+                    match crate::engine::proxy_common::read_http_request_head(&mut socket, 8192)
+                        .await
+                    {
+                        Ok(Some(bytes)) => bytes,
+                        Ok(None) | Err(_) => return,
+                    };
                 let request_str = String::from_utf8_lossy(&request_bytes);
 
                 // Parse GET /stream?url=ENCODED_URL HTTP/1.1
@@ -1430,9 +1426,9 @@ fn parse_stream_request(request: &str) -> Option<StreamRequest> {
 
 #[cfg(test)]
 mod tests {
-    use tokio::io::AsyncReadExt;
     use super::*;
     use std::time::{Duration, Instant};
+    use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
 

--- a/src-tauri/src/engine/xtream.rs
+++ b/src-tauri/src/engine/xtream.rs
@@ -349,7 +349,7 @@ fn append_xtream_streams_to_m3u(
         let group = entry
             .get("category_id")
             .and_then(|v| {
-                v.as_str().or_else(|| {
+                v.as_str().or({
                     // Some servers return category_id as a number
                     None
                 })

--- a/src-tauri/src/engine/xtream.rs
+++ b/src-tauri/src/engine/xtream.rs
@@ -348,12 +348,9 @@ fn append_xtream_streams_to_m3u(
             .unwrap_or("");
         let group = entry
             .get("category_id")
-            .and_then(|v| {
-                v.as_str().or({
-                    // Some servers return category_id as a number
-                    None
-                })
-            })
+            // Servers that return category_id as a number are handled by the
+            // numeric match below, so a string miss is simply no group.
+            .and_then(|v| v.as_str())
             .and_then(|id| cat_map.get(id))
             .map(|s| s.as_str())
             .unwrap_or("");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,9 @@ fn create_window_from_main_config(app: &tauri::AppHandle, label: String) {
     match tauri::WebviewWindowBuilder::from_config(app, &window_config)
         .and_then(|builder| builder.build())
     {
+        // The built window is only consumed by the macOS-only vibrancy setup
+        // below; elsewhere the theme is applied through the app handle.
+        #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
         Ok(window) => {
             let theme_preference = {
                 let state = app.state::<Arc<AppState>>();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,9 @@
+// The scan/ffmpeg/cast pipelines thread a lot of per-check configuration
+// through their worker functions. Bundling those into parameter structs is a
+// worthwhile refactor, but it is a behavioural change to the hottest code in
+// the app and does not belong to the lint gate that introduced this allow.
+#![allow(clippy::too_many_arguments)]
+
 pub mod commands;
 pub mod engine;
 pub mod error;
@@ -861,13 +867,13 @@ pub fn run() {
                 theme
             };
             if let Err(error) =
-                commands::settings::apply_theme_preference(&app.handle(), theme_preference)
+                commands::settings::apply_theme_preference(app.handle(), theme_preference)
             {
                 log::warn!("Failed to apply startup theme preference: {}", error);
             }
 
-            commands::recent::refresh_recent_menu(&app.handle());
-            commands::saved::refresh_saved_menu(&app.handle());
+            commands::recent::refresh_recent_menu(app.handle());
+            commands::saved::refresh_saved_menu(app.handle());
 
             let launch_open_paths = collect_launch_open_paths();
             if !launch_open_paths.is_empty() {
@@ -875,7 +881,7 @@ pub fn run() {
                     "Detected {} playlist path(s) from launch arguments",
                     launch_open_paths.len()
                 );
-                emit_open_paths_to_focused_window(&app.handle(), &launch_open_paths);
+                emit_open_paths_to_focused_window(app.handle(), &launch_open_paths);
             }
 
             // Warm up the localhost streaming proxy in the background. Play

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -550,6 +550,7 @@ pub fn run() {
         )
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_os::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(
             tauri_plugin_window_state::Builder::new()
                 .with_state_flags(
@@ -992,6 +993,8 @@ pub fn run() {
                 }
             }
 
+            commands::updater::spawn_automatic_update_checks(app.handle().clone());
+
             Ok(())
         })
         .manage(AppState::new() as Arc<AppState>)
@@ -1029,6 +1032,11 @@ pub fn run() {
             commands::settings::read_screenshot,
             commands::settings::get_screenshot_cache_stats,
             commands::settings::clear_screenshot_cache,
+            commands::updater::check_for_updates,
+            commands::updater::discovered_update,
+            commands::updater::update_install_mode,
+            commands::updater::open_manual_update,
+            commands::updater::install_update,
             commands::history::get_scan_history,
             commands::history::clear_scan_history,
             commands::recent::get_recent_playlists,

--- a/src-tauri/src/models/scan.rs
+++ b/src-tauri/src/models/scan.rs
@@ -18,16 +18,12 @@ pub const MAX_RETRIES: u32 = 10;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum RetryBackoff {
+    #[default]
     None,
     Linear,
     Exponential,
-}
-
-impl Default for RetryBackoff {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,8 +75,7 @@ impl ScanConfig {
 
         if let Some(ext) = self.extended_timeout {
             if !ext.is_finite()
-                || ext < MIN_EXTENDED_TIMEOUT_SECS
-                || ext > MAX_EXTENDED_TIMEOUT_SECS
+                || !(MIN_EXTENDED_TIMEOUT_SECS..=MAX_EXTENDED_TIMEOUT_SECS).contains(&ext)
             {
                 return Err(AppError::Validation(format!(
                     "Invalid extended timeout: must be between {} and {} seconds",
@@ -96,7 +91,8 @@ impl ScanConfig {
             )));
         }
 
-        if self.retries < MIN_RETRIES || self.retries > MAX_RETRIES {
+        // No lower-bound check: MIN_RETRIES is 0, which u32 already enforces.
+        if self.retries > MAX_RETRIES {
             return Err(AppError::Validation(format!(
                 "Invalid retries: must be between {} and {}",
                 MIN_RETRIES, MAX_RETRIES

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -80,72 +80,65 @@ pub struct AppSettings {
     pub automatic_update_checks: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(default)]
-pub struct ScanPresetConfig {
-    pub timeout: f64,
-    pub extended_timeout: Option<f64>,
-    pub concurrency: u32,
-    pub retries: u32,
-    pub retry_backoff: RetryBackoff,
-    pub user_agent: String,
-    pub skip_screenshots: bool,
-    pub profile_bitrate: bool,
-    pub ffprobe_timeout_secs: f64,
-    pub ffmpeg_bitrate_timeout_secs: f64,
-    pub accept_invalid_certs: bool,
-    pub proxy_file: Option<String>,
-    pub test_geoblock: bool,
-    pub screenshots_dir: Option<String>,
-    pub low_fps_threshold: f64,
-    pub screenshot_format: ScreenshotFormat,
+/// Declares which `AppSettings` fields a scan preset captures, and derives
+/// `ScanPresetConfig` plus both copy directions from that one list.
+///
+/// Previously the field list appeared three times — the struct, `from_settings`
+/// and `apply_to_settings` — so a new scan setting silently failed to round-trip
+/// through presets if any one of them was missed. Now the list below is the only
+/// place to edit, and a name that does not exist on `AppSettings` (or whose type
+/// disagrees) fails to compile.
+macro_rules! scan_preset_fields {
+    ($($field:ident: $ty:ty,)*) => {
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        #[serde(default)]
+        pub struct ScanPresetConfig {
+            $(pub $field: $ty,)*
+        }
+
+        impl ScanPresetConfig {
+            /// Capture the scan-relevant subset of `settings`.
+            // The macro cannot tell Copy fields from owned ones, so it clones
+            // uniformly; for the Copy fields that is just a move.
+            #[allow(clippy::clone_on_copy)]
+            pub fn from_settings(settings: &AppSettings) -> Self {
+                Self {
+                    $($field: settings.$field.clone(),)*
+                }
+            }
+
+            /// Overwrite only the scan-relevant fields of `settings`, leaving
+            /// UI and app-level preferences untouched.
+            #[allow(clippy::clone_on_copy)]
+            pub fn apply_to_settings(&self, settings: &mut AppSettings) {
+                $(settings.$field = self.$field.clone();)*
+            }
+        }
+    };
+}
+
+scan_preset_fields! {
+    timeout: f64,
+    extended_timeout: Option<f64>,
+    concurrency: u32,
+    retries: u32,
+    retry_backoff: RetryBackoff,
+    user_agent: String,
+    skip_screenshots: bool,
+    profile_bitrate: bool,
+    ffprobe_timeout_secs: f64,
+    ffmpeg_bitrate_timeout_secs: f64,
+    accept_invalid_certs: bool,
+    proxy_file: Option<String>,
+    test_geoblock: bool,
+    screenshots_dir: Option<String>,
+    low_fps_threshold: f64,
+    screenshot_format: ScreenshotFormat,
 }
 
 impl Default for ScanPresetConfig {
     fn default() -> Self {
         Self::from_settings(&AppSettings::default())
-    }
-}
-
-impl ScanPresetConfig {
-    pub fn from_settings(settings: &AppSettings) -> Self {
-        Self {
-            timeout: settings.timeout,
-            extended_timeout: settings.extended_timeout,
-            concurrency: settings.concurrency,
-            retries: settings.retries,
-            retry_backoff: settings.retry_backoff,
-            user_agent: settings.user_agent.clone(),
-            skip_screenshots: settings.skip_screenshots,
-            profile_bitrate: settings.profile_bitrate,
-            ffprobe_timeout_secs: settings.ffprobe_timeout_secs,
-            ffmpeg_bitrate_timeout_secs: settings.ffmpeg_bitrate_timeout_secs,
-            accept_invalid_certs: settings.accept_invalid_certs,
-            proxy_file: settings.proxy_file.clone(),
-            test_geoblock: settings.test_geoblock,
-            screenshots_dir: settings.screenshots_dir.clone(),
-            low_fps_threshold: settings.low_fps_threshold,
-            screenshot_format: settings.screenshot_format,
-        }
-    }
-
-    pub fn apply_to_settings(&self, settings: &mut AppSettings) {
-        settings.timeout = self.timeout;
-        settings.extended_timeout = self.extended_timeout;
-        settings.concurrency = self.concurrency;
-        settings.retries = self.retries;
-        settings.retry_backoff = self.retry_backoff;
-        settings.user_agent = self.user_agent.clone();
-        settings.skip_screenshots = self.skip_screenshots;
-        settings.profile_bitrate = self.profile_bitrate;
-        settings.ffprobe_timeout_secs = self.ffprobe_timeout_secs;
-        settings.ffmpeg_bitrate_timeout_secs = self.ffmpeg_bitrate_timeout_secs;
-        settings.accept_invalid_certs = self.accept_invalid_certs;
-        settings.proxy_file = self.proxy_file.clone();
-        settings.test_geoblock = self.test_geoblock;
-        settings.screenshots_dir = self.screenshots_dir.clone();
-        settings.low_fps_threshold = self.low_fps_threshold;
-        settings.screenshot_format = self.screenshot_format;
     }
 }
 
@@ -219,6 +212,24 @@ mod tests {
         let settings = AppSettings::default();
         assert!(settings.scan_notifications);
         assert!(!settings.accept_invalid_certs);
+    }
+
+    /// Presets are stored as their own JSON object, so their keys have to keep
+    /// matching the settings keys they are copied to and from. The macro makes
+    /// a *missing* field a compile error; this catches the remaining case of a
+    /// preset field that serializes under a name `AppSettings` does not use.
+    #[test]
+    fn preset_keys_are_a_subset_of_settings_keys() {
+        let settings = serde_json::to_value(AppSettings::default()).expect("settings serialize");
+        let preset = serde_json::to_value(ScanPresetConfig::default()).expect("preset serializes");
+
+        let settings_keys = settings.as_object().expect("settings is an object");
+        for key in preset.as_object().expect("preset is an object").keys() {
+            assert!(
+                settings_keys.contains_key(key),
+                "preset field `{key}` has no matching AppSettings field"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -7,29 +7,21 @@ pub const DEFAULT_FFMPEG_BITRATE_TIMEOUT_SECS: f64 = 30.0;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ThemePreference {
+    #[default]
     System,
     Light,
     Dark,
 }
 
-impl Default for ThemePreference {
-    fn default() -> Self {
-        Self::System
-    }
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ScreenshotFormat {
+    #[default]
     Webp,
     Png,
-}
-
-impl Default for ScreenshotFormat {
-    fn default() -> Self {
-        Self::Webp
-    }
 }
 
 impl ScreenshotFormat {
@@ -43,17 +35,13 @@ impl ScreenshotFormat {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ChannelLogoSize {
+    #[default]
     Small,
     Medium,
     Large,
     Huge,
-}
-
-impl Default for ChannelLogoSize {
-    fn default() -> Self {
-        Self::Small
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -271,17 +259,21 @@ mod tests {
 
     #[test]
     fn preset_config_round_trip_updates_scan_fields_only() {
-        let mut base = AppSettings::default();
-        base.timeout = 22.5;
-        base.retries = 7;
-        base.user_agent = "PresetAgent/1.0".to_string();
-        base.screenshot_format = ScreenshotFormat::Png;
-        base.accept_invalid_certs = true;
+        let base = AppSettings {
+            timeout: 22.5,
+            retries: 7,
+            user_agent: "PresetAgent/1.0".to_string(),
+            screenshot_format: ScreenshotFormat::Png,
+            accept_invalid_certs: true,
+            ..AppSettings::default()
+        };
         let preset = ScanPresetConfig::from_settings(&base);
 
-        let mut destination = AppSettings::default();
-        destination.theme = super::ThemePreference::Dark;
-        destination.scan_history_limit = 99;
+        let mut destination = AppSettings {
+            theme: super::ThemePreference::Dark,
+            scan_history_limit: 99,
+            ..AppSettings::default()
+        };
         preset.apply_to_settings(&mut destination);
 
         assert_eq!(destination.timeout, 22.5);

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -87,6 +87,9 @@ pub struct AppSettings {
     pub low_space_threshold_gb: f64,
     pub separate_placeholder_status: bool,
     pub show_header_button_text: bool,
+    /// Look for a signed update on launch and every six hours. Discovery only
+    /// ever surfaces a notice; installing always needs explicit confirmation.
+    pub automatic_update_checks: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -214,6 +217,7 @@ impl Default for AppSettings {
             low_space_threshold_gb: 5.0,
             separate_placeholder_status: true,
             show_header_button_text: !cfg!(target_os = "macos"),
+            automatic_update_checks: true,
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -62,18 +62,10 @@ impl Default for WindowScanState {
     }
 }
 
+#[derive(Default)]
 pub struct CastState {
     pub session: Option<ActiveCastSession>,
     pub proxy: Option<CastProxyHandle>,
-}
-
-impl Default for CastState {
-    fn default() -> Self {
-        Self {
-            session: None,
-            proxy: None,
-        }
-    }
 }
 
 pub struct AppState {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -89,6 +89,19 @@ pub struct AppState {
     window_scan_states: Mutex<HashMap<String, WindowScanState>>,
     backend_perf_samples: Mutex<VecDeque<BackendPerfSample>>,
     playlist_preview_cache: Mutex<HashMap<String, CachedPlaylistPreview>>,
+    /// Rejects a second install immediately instead of queueing it behind the
+    /// first one on `update_checking`.
+    pub update_installing: std::sync::atomic::AtomicBool,
+    /// Serializes every updater operation so automatic discovery, a manual
+    /// check, and an install can never contend for the updater.
+    pub update_checking: Mutex<()>,
+    /// The update found by the most recent check, if any. Retaining the
+    /// verified metadata lets the install action apply exactly the update the
+    /// user was shown rather than re-resolving it.
+    pub update_available: Mutex<Option<tauri_plugin_updater::Update>>,
+    /// Wakes the periodic check loop when the preference is switched back on,
+    /// instead of waiting out the current interval.
+    pub update_check_wake: Notify,
 }
 
 impl AppState {
@@ -103,6 +116,10 @@ impl AppState {
             window_scan_states: Mutex::new(HashMap::new()),
             backend_perf_samples: Mutex::new(VecDeque::new()),
             playlist_preview_cache: Mutex::new(HashMap::new()),
+            update_installing: std::sync::atomic::AtomicBool::new(false),
+            update_checking: Mutex::new(()),
+            update_available: Mutex::new(None),
+            update_check_wake: Notify::new(),
         })
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -86,5 +86,13 @@
         "role": "Editor"
       }
     ]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/kristofferR/IPTVChecker/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMzMDVEMzBDQjc2RkQ3NUEKUldSYTEyKzNETk1GTXh4N2pvMG9mR3YycyttN2U2Nmg5OFVKbnNBdUVITTVkdkp0dm02aldqUnAK"
+    }
   }
 }

--- a/src-tauri/tauri.conf.release.json
+++ b/src-tauri/tauri.conf.release.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/src-tauri/tests/scan_pipeline_integration.rs
+++ b/src-tauri/tests/scan_pipeline_integration.rs
@@ -1,7 +1,9 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use iptv_checker_lib::commands::export::{export_csv, export_m3u};
 use iptv_checker_lib::engine::checker::check_channel_status_with_debug;
+use iptv_checker_lib::engine::parser::parse_m3u;
 use iptv_checker_lib::engine::proxy::{confirm_geoblock, test_with_proxy};
 use iptv_checker_lib::engine::resume::{
     load_checkpoint_results, load_processed_channels, write_entries, CheckpointWriteEntry,
@@ -277,4 +279,130 @@ fn checkpoint_batch_roundtrip_keeps_latest_results_and_redacts_secrets() {
 
     let _ = std::fs::remove_file(&log_file);
     let _ = std::fs::remove_file(&checkpoint_file);
+}
+
+/// Parse -> check -> export, over the same code paths the app uses.
+///
+/// The unit tests cover each stage in isolation; this one checks that a real
+/// playlist survives the whole trip: that parsed channels keep the identity the
+/// exporters rely on, that a mixed alive/dead server produces the statuses the
+/// "alive only" export filters on, and that the exported M3U can be parsed back.
+#[tokio::test]
+async fn playlist_round_trips_from_parse_through_check_to_export() {
+    let stream_body = vec![b'x'; 600 * 1024];
+    let handler = Arc::new(move |path: &str| {
+        // /live/2 is the dead one; everything else streams.
+        if path.starts_with("/live/2") {
+            return TestHttpResponse {
+                status_code: 404,
+                reason: "Not Found",
+                headers: vec![("Content-Type".to_string(), "text/plain".to_string())],
+                body: b"gone".to_vec(),
+            };
+        }
+        TestHttpResponse {
+            status_code: 200,
+            reason: "OK",
+            headers: vec![("Content-Type".to_string(), "video/mp2t".to_string())],
+            body: stream_body.clone(),
+        }
+    });
+    let (base_url, server_handle) = spawn_http_server(handler).await;
+
+    let playlist = format!(
+        "#EXTM3U\n\
+         #EXTINF:-1 tvg-id=\"one\" group-title=\"News\",Channel One\n\
+         {base_url}/live/1\n\
+         #EXTINF:-1 tvg-id=\"two\" group-title=\"News\",Channel Two\n\
+         {base_url}/live/2\n\
+         #EXTINF:-1 tvg-id=\"three\" group-title=\"Sports\",Channel Three\n\
+         {base_url}/live/3\n"
+    );
+
+    let preview = parse_m3u(playlist.as_bytes(), "integration.m3u", &None, &None)
+        .expect("playlist should parse");
+    assert_eq!(preview.total_channels, 3);
+    assert_eq!(
+        preview.groups,
+        vec!["News".to_string(), "Sports".to_string()]
+    );
+
+    // Check every parsed channel against the mock server.
+    let cancel = CancellationToken::new();
+    let mut results = Vec::new();
+    for channel in &preview.channels {
+        let outcome = check_channel_status_with_debug(
+            &test_client(),
+            &channel.url,
+            2.0,
+            0,
+            RetryBackoff::None,
+            None,
+            "IPTVCheckerTests/1.0",
+            &cancel,
+        )
+        .await
+        .expect("checker request should complete");
+
+        let mut result = make_result(channel.index, outcome.status, &channel.url, None);
+        result.name = channel.name.clone();
+        result.group = channel.group.clone();
+        result.extinf_line = channel.extinf_line.clone();
+        results.push(result);
+    }
+    server_handle.abort();
+
+    let statuses: Vec<_> = results.iter().map(|result| result.status).collect();
+    assert_eq!(
+        statuses,
+        vec![
+            ChannelStatus::Alive,
+            ChannelStatus::Dead,
+            ChannelStatus::Alive
+        ],
+        "the 404 channel must be the only dead one"
+    );
+
+    // Export only the alive channels, as the "alive only" export scope does.
+    let alive: Vec<ChannelResult> = results
+        .iter()
+        .filter(|result| result.status == ChannelStatus::Alive)
+        .cloned()
+        .collect();
+
+    let m3u_path = temp_file("roundtrip.m3u");
+    export_m3u(alive.clone(), m3u_path.clone())
+        .await
+        .expect("m3u export should succeed");
+
+    let exported = std::fs::read(&m3u_path).expect("exported m3u should be readable");
+    let reparsed =
+        parse_m3u(&exported, "exported.m3u", &None, &None).expect("exported m3u should parse");
+    assert_eq!(
+        reparsed.total_channels, 2,
+        "dead channel must not be exported"
+    );
+    assert_eq!(
+        reparsed
+            .channels
+            .iter()
+            .map(|channel| channel.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Channel One", "Channel Three"],
+    );
+
+    let csv_path = temp_file("roundtrip.csv");
+    export_csv(alive, csv_path.clone(), "integration".to_string(), true)
+        .await
+        .expect("csv export should succeed");
+
+    let csv = std::fs::read_to_string(&csv_path).expect("exported csv should be readable");
+    let data_rows = csv.lines().skip(2).filter(|line| !line.is_empty()).count();
+    assert_eq!(data_rows, 2, "csv should hold one row per exported channel");
+    assert!(csv.contains("Channel One"));
+    assert!(csv.contains("Channel Three"));
+    assert!(!csv.contains("Channel Two"));
+
+    let _ = std::fs::remove_file(&m3u_path);
+    let _ = std::fs::remove_file(&csv_path);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,6 @@
-import { listen } from "@tauri-apps/api/event";
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
-import {
-  isPermissionGranted,
-  onAction,
-  requestPermission,
-  sendNotification,
-} from "@tauri-apps/plugin-notification";
 import {
   lazy,
   Profiler,
-  type ProfilerOnRenderCallback,
   Suspense,
   useCallback,
   useEffect,
@@ -18,37 +8,47 @@ import {
   useMemo,
   useRef,
   useState,
+  type ProfilerOnRenderCallback,
 } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { setLiquidGlassEffect } from "tauri-plugin-liquid-glass-api";
-import { AppBanners } from "./components/AppBanners";
-import { ChannelTable } from "./components/ChannelTable";
-import { FilterBar } from "./components/FilterBar";
-import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
-import { ProgressBar } from "./components/ProgressBar";
-import { StartScreen } from "./components/StartScreen";
-import { StatsPanel } from "./components/StatsPanel";
-import { ThumbnailPanel } from "./components/ThumbnailPanel";
-import { Toolbar } from "./components/Toolbar";
-import { type UseChromecastResult, useChromecast } from "./hooks/useChromecast";
-import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
-import { usePlaylistSources } from "./hooks/usePlaylistSources";
-import { useScan } from "./hooks/useScan";
-import { useSettings } from "./hooks/useSettings";
-import { useStreamPlayer } from "./hooks/useStreamPlayer";
-import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
-  checkFfmpegAvailable,
+  isPermissionGranted,
+  onAction,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+import type { AppSettings, ChannelResult, ScanConfig } from "./lib/types";
+import {
   clearScanHistory,
   getScanHistory,
+  checkFfmpegAvailable,
+  readScreenshot,
   openChannelInPlayer,
   quickCheckChannel,
-  readScreenshot,
 } from "./lib/tauri";
-import type { AppSettings, ChannelResult, ChromecastDevice, ScanConfig } from "./lib/types";
+import { useScan } from "./hooks/useScan";
+import { useSettings } from "./hooks/useSettings";
+import { useChromecast, type UseChromecastResult } from "./hooks/useChromecast";
+import { useStreamPlayer } from "./hooks/useStreamPlayer";
+import { usePlaylistSources } from "./hooks/usePlaylistSources";
+import { useUpdateCheck } from "./hooks/useUpdateCheck";
+import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
+import { buildCastRequest, isCastSessionActive } from "./lib/cast";
+import type { ChromecastDevice } from "./lib/types";
 import { useAppStore } from "./store";
 import type { AppStore, OpenSourceDialogState } from "./store/types";
-
+import { Toolbar } from "./components/Toolbar";
+import { FilterBar } from "./components/FilterBar";
+import { ChannelTable } from "./components/ChannelTable";
+import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
+import { ThumbnailPanel } from "./components/ThumbnailPanel";
+import { StatsPanel } from "./components/StatsPanel";
+import { ProgressBar } from "./components/ProgressBar";
+import { AppBanners } from "./components/AppBanners";
+import { StartScreen } from "./components/StartScreen";
 const KeyboardShortcutsDialog = lazy(() => import("./components/KeyboardShortcutsDialog"));
 const HistoryPanel = lazy(() => import("./components/HistoryPanel"));
 const OpenSourceDialog = lazy(() => import("./components/OpenSourceDialog"));
@@ -58,19 +58,23 @@ const XtreamServerTestDialog = lazy(() =>
   })),
 );
 const SavedPlaylistsDialog = lazy(() => import("./components/SavedPlaylistsDialog"));
-const SavedPlaylistEditorDialog = lazy(() => import("./components/SavedPlaylistEditorDialog"));
-
+const SavedPlaylistEditorDialog = lazy(
+  () => import("./components/SavedPlaylistEditorDialog"),
+);
 import { AlertTriangle } from "lucide-react";
-import { toPendingChannelResult } from "./lib/channelResults";
+import { detectPlatform } from "./lib/platform";
+import { logger } from "./lib/logger";
 import { errorToString } from "./lib/errors";
 import { HapticFeedbackPattern, PerformanceTime, triggerHaptic } from "./lib/haptics";
-import { logger } from "./lib/logger";
-import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
-import { detectPlatform } from "./lib/platform";
-import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
+import { toPendingChannelResult } from "./lib/channelResults";
 import { isScanActive } from "./lib/scanState";
 import { isInputLikeTarget, isPrimaryModifierPressed } from "./lib/shortcuts";
-import { normalizeSourceFilter, validateSourceFilterPattern } from "./lib/sourceFilter";
+import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
+import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
+import {
+  normalizeSourceFilter,
+  validateSourceFilterPattern,
+} from "./lib/sourceFilter";
 
 async function restoreAndFocusWindow(window: {
   unminimize: () => Promise<void>;
@@ -152,9 +156,7 @@ function ScanPauseBanners() {
       {networkPaused && isScanActive(scanState) && (
         <div className="flex items-center gap-2 px-4 py-2 bg-orange-500/10 border-b border-orange-500/20 text-orange-400 text-[13px]">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span className="flex-1">
-            Scan paused — network connectivity lost. Waiting for recovery...
-          </span>
+          <span className="flex-1">Scan paused — network connectivity lost. Waiting for recovery...</span>
         </div>
       )}
     </>
@@ -300,7 +302,11 @@ function SelectedChannelSidebar({
   );
 }
 
-function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<void> }) {
+function ScanRuntimeEffects({
+  refreshHistory,
+}: {
+  refreshHistory: () => Promise<void>;
+}) {
   const playlist = useAppStore((s) => s.playlist);
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
@@ -321,7 +327,9 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
 
   useEffect(() => {
     const previous = reportAutoRevealPreviousScanStateRef.current;
-    const scanJustStarted = scanState === "scanning" && !isScanActive(previous);
+    const scanJustStarted =
+      scanState === "scanning" &&
+      !isScanActive(previous);
 
     if (scanJustStarted) {
       getStore().prepareReportAutoRevealForScanStart();
@@ -342,7 +350,10 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
       return;
     }
 
-    const active = scanState === "scanning" || scanState === "paused" || scanState === "complete";
+    const active =
+      scanState === "scanning" ||
+      scanState === "paused" ||
+      scanState === "complete";
     if (!active) {
       return;
     }
@@ -365,7 +376,10 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
     if (!justFinished) return;
 
     if (scanState === "complete") {
-      void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.DrawCompleted);
+      void triggerHaptic(
+        HapticFeedbackPattern.Generic,
+        PerformanceTime.DrawCompleted,
+      );
     }
 
     if (!scanNotifications || !summary) return;
@@ -404,13 +418,14 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
         progress && progress.total > 0
           ? Math.min(100, Math.max(0, (progress.completed / progress.total) * 100))
           : 0;
-      const status = networkPaused
-        ? ProgressBarStatus.Error
-        : scanState === "paused"
-          ? ProgressBarStatus.Paused
-          : progress
-            ? ProgressBarStatus.Normal
-            : ProgressBarStatus.Indeterminate;
+      const status =
+        networkPaused
+          ? ProgressBarStatus.Error
+          : scanState === "paused"
+            ? ProgressBarStatus.Paused
+            : progress
+              ? ProgressBarStatus.Normal
+              : ProgressBarStatus.Indeterminate;
 
       void appWindow
         .setProgressBar({
@@ -420,7 +435,9 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
         .catch(() => {});
 
       if (isMac) {
-        const badgeLabel = progress ? `${progress.alive + progress.drm}/${progress.dead}` : "...";
+        const badgeLabel = progress
+          ? `${progress.alive + progress.drm}/${progress.dead}`
+          : "...";
         void appWindow.setBadgeLabel(badgeLabel).catch(() => {});
       }
     };
@@ -444,7 +461,8 @@ function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<
       const now = Date.now();
       const elapsed = now - lastOsProgressUpdateMsRef.current;
       const shouldUpdateNow =
-        lastOsProgressUpdateMsRef.current === 0 || elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
+        lastOsProgressUpdateMsRef.current === 0 ||
+        elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
 
       clearScheduledUpdate();
       if (shouldUpdateNow) {
@@ -562,9 +580,16 @@ export default function App() {
   const isCasting = isCastSessionActive(castSession);
 
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
-  const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
-    useScan();
-  const { checkForUpdates } = useUpdateCheck();
+  const {
+    start,
+    cancel,
+    pause,
+    resume,
+    initFromPlaylist,
+    syncFromPlaylist,
+    updateResult,
+  } = useScan();
+  const { checkForUpdates, installUpdate } = useUpdateCheck();
   const {
     handleClearRecentPlaylists,
     handleOpen,
@@ -612,9 +637,7 @@ export default function App() {
   useEffect(() => {
     const title = playlist ? `${playlist.file_name} | IPTV Checker` : "IPTV Checker";
     document.title = title;
-    void getCurrentWindow()
-      .setTitle(title)
-      .catch(() => {});
+    void getCurrentWindow().setTitle(title).catch(() => {});
   }, [playlist]);
 
   // Detect platform via native plugin and refresh the initial fallback.
@@ -705,7 +728,10 @@ export default function App() {
     getStore().setHistoryLoading(true);
     getStore().setHistoryError(null);
     try {
-      const items = await getScanHistory(playlist.file_path, playlist.source_identity);
+      const items = await getScanHistory(
+        playlist.file_path,
+        playlist.source_identity,
+      );
       getStore().setHistoryEntries(items);
     } catch (err) {
       getStore().setHistoryError(errorToString(err));
@@ -779,36 +805,32 @@ export default function App() {
     void refreshHistory();
   }, [playlist, refreshHistory]);
 
-  const handleExternalOpenPaths = useCallback(
-    (paths: string[]) => {
-      const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
-      if (!targetPath) {
-        return;
-      }
+  const handleExternalOpenPaths = useCallback((paths: string[]) => {
+    const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
+    if (!targetPath) {
+      return;
+    }
 
-      if (paths.length > 1) {
-        getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
-      }
+    if (paths.length > 1) {
+      getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
+    }
 
-      void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
-      void openPlaylistPath(targetPath);
-    },
-    [openPlaylistPath],
-  );
+    void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
+    void openPlaylistPath(targetPath);
+  }, [openPlaylistPath]);
 
-  const handleDroppedPaths = useCallback(
-    (paths: string[]) => {
-      const playlistPath = paths.find((path) => isPlaylistLikePath(path));
+  const handleDroppedPaths = useCallback((paths: string[]) => {
+    const playlistPath = paths.find((path) =>
+      isPlaylistLikePath(path),
+    );
 
-      if (!playlistPath) {
-        getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
-        return;
-      }
+    if (!playlistPath) {
+      getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
+      return;
+    }
 
-      void openPlaylistPath(playlistPath);
-    },
-    [openPlaylistPath],
-  );
+    void openPlaylistPath(playlistPath);
+  }, [openPlaylistPath]);
 
   useEffect(() => {
     let mounted = true;
@@ -860,66 +882,69 @@ export default function App() {
     return () => window.removeEventListener("contextmenu", handler);
   }, []);
 
-  const startScanWithSelection = useCallback(
-    async (selection: number[]) => {
-      const state = getStore();
-      const currentChannelSearchError = validateSourceFilterPattern(state.channelSearch);
+  const startScanWithSelection = useCallback(async (selection: number[]) => {
+    const state = getStore();
+    const currentChannelSearchError = validateSourceFilterPattern(
+      state.channelSearch,
+    );
 
-      if (currentChannelSearchError) {
-        state.setScanInputError(`Invalid source filter regex: ${currentChannelSearchError}`);
-        return false;
-      }
+    if (currentChannelSearchError) {
+      state.setScanInputError(
+        `Invalid source filter regex: ${currentChannelSearchError}`,
+      );
+      return false;
+    }
 
-      const applyResult = await ensureSourceFilterApplied();
-      if (!applyResult.ok) {
-        return false;
-      }
+    const applyResult = await ensureSourceFilterApplied();
+    if (!applyResult.ok) {
+      return false;
+    }
 
-      const refreshedState = getStore();
-      const currentPlaylist = refreshedState.playlist;
-      const currentChannelSearch = normalizeSourceFilter(refreshedState.channelSearch);
-      const currentGroupFilter = refreshedState.groupFilter;
-      const currentSettings = refreshedState.settings;
-      const effectiveSelection = applyResult.reapplied ? [] : selection;
+    const refreshedState = getStore();
+    const currentPlaylist = refreshedState.playlist;
+    const currentChannelSearch = normalizeSourceFilter(
+      refreshedState.channelSearch,
+    );
+    const currentGroupFilter = refreshedState.groupFilter;
+    const currentSettings = refreshedState.settings;
+    const effectiveSelection = applyResult.reapplied ? [] : selection;
 
-      if (!currentPlaylist) return false;
+    if (!currentPlaylist) return false;
 
-      const config: ScanConfig = {
-        file_path: currentPlaylist.file_path,
-        source_identity: currentPlaylist.source_identity ?? null,
-        playlist_display_name: currentPlaylist.file_name,
-        group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
-        channel_search: currentChannelSearch || null,
-        selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
-        hide_vod_content: currentSettings.hide_vod_content,
-        timeout: currentSettings.timeout,
-        extended_timeout: currentSettings.extended_timeout,
-        concurrency: resolveSmartConcurrency(
-          currentSettings.concurrency,
-          currentPlaylist.single_provider,
-          currentPlaylist.xtream_max_connections ?? null,
-        ),
-        retries: currentSettings.retries,
-        retry_backoff: currentSettings.retry_backoff,
-        user_agent: currentSettings.user_agent,
-        skip_screenshots: currentSettings.skip_screenshots,
-        profile_bitrate: currentSettings.profile_bitrate,
-        ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
-        ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
-        accept_invalid_certs: currentSettings.accept_invalid_certs,
-        proxy_file: currentSettings.proxy_file,
-        test_geoblock: currentSettings.test_geoblock,
-        screenshots_dir: currentSettings.screenshots_dir,
-        client_capabilities: {
-          event_batch_v1: true,
-        },
-      };
+    const config: ScanConfig = {
+      file_path: currentPlaylist.file_path,
+      source_identity: currentPlaylist.source_identity ?? null,
+      playlist_display_name: currentPlaylist.file_name,
+      group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
+      channel_search: currentChannelSearch || null,
+      selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
+      hide_vod_content: currentSettings.hide_vod_content,
+      timeout: currentSettings.timeout,
+      extended_timeout: currentSettings.extended_timeout,
+      concurrency: resolveSmartConcurrency(
+        currentSettings.concurrency,
+        currentPlaylist.single_provider,
+        currentPlaylist.xtream_max_connections ?? null,
+      ),
+      retries: currentSettings.retries,
+      retry_backoff: currentSettings.retry_backoff,
+      user_agent: currentSettings.user_agent,
+      skip_screenshots: currentSettings.skip_screenshots,
+      profile_bitrate: currentSettings.profile_bitrate,
+      ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
+      ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
+      accept_invalid_certs: currentSettings.accept_invalid_certs,
+      proxy_file: currentSettings.proxy_file,
+      test_geoblock: currentSettings.test_geoblock,
+      screenshots_dir: currentSettings.screenshots_dir,
+      client_capabilities: {
+        event_batch_v1: true,
+      },
+    };
 
-      await start(config, currentPlaylist.total_channels, effectiveSelection);
-      return true;
-    },
-    [ensureSourceFilterApplied, start],
-  );
+    await start(config, currentPlaylist.total_channels, effectiveSelection);
+    return true;
+  }, [ensureSourceFilterApplied, start]);
 
   const handleStartScan = useCallback(async () => {
     const started = await startScanWithSelection(getStore().selectedChannelIndices);
@@ -950,67 +975,61 @@ export default function App() {
     );
   };
 
-  const handleSidebarDragStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+  const handleSidebarDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
 
-      const onMouseMove = (ev: MouseEvent) => {
-        if (!sidebarDragRef.current) return;
-        const delta = ev.clientX - sidebarDragRef.current.startX;
-        const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
-        getStore().setSidebarWidth(newWidth);
-      };
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!sidebarDragRef.current) return;
+      const delta = ev.clientX - sidebarDragRef.current.startX;
+      const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
+      getStore().setSidebarWidth(newWidth);
+    };
 
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-        sidebarDragRef.current = null;
-      };
+    const onMouseUp = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      sidebarDragRef.current = null;
+    };
 
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
-    },
-    [sidebarWidth],
-  );
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [sidebarWidth]);
 
-  const handleReportSidebarDragStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      reportSidebarDragRef.current = {
-        startX: e.clientX,
-        startWidth: reportSidebarWidth,
-      };
+  const handleReportSidebarDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    reportSidebarDragRef.current = {
+      startX: e.clientX,
+      startWidth: reportSidebarWidth,
+    };
 
-      const onMouseMove = (ev: MouseEvent) => {
-        if (!reportSidebarDragRef.current) return;
-        const delta = reportSidebarDragRef.current.startX - ev.clientX;
-        const newWidth = Math.max(
-          260,
-          Math.min(700, reportSidebarDragRef.current.startWidth + delta),
-        );
-        getStore().setReportSidebarWidth(newWidth);
-      };
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!reportSidebarDragRef.current) return;
+      const delta = reportSidebarDragRef.current.startX - ev.clientX;
+      const newWidth = Math.max(
+        260,
+        Math.min(700, reportSidebarDragRef.current.startWidth + delta),
+      );
+      getStore().setReportSidebarWidth(newWidth);
+    };
 
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-        reportSidebarDragRef.current = null;
-      };
+    const onMouseUp = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      reportSidebarDragRef.current = null;
+    };
 
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
-    },
-    [reportSidebarWidth],
-  );
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, [reportSidebarWidth]);
 
   useEffect(() => {
     localStorage.setItem("sidebar-width", String(sidebarWidth));
@@ -1110,7 +1129,9 @@ export default function App() {
         const session = currentChromecast.session;
         const device =
           currentChromecast.devices.find((d) => d.id === session.deviceId) ??
-          (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
+          (lastCastDeviceRef.current?.id === session.deviceId
+            ? lastCastDeviceRef.current
+            : null);
         if (device) {
           void currentChromecast.cast(device, buildCastRequest(result));
           return;
@@ -1148,10 +1169,7 @@ export default function App() {
   }, [pendingPlaybackChannel, playStream]);
 
   // Merge player-derived metadata into ChannelResult for unscanned channels
-  const lastMergedMetaRef = useRef<{
-    index: number;
-    meta: typeof streamPlayer.streamMetadata;
-  } | null>(null);
+  const lastMergedMetaRef = useRef<{ index: number; meta: typeof streamPlayer.streamMetadata } | null>(null);
   useEffect(() => {
     const meta = streamPlayer.streamMetadata;
     const idx = streamPlayer.activeChannelIndex;
@@ -1169,38 +1187,14 @@ export default function App() {
     let changed = false;
     const updated = { ...existing };
 
-    if (meta.width != null && existing.width == null) {
-      updated.width = meta.width;
-      changed = true;
-    }
-    if (meta.height != null && existing.height == null) {
-      updated.height = meta.height;
-      changed = true;
-    }
-    if (meta.resolution && !existing.resolution) {
-      updated.resolution = meta.resolution;
-      changed = true;
-    }
-    if (meta.codec && !existing.codec) {
-      updated.codec = meta.codec;
-      changed = true;
-    }
-    if (meta.fps != null && existing.fps == null) {
-      updated.fps = meta.fps;
-      changed = true;
-    }
-    if (meta.videoBitrate && !existing.video_bitrate) {
-      updated.video_bitrate = meta.videoBitrate;
-      changed = true;
-    }
-    if (meta.audioCodec && !existing.audio_codec) {
-      updated.audio_codec = meta.audioCodec;
-      changed = true;
-    }
-    if (meta.audioBitrate && !existing.audio_bitrate) {
-      updated.audio_bitrate = meta.audioBitrate;
-      changed = true;
-    }
+    if (meta.width != null && existing.width == null) { updated.width = meta.width; changed = true; }
+    if (meta.height != null && existing.height == null) { updated.height = meta.height; changed = true; }
+    if (meta.resolution && !existing.resolution) { updated.resolution = meta.resolution; changed = true; }
+    if (meta.codec && !existing.codec) { updated.codec = meta.codec; changed = true; }
+    if (meta.fps != null && existing.fps == null) { updated.fps = meta.fps; changed = true; }
+    if (meta.videoBitrate && !existing.video_bitrate) { updated.video_bitrate = meta.videoBitrate; changed = true; }
+    if (meta.audioCodec && !existing.audio_codec) { updated.audio_codec = meta.audioCodec; changed = true; }
+    if (meta.audioBitrate && !existing.audio_bitrate) { updated.audio_bitrate = meta.audioBitrate; changed = true; }
 
     if (changed) {
       updateResult(updated);
@@ -1221,7 +1215,9 @@ export default function App() {
         if (state.flatResults.length > 0) {
           getStore().setSelectedChannel(state.flatResults[0]);
         } else if (state.playlist && state.playlist.channels.length > 0) {
-          getStore().setSelectedChannel(toPendingChannelResult(state.playlist.channels[0]));
+          getStore().setSelectedChannel(
+            toPendingChannelResult(state.playlist.channels[0]),
+          );
         }
       }
       getStore().setSidebarHidden(false);
@@ -1270,7 +1266,13 @@ export default function App() {
       handleStartScan,
       cancel,
     };
-  }, [handleOpen, handleOpenSettings, handleOpenLog, handleStartScan, cancel]);
+  }, [
+    handleOpen,
+    handleOpenSettings,
+    handleOpenLog,
+    handleStartScan,
+    cancel,
+  ]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -1315,7 +1317,14 @@ export default function App() {
         }
         return;
       }
-      if (!e.repeat && e.key === " " && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      if (
+        !e.repeat &&
+        e.key === " " &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.shiftKey &&
+        !e.altKey
+      ) {
         if (inputLikeTarget) return;
         e.preventDefault();
         getStore().toggleLightboxOpen();
@@ -1376,7 +1385,8 @@ export default function App() {
   const headerPortalRef = useRef<HTMLDivElement>(null);
   const [toolbarHeight, setToolbarHeight] = useState(0);
   const tableProfilerEnabled =
-    uiPerfEnabled() && (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
+    uiPerfEnabled() &&
+    (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
   const channelTableElement = (
     <ChannelTable
       onSelectChannel={handleSelectChannel}
@@ -1394,7 +1404,9 @@ export default function App() {
     if (!el) return;
     const update = () => {
       const nextToolbarHeight = el.offsetHeight;
-      setToolbarHeight((prev) => (prev === nextToolbarHeight ? prev : nextToolbarHeight));
+      setToolbarHeight((prev) =>
+        prev === nextToolbarHeight ? prev : nextToolbarHeight,
+      );
     };
     update();
     const observer = new ResizeObserver(update);
@@ -1404,14 +1416,22 @@ export default function App() {
 
   const tableChromeStyle = isMac
     ? {
-        marginLeft: liveSelectedChannel && !sidebarHidden ? `${sidebarWidth}px` : undefined,
-        marginRight: playlist && showReportPanel ? `${reportSidebarWidth}px` : undefined,
+        marginLeft:
+          liveSelectedChannel && !sidebarHidden
+            ? `${sidebarWidth}px`
+            : undefined,
+        marginRight:
+          playlist && showReportPanel
+            ? `${reportSidebarWidth}px`
+            : undefined,
       }
     : undefined;
 
   return (
     <div className="flex flex-col h-screen bg-surface">
-      <ScanRuntimeEffects refreshHistory={refreshHistory} />
+      <ScanRuntimeEffects
+        refreshHistory={refreshHistory}
+      />
       <div
         ref={toolbarMeasureRef}
         className={`relative z-20 ${isMac && playlist ? "glass-material bg-panel" : ""} ${isMac && !playlist ? "pb-4" : ""}`}
@@ -1447,73 +1467,73 @@ export default function App() {
       </div>
 
       <div className="flex flex-col flex-1 min-h-0">
-        {ffmpegWarning && (
-          <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
-            <AlertTriangle className="w-4 h-4" />
-            ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
-          </div>
-        )}
-        <ScanPauseBanners />
-
-        <AppBanners />
-
-        <div className="flex flex-col flex-1 min-h-0">
-          <div className="flex flex-1 min-h-0 bg-content">
-            {liveSelectedChannel && !sidebarHidden && (
-              <SelectedChannelSidebar
-                sidebarWidth={sidebarWidth}
-                onResizeStart={handleSidebarDragStart}
-                streamPlayer={streamPlayer}
-                chromecast={chromecast}
-                onPlayChannel={handlePlayInApp}
-                onScanChannel={handleScanSelected}
-                onStopPlayer={handleStopPlayer}
-                onOpenExternal={handleOpenExternal}
-                onPip={handlePip}
-              />
-            )}
-            <div className="flex flex-col flex-1 min-w-0">
-              {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
-              {playlist ? (
-                tableProfilerEnabled ? (
-                  <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
-                    {channelTableElement}
-                  </Profiler>
-                ) : (
-                  channelTableElement
-                )
-              ) : (
-                <StartScreen
-                  playlistLoading={playlistLoading}
-                  playlistLoadProgress={playlistLoadProgress}
-                  modKey={modKey}
-                  recentPlaylists={recentPlaylists}
-                  savedPlaylists={savedPlaylists}
-                  onOpen={handleOpen}
-                  onOpenFolder={handleOpenFolder}
-                  onOpenUrl={handleOpenUrl}
-                  onOpenXtream={handleOpenXtream}
-                  onManageSavedPlaylists={handleManageSavedPlaylists}
-                  onOpenSaved={handleOpenSaved}
-                  onOpenRecent={handleOpenRecent}
-                  onClearRecent={handleClearRecentPlaylists}
-                />
-              )}
-            </div>
-
-            {playlist && showReportPanel && (
-              <PlaylistReportPanel
-                placement="right"
-                widthPx={reportSidebarWidth}
-                onResizeStart={handleReportSidebarDragStart}
-                onClose={handleCloseReport}
-              />
-            )}
-          </div>
-
-          <StatsPanel />
-          <ProgressBar />
+      {ffmpegWarning && (
+        <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
+          <AlertTriangle className="w-4 h-4" />
+          ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
         </div>
+      )}
+      <ScanPauseBanners />
+
+      <AppBanners onInstallUpdate={installUpdate} />
+
+      <div className="flex flex-col flex-1 min-h-0">
+        <div className="flex flex-1 min-h-0 bg-content">
+          {liveSelectedChannel && !sidebarHidden && (
+            <SelectedChannelSidebar
+              sidebarWidth={sidebarWidth}
+              onResizeStart={handleSidebarDragStart}
+              streamPlayer={streamPlayer}
+              chromecast={chromecast}
+              onPlayChannel={handlePlayInApp}
+              onScanChannel={handleScanSelected}
+              onStopPlayer={handleStopPlayer}
+              onOpenExternal={handleOpenExternal}
+              onPip={handlePip}
+            />
+          )}
+          <div className="flex flex-col flex-1 min-w-0">
+            {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
+            {playlist ? (
+              tableProfilerEnabled ? (
+                <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
+                  {channelTableElement}
+                </Profiler>
+              ) : (
+                channelTableElement
+              )
+            ) : (
+              <StartScreen
+                playlistLoading={playlistLoading}
+                playlistLoadProgress={playlistLoadProgress}
+                modKey={modKey}
+                recentPlaylists={recentPlaylists}
+                savedPlaylists={savedPlaylists}
+                onOpen={handleOpen}
+                onOpenFolder={handleOpenFolder}
+                onOpenUrl={handleOpenUrl}
+                onOpenXtream={handleOpenXtream}
+                onManageSavedPlaylists={handleManageSavedPlaylists}
+                onOpenSaved={handleOpenSaved}
+                onOpenRecent={handleOpenRecent}
+                onClearRecent={handleClearRecentPlaylists}
+              />
+            )}
+        </div>
+
+        {playlist && showReportPanel && (
+          <PlaylistReportPanel
+            placement="right"
+            widthPx={reportSidebarWidth}
+            onResizeStart={handleReportSidebarDragStart}
+            onClose={handleCloseReport}
+          />
+        )}
+      </div>
+
+      <StatsPanel />
+      <ProgressBar />
+      </div>
       </div>
 
       {openSourceDialogState && (
@@ -1615,10 +1635,13 @@ export default function App() {
       {pendingPlaybackChannel && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
           <div className="w-full max-w-xl rounded-xl border border-border-app bg-overlay p-5 shadow-2xl">
-            <h2 className="text-[16px] font-semibold mb-2">Scan currently running</h2>
+            <h2 className="text-[16px] font-semibold mb-2">
+              Scan currently running
+            </h2>
             <p className="text-[14px] text-text-secondary leading-relaxed">
-              A scan is currently running. Playing a channel while scanning may interfere with the
-              scan or cause playback issues if the server&apos;s max connection limit is exceeded.
+              A scan is currently running. Playing a channel while scanning may
+              interfere with the scan or cause playback issues if the server&apos;s
+              max connection limit is exceeded.
             </p>
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
@@ -1639,6 +1662,7 @@ export default function App() {
           </div>
         </div>
       )}
+
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ import {
   readScreenshot,
 } from "./lib/tauri";
 import type { AppSettings, ChannelResult, ChromecastDevice, ScanConfig } from "./lib/types";
-import { useAppStore } from "./store";
+import { selectResultByIndex, useAppStore } from "./store";
 import type { AppStore, OpenSourceDialogState } from "./store/types";
 
 const KeyboardShortcutsDialog = lazy(() => import("./components/KeyboardShortcutsDialog"));
@@ -131,7 +131,7 @@ async function canSendNotifications(requiresPermission: boolean): Promise<boolea
 
 const selectLiveSelectedChannel = (state: AppStore): ChannelResult | null => {
   const selected = state.selectedChannel;
-  return selected ? (state.results[selected.index] ?? selected) : null;
+  return selected ? (selectResultByIndex(state, selected.index) ?? selected) : null;
 };
 
 type StreamPlayerController = ReturnType<typeof useStreamPlayer>;
@@ -1163,7 +1163,7 @@ export default function App() {
     lastMergedMetaRef.current = { index: idx, meta };
 
     const state = getStore();
-    const existing = state.results[idx];
+    const existing = selectResultByIndex(state, idx);
     if (!existing) return;
 
     let changed = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
+import { listen } from "@tauri-apps/api/event";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
+import {
+  isPermissionGranted,
+  onAction,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
 import {
   lazy,
   Profiler,
+  type ProfilerOnRenderCallback,
   Suspense,
   useCallback,
   useEffect,
@@ -8,47 +18,37 @@ import {
   useMemo,
   useRef,
   useState,
-  type ProfilerOnRenderCallback,
 } from "react";
-import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { setLiquidGlassEffect } from "tauri-plugin-liquid-glass-api";
-import {
-  isPermissionGranted,
-  onAction,
-  requestPermission,
-  sendNotification,
-} from "@tauri-apps/plugin-notification";
-import type { AppSettings, ChannelResult, ScanConfig } from "./lib/types";
-import {
-  clearScanHistory,
-  getScanHistory,
-  checkFfmpegAvailable,
-  readScreenshot,
-  openChannelInPlayer,
-  quickCheckChannel,
-} from "./lib/tauri";
+import { AppBanners } from "./components/AppBanners";
+import { ChannelTable } from "./components/ChannelTable";
+import { FilterBar } from "./components/FilterBar";
+import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
+import { ProgressBar } from "./components/ProgressBar";
+import { StartScreen } from "./components/StartScreen";
+import { StatsPanel } from "./components/StatsPanel";
+import { ThumbnailPanel } from "./components/ThumbnailPanel";
+import { Toolbar } from "./components/Toolbar";
+import { type UseChromecastResult, useChromecast } from "./hooks/useChromecast";
+import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
+import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
-import { useChromecast, type UseChromecastResult } from "./hooks/useChromecast";
 import { useStreamPlayer } from "./hooks/useStreamPlayer";
-import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
-import type { ChromecastDevice } from "./lib/types";
+import {
+  checkFfmpegAvailable,
+  clearScanHistory,
+  getScanHistory,
+  openChannelInPlayer,
+  quickCheckChannel,
+  readScreenshot,
+} from "./lib/tauri";
+import type { AppSettings, ChannelResult, ChromecastDevice, ScanConfig } from "./lib/types";
 import { useAppStore } from "./store";
 import type { AppStore, OpenSourceDialogState } from "./store/types";
-import { Toolbar } from "./components/Toolbar";
-import { FilterBar } from "./components/FilterBar";
-import { ChannelTable } from "./components/ChannelTable";
-import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
-import { ThumbnailPanel } from "./components/ThumbnailPanel";
-import { StatsPanel } from "./components/StatsPanel";
-import { ProgressBar } from "./components/ProgressBar";
-import { AppBanners } from "./components/AppBanners";
-import { StartScreen } from "./components/StartScreen";
+
 const KeyboardShortcutsDialog = lazy(() => import("./components/KeyboardShortcutsDialog"));
 const HistoryPanel = lazy(() => import("./components/HistoryPanel"));
 const OpenSourceDialog = lazy(() => import("./components/OpenSourceDialog"));
@@ -58,23 +58,19 @@ const XtreamServerTestDialog = lazy(() =>
   })),
 );
 const SavedPlaylistsDialog = lazy(() => import("./components/SavedPlaylistsDialog"));
-const SavedPlaylistEditorDialog = lazy(
-  () => import("./components/SavedPlaylistEditorDialog"),
-);
+const SavedPlaylistEditorDialog = lazy(() => import("./components/SavedPlaylistEditorDialog"));
+
 import { AlertTriangle } from "lucide-react";
-import { detectPlatform } from "./lib/platform";
-import { logger } from "./lib/logger";
+import { toPendingChannelResult } from "./lib/channelResults";
 import { errorToString } from "./lib/errors";
 import { HapticFeedbackPattern, PerformanceTime, triggerHaptic } from "./lib/haptics";
-import { toPendingChannelResult } from "./lib/channelResults";
+import { logger } from "./lib/logger";
+import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
+import { detectPlatform } from "./lib/platform";
+import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
 import { isScanActive } from "./lib/scanState";
 import { isInputLikeTarget, isPrimaryModifierPressed } from "./lib/shortcuts";
-import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
-import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
-import {
-  normalizeSourceFilter,
-  validateSourceFilterPattern,
-} from "./lib/sourceFilter";
+import { normalizeSourceFilter, validateSourceFilterPattern } from "./lib/sourceFilter";
 
 async function restoreAndFocusWindow(window: {
   unminimize: () => Promise<void>;
@@ -156,7 +152,9 @@ function ScanPauseBanners() {
       {networkPaused && isScanActive(scanState) && (
         <div className="flex items-center gap-2 px-4 py-2 bg-orange-500/10 border-b border-orange-500/20 text-orange-400 text-[13px]">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span className="flex-1">Scan paused — network connectivity lost. Waiting for recovery...</span>
+          <span className="flex-1">
+            Scan paused — network connectivity lost. Waiting for recovery...
+          </span>
         </div>
       )}
     </>
@@ -302,11 +300,7 @@ function SelectedChannelSidebar({
   );
 }
 
-function ScanRuntimeEffects({
-  refreshHistory,
-}: {
-  refreshHistory: () => Promise<void>;
-}) {
+function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<void> }) {
   const playlist = useAppStore((s) => s.playlist);
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
@@ -327,9 +321,7 @@ function ScanRuntimeEffects({
 
   useEffect(() => {
     const previous = reportAutoRevealPreviousScanStateRef.current;
-    const scanJustStarted =
-      scanState === "scanning" &&
-      !isScanActive(previous);
+    const scanJustStarted = scanState === "scanning" && !isScanActive(previous);
 
     if (scanJustStarted) {
       getStore().prepareReportAutoRevealForScanStart();
@@ -350,10 +342,7 @@ function ScanRuntimeEffects({
       return;
     }
 
-    const active =
-      scanState === "scanning" ||
-      scanState === "paused" ||
-      scanState === "complete";
+    const active = scanState === "scanning" || scanState === "paused" || scanState === "complete";
     if (!active) {
       return;
     }
@@ -376,10 +365,7 @@ function ScanRuntimeEffects({
     if (!justFinished) return;
 
     if (scanState === "complete") {
-      void triggerHaptic(
-        HapticFeedbackPattern.Generic,
-        PerformanceTime.DrawCompleted,
-      );
+      void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.DrawCompleted);
     }
 
     if (!scanNotifications || !summary) return;
@@ -418,14 +404,13 @@ function ScanRuntimeEffects({
         progress && progress.total > 0
           ? Math.min(100, Math.max(0, (progress.completed / progress.total) * 100))
           : 0;
-      const status =
-        networkPaused
-          ? ProgressBarStatus.Error
-          : scanState === "paused"
-            ? ProgressBarStatus.Paused
-            : progress
-              ? ProgressBarStatus.Normal
-              : ProgressBarStatus.Indeterminate;
+      const status = networkPaused
+        ? ProgressBarStatus.Error
+        : scanState === "paused"
+          ? ProgressBarStatus.Paused
+          : progress
+            ? ProgressBarStatus.Normal
+            : ProgressBarStatus.Indeterminate;
 
       void appWindow
         .setProgressBar({
@@ -435,9 +420,7 @@ function ScanRuntimeEffects({
         .catch(() => {});
 
       if (isMac) {
-        const badgeLabel = progress
-          ? `${progress.alive + progress.drm}/${progress.dead}`
-          : "...";
+        const badgeLabel = progress ? `${progress.alive + progress.drm}/${progress.dead}` : "...";
         void appWindow.setBadgeLabel(badgeLabel).catch(() => {});
       }
     };
@@ -461,8 +444,7 @@ function ScanRuntimeEffects({
       const now = Date.now();
       const elapsed = now - lastOsProgressUpdateMsRef.current;
       const shouldUpdateNow =
-        lastOsProgressUpdateMsRef.current === 0 ||
-        elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
+        lastOsProgressUpdateMsRef.current === 0 || elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
 
       clearScheduledUpdate();
       if (shouldUpdateNow) {
@@ -580,15 +562,8 @@ export default function App() {
   const isCasting = isCastSessionActive(castSession);
 
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
-  const {
-    start,
-    cancel,
-    pause,
-    resume,
-    initFromPlaylist,
-    syncFromPlaylist,
-    updateResult,
-  } = useScan();
+  const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
+    useScan();
   const { checkForUpdates, installUpdate } = useUpdateCheck();
   const {
     handleClearRecentPlaylists,
@@ -637,7 +612,9 @@ export default function App() {
   useEffect(() => {
     const title = playlist ? `${playlist.file_name} | IPTV Checker` : "IPTV Checker";
     document.title = title;
-    void getCurrentWindow().setTitle(title).catch(() => {});
+    void getCurrentWindow()
+      .setTitle(title)
+      .catch(() => {});
   }, [playlist]);
 
   // Detect platform via native plugin and refresh the initial fallback.
@@ -728,10 +705,7 @@ export default function App() {
     getStore().setHistoryLoading(true);
     getStore().setHistoryError(null);
     try {
-      const items = await getScanHistory(
-        playlist.file_path,
-        playlist.source_identity,
-      );
+      const items = await getScanHistory(playlist.file_path, playlist.source_identity);
       getStore().setHistoryEntries(items);
     } catch (err) {
       getStore().setHistoryError(errorToString(err));
@@ -805,32 +779,36 @@ export default function App() {
     void refreshHistory();
   }, [playlist, refreshHistory]);
 
-  const handleExternalOpenPaths = useCallback((paths: string[]) => {
-    const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
-    if (!targetPath) {
-      return;
-    }
+  const handleExternalOpenPaths = useCallback(
+    (paths: string[]) => {
+      const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
+      if (!targetPath) {
+        return;
+      }
 
-    if (paths.length > 1) {
-      getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
-    }
+      if (paths.length > 1) {
+        getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
+      }
 
-    void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
-    void openPlaylistPath(targetPath);
-  }, [openPlaylistPath]);
+      void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
+      void openPlaylistPath(targetPath);
+    },
+    [openPlaylistPath],
+  );
 
-  const handleDroppedPaths = useCallback((paths: string[]) => {
-    const playlistPath = paths.find((path) =>
-      isPlaylistLikePath(path),
-    );
+  const handleDroppedPaths = useCallback(
+    (paths: string[]) => {
+      const playlistPath = paths.find((path) => isPlaylistLikePath(path));
 
-    if (!playlistPath) {
-      getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
-      return;
-    }
+      if (!playlistPath) {
+        getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
+        return;
+      }
 
-    void openPlaylistPath(playlistPath);
-  }, [openPlaylistPath]);
+      void openPlaylistPath(playlistPath);
+    },
+    [openPlaylistPath],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -882,69 +860,66 @@ export default function App() {
     return () => window.removeEventListener("contextmenu", handler);
   }, []);
 
-  const startScanWithSelection = useCallback(async (selection: number[]) => {
-    const state = getStore();
-    const currentChannelSearchError = validateSourceFilterPattern(
-      state.channelSearch,
-    );
+  const startScanWithSelection = useCallback(
+    async (selection: number[]) => {
+      const state = getStore();
+      const currentChannelSearchError = validateSourceFilterPattern(state.channelSearch);
 
-    if (currentChannelSearchError) {
-      state.setScanInputError(
-        `Invalid source filter regex: ${currentChannelSearchError}`,
-      );
-      return false;
-    }
+      if (currentChannelSearchError) {
+        state.setScanInputError(`Invalid source filter regex: ${currentChannelSearchError}`);
+        return false;
+      }
 
-    const applyResult = await ensureSourceFilterApplied();
-    if (!applyResult.ok) {
-      return false;
-    }
+      const applyResult = await ensureSourceFilterApplied();
+      if (!applyResult.ok) {
+        return false;
+      }
 
-    const refreshedState = getStore();
-    const currentPlaylist = refreshedState.playlist;
-    const currentChannelSearch = normalizeSourceFilter(
-      refreshedState.channelSearch,
-    );
-    const currentGroupFilter = refreshedState.groupFilter;
-    const currentSettings = refreshedState.settings;
-    const effectiveSelection = applyResult.reapplied ? [] : selection;
+      const refreshedState = getStore();
+      const currentPlaylist = refreshedState.playlist;
+      const currentChannelSearch = normalizeSourceFilter(refreshedState.channelSearch);
+      const currentGroupFilter = refreshedState.groupFilter;
+      const currentSettings = refreshedState.settings;
+      const effectiveSelection = applyResult.reapplied ? [] : selection;
 
-    if (!currentPlaylist) return false;
+      if (!currentPlaylist) return false;
 
-    const config: ScanConfig = {
-      file_path: currentPlaylist.file_path,
-      source_identity: currentPlaylist.source_identity ?? null,
-      playlist_display_name: currentPlaylist.file_name,
-      group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
-      channel_search: currentChannelSearch || null,
-      selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
-      hide_vod_content: currentSettings.hide_vod_content,
-      timeout: currentSettings.timeout,
-      extended_timeout: currentSettings.extended_timeout,
-      concurrency: resolveSmartConcurrency(
-        currentSettings.concurrency,
-        currentPlaylist.single_provider,
-        currentPlaylist.xtream_max_connections ?? null,
-      ),
-      retries: currentSettings.retries,
-      retry_backoff: currentSettings.retry_backoff,
-      user_agent: currentSettings.user_agent,
-      skip_screenshots: currentSettings.skip_screenshots,
-      profile_bitrate: currentSettings.profile_bitrate,
-      ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
-      ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
-      accept_invalid_certs: currentSettings.accept_invalid_certs,
-      proxy_file: currentSettings.proxy_file,
-      test_geoblock: currentSettings.test_geoblock,
-      screenshots_dir: currentSettings.screenshots_dir,
-      client_capabilities: {
-        event_batch_v1: true,
-      },
-    };
+      const config: ScanConfig = {
+        file_path: currentPlaylist.file_path,
+        source_identity: currentPlaylist.source_identity ?? null,
+        playlist_display_name: currentPlaylist.file_name,
+        group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
+        channel_search: currentChannelSearch || null,
+        selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
+        hide_vod_content: currentSettings.hide_vod_content,
+        timeout: currentSettings.timeout,
+        extended_timeout: currentSettings.extended_timeout,
+        concurrency: resolveSmartConcurrency(
+          currentSettings.concurrency,
+          currentPlaylist.single_provider,
+          currentPlaylist.xtream_max_connections ?? null,
+        ),
+        retries: currentSettings.retries,
+        retry_backoff: currentSettings.retry_backoff,
+        user_agent: currentSettings.user_agent,
+        skip_screenshots: currentSettings.skip_screenshots,
+        profile_bitrate: currentSettings.profile_bitrate,
+        ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
+        ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
+        accept_invalid_certs: currentSettings.accept_invalid_certs,
+        proxy_file: currentSettings.proxy_file,
+        test_geoblock: currentSettings.test_geoblock,
+        screenshots_dir: currentSettings.screenshots_dir,
+        client_capabilities: {
+          event_batch_v1: true,
+        },
+      };
 
-    await start(config, currentPlaylist.total_channels, effectiveSelection);
-    return true;
-  }, [ensureSourceFilterApplied, start]);
+      await start(config, currentPlaylist.total_channels, effectiveSelection);
+      return true;
+    },
+    [ensureSourceFilterApplied, start],
+  );
 
   const handleStartScan = useCallback(async () => {
     const started = await startScanWithSelection(getStore().selectedChannelIndices);
@@ -975,61 +950,67 @@ export default function App() {
     );
   };
 
-  const handleSidebarDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+  const handleSidebarDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
 
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!sidebarDragRef.current) return;
-      const delta = ev.clientX - sidebarDragRef.current.startX;
-      const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
-      getStore().setSidebarWidth(newWidth);
-    };
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!sidebarDragRef.current) return;
+        const delta = ev.clientX - sidebarDragRef.current.startX;
+        const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
+        getStore().setSidebarWidth(newWidth);
+      };
 
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      sidebarDragRef.current = null;
-    };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        sidebarDragRef.current = null;
+      };
 
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, [sidebarWidth]);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [sidebarWidth],
+  );
 
-  const handleReportSidebarDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    reportSidebarDragRef.current = {
-      startX: e.clientX,
-      startWidth: reportSidebarWidth,
-    };
+  const handleReportSidebarDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      reportSidebarDragRef.current = {
+        startX: e.clientX,
+        startWidth: reportSidebarWidth,
+      };
 
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!reportSidebarDragRef.current) return;
-      const delta = reportSidebarDragRef.current.startX - ev.clientX;
-      const newWidth = Math.max(
-        260,
-        Math.min(700, reportSidebarDragRef.current.startWidth + delta),
-      );
-      getStore().setReportSidebarWidth(newWidth);
-    };
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!reportSidebarDragRef.current) return;
+        const delta = reportSidebarDragRef.current.startX - ev.clientX;
+        const newWidth = Math.max(
+          260,
+          Math.min(700, reportSidebarDragRef.current.startWidth + delta),
+        );
+        getStore().setReportSidebarWidth(newWidth);
+      };
 
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      reportSidebarDragRef.current = null;
-    };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        reportSidebarDragRef.current = null;
+      };
 
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, [reportSidebarWidth]);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [reportSidebarWidth],
+  );
 
   useEffect(() => {
     localStorage.setItem("sidebar-width", String(sidebarWidth));
@@ -1129,9 +1110,7 @@ export default function App() {
         const session = currentChromecast.session;
         const device =
           currentChromecast.devices.find((d) => d.id === session.deviceId) ??
-          (lastCastDeviceRef.current?.id === session.deviceId
-            ? lastCastDeviceRef.current
-            : null);
+          (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
         if (device) {
           void currentChromecast.cast(device, buildCastRequest(result));
           return;
@@ -1169,7 +1148,10 @@ export default function App() {
   }, [pendingPlaybackChannel, playStream]);
 
   // Merge player-derived metadata into ChannelResult for unscanned channels
-  const lastMergedMetaRef = useRef<{ index: number; meta: typeof streamPlayer.streamMetadata } | null>(null);
+  const lastMergedMetaRef = useRef<{
+    index: number;
+    meta: typeof streamPlayer.streamMetadata;
+  } | null>(null);
   useEffect(() => {
     const meta = streamPlayer.streamMetadata;
     const idx = streamPlayer.activeChannelIndex;
@@ -1187,14 +1169,38 @@ export default function App() {
     let changed = false;
     const updated = { ...existing };
 
-    if (meta.width != null && existing.width == null) { updated.width = meta.width; changed = true; }
-    if (meta.height != null && existing.height == null) { updated.height = meta.height; changed = true; }
-    if (meta.resolution && !existing.resolution) { updated.resolution = meta.resolution; changed = true; }
-    if (meta.codec && !existing.codec) { updated.codec = meta.codec; changed = true; }
-    if (meta.fps != null && existing.fps == null) { updated.fps = meta.fps; changed = true; }
-    if (meta.videoBitrate && !existing.video_bitrate) { updated.video_bitrate = meta.videoBitrate; changed = true; }
-    if (meta.audioCodec && !existing.audio_codec) { updated.audio_codec = meta.audioCodec; changed = true; }
-    if (meta.audioBitrate && !existing.audio_bitrate) { updated.audio_bitrate = meta.audioBitrate; changed = true; }
+    if (meta.width != null && existing.width == null) {
+      updated.width = meta.width;
+      changed = true;
+    }
+    if (meta.height != null && existing.height == null) {
+      updated.height = meta.height;
+      changed = true;
+    }
+    if (meta.resolution && !existing.resolution) {
+      updated.resolution = meta.resolution;
+      changed = true;
+    }
+    if (meta.codec && !existing.codec) {
+      updated.codec = meta.codec;
+      changed = true;
+    }
+    if (meta.fps != null && existing.fps == null) {
+      updated.fps = meta.fps;
+      changed = true;
+    }
+    if (meta.videoBitrate && !existing.video_bitrate) {
+      updated.video_bitrate = meta.videoBitrate;
+      changed = true;
+    }
+    if (meta.audioCodec && !existing.audio_codec) {
+      updated.audio_codec = meta.audioCodec;
+      changed = true;
+    }
+    if (meta.audioBitrate && !existing.audio_bitrate) {
+      updated.audio_bitrate = meta.audioBitrate;
+      changed = true;
+    }
 
     if (changed) {
       updateResult(updated);
@@ -1215,9 +1221,7 @@ export default function App() {
         if (state.flatResults.length > 0) {
           getStore().setSelectedChannel(state.flatResults[0]);
         } else if (state.playlist && state.playlist.channels.length > 0) {
-          getStore().setSelectedChannel(
-            toPendingChannelResult(state.playlist.channels[0]),
-          );
+          getStore().setSelectedChannel(toPendingChannelResult(state.playlist.channels[0]));
         }
       }
       getStore().setSidebarHidden(false);
@@ -1266,13 +1270,7 @@ export default function App() {
       handleStartScan,
       cancel,
     };
-  }, [
-    handleOpen,
-    handleOpenSettings,
-    handleOpenLog,
-    handleStartScan,
-    cancel,
-  ]);
+  }, [handleOpen, handleOpenSettings, handleOpenLog, handleStartScan, cancel]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -1317,14 +1315,7 @@ export default function App() {
         }
         return;
       }
-      if (
-        !e.repeat &&
-        e.key === " " &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.shiftKey &&
-        !e.altKey
-      ) {
+      if (!e.repeat && e.key === " " && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         if (inputLikeTarget) return;
         e.preventDefault();
         getStore().toggleLightboxOpen();
@@ -1385,8 +1376,7 @@ export default function App() {
   const headerPortalRef = useRef<HTMLDivElement>(null);
   const [toolbarHeight, setToolbarHeight] = useState(0);
   const tableProfilerEnabled =
-    uiPerfEnabled() &&
-    (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
+    uiPerfEnabled() && (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
   const channelTableElement = (
     <ChannelTable
       onSelectChannel={handleSelectChannel}
@@ -1404,9 +1394,7 @@ export default function App() {
     if (!el) return;
     const update = () => {
       const nextToolbarHeight = el.offsetHeight;
-      setToolbarHeight((prev) =>
-        prev === nextToolbarHeight ? prev : nextToolbarHeight,
-      );
+      setToolbarHeight((prev) => (prev === nextToolbarHeight ? prev : nextToolbarHeight));
     };
     update();
     const observer = new ResizeObserver(update);
@@ -1416,22 +1404,14 @@ export default function App() {
 
   const tableChromeStyle = isMac
     ? {
-        marginLeft:
-          liveSelectedChannel && !sidebarHidden
-            ? `${sidebarWidth}px`
-            : undefined,
-        marginRight:
-          playlist && showReportPanel
-            ? `${reportSidebarWidth}px`
-            : undefined,
+        marginLeft: liveSelectedChannel && !sidebarHidden ? `${sidebarWidth}px` : undefined,
+        marginRight: playlist && showReportPanel ? `${reportSidebarWidth}px` : undefined,
       }
     : undefined;
 
   return (
     <div className="flex flex-col h-screen bg-surface">
-      <ScanRuntimeEffects
-        refreshHistory={refreshHistory}
-      />
+      <ScanRuntimeEffects refreshHistory={refreshHistory} />
       <div
         ref={toolbarMeasureRef}
         className={`relative z-20 ${isMac && playlist ? "glass-material bg-panel" : ""} ${isMac && !playlist ? "pb-4" : ""}`}
@@ -1467,73 +1447,73 @@ export default function App() {
       </div>
 
       <div className="flex flex-col flex-1 min-h-0">
-      {ffmpegWarning && (
-        <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
-          <AlertTriangle className="w-4 h-4" />
-          ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
-        </div>
-      )}
-      <ScanPauseBanners />
+        {ffmpegWarning && (
+          <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
+            <AlertTriangle className="w-4 h-4" />
+            ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
+          </div>
+        )}
+        <ScanPauseBanners />
 
-      <AppBanners onInstallUpdate={installUpdate} />
+        <AppBanners onInstallUpdate={installUpdate} />
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="flex flex-1 min-h-0 bg-content">
-          {liveSelectedChannel && !sidebarHidden && (
-            <SelectedChannelSidebar
-              sidebarWidth={sidebarWidth}
-              onResizeStart={handleSidebarDragStart}
-              streamPlayer={streamPlayer}
-              chromecast={chromecast}
-              onPlayChannel={handlePlayInApp}
-              onScanChannel={handleScanSelected}
-              onStopPlayer={handleStopPlayer}
-              onOpenExternal={handleOpenExternal}
-              onPip={handlePip}
-            />
-          )}
-          <div className="flex flex-col flex-1 min-w-0">
-            {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
-            {playlist ? (
-              tableProfilerEnabled ? (
-                <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
-                  {channelTableElement}
-                </Profiler>
-              ) : (
-                channelTableElement
-              )
-            ) : (
-              <StartScreen
-                playlistLoading={playlistLoading}
-                playlistLoadProgress={playlistLoadProgress}
-                modKey={modKey}
-                recentPlaylists={recentPlaylists}
-                savedPlaylists={savedPlaylists}
-                onOpen={handleOpen}
-                onOpenFolder={handleOpenFolder}
-                onOpenUrl={handleOpenUrl}
-                onOpenXtream={handleOpenXtream}
-                onManageSavedPlaylists={handleManageSavedPlaylists}
-                onOpenSaved={handleOpenSaved}
-                onOpenRecent={handleOpenRecent}
-                onClearRecent={handleClearRecentPlaylists}
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="flex flex-1 min-h-0 bg-content">
+            {liveSelectedChannel && !sidebarHidden && (
+              <SelectedChannelSidebar
+                sidebarWidth={sidebarWidth}
+                onResizeStart={handleSidebarDragStart}
+                streamPlayer={streamPlayer}
+                chromecast={chromecast}
+                onPlayChannel={handlePlayInApp}
+                onScanChannel={handleScanSelected}
+                onStopPlayer={handleStopPlayer}
+                onOpenExternal={handleOpenExternal}
+                onPip={handlePip}
               />
             )}
+            <div className="flex flex-col flex-1 min-w-0">
+              {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
+              {playlist ? (
+                tableProfilerEnabled ? (
+                  <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
+                    {channelTableElement}
+                  </Profiler>
+                ) : (
+                  channelTableElement
+                )
+              ) : (
+                <StartScreen
+                  playlistLoading={playlistLoading}
+                  playlistLoadProgress={playlistLoadProgress}
+                  modKey={modKey}
+                  recentPlaylists={recentPlaylists}
+                  savedPlaylists={savedPlaylists}
+                  onOpen={handleOpen}
+                  onOpenFolder={handleOpenFolder}
+                  onOpenUrl={handleOpenUrl}
+                  onOpenXtream={handleOpenXtream}
+                  onManageSavedPlaylists={handleManageSavedPlaylists}
+                  onOpenSaved={handleOpenSaved}
+                  onOpenRecent={handleOpenRecent}
+                  onClearRecent={handleClearRecentPlaylists}
+                />
+              )}
+            </div>
+
+            {playlist && showReportPanel && (
+              <PlaylistReportPanel
+                placement="right"
+                widthPx={reportSidebarWidth}
+                onResizeStart={handleReportSidebarDragStart}
+                onClose={handleCloseReport}
+              />
+            )}
+          </div>
+
+          <StatsPanel />
+          <ProgressBar />
         </div>
-
-        {playlist && showReportPanel && (
-          <PlaylistReportPanel
-            placement="right"
-            widthPx={reportSidebarWidth}
-            onResizeStart={handleReportSidebarDragStart}
-            onClose={handleCloseReport}
-          />
-        )}
-      </div>
-
-      <StatsPanel />
-      <ProgressBar />
-      </div>
       </div>
 
       {openSourceDialogState && (
@@ -1635,13 +1615,10 @@ export default function App() {
       {pendingPlaybackChannel && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
           <div className="w-full max-w-xl rounded-xl border border-border-app bg-overlay p-5 shadow-2xl">
-            <h2 className="text-[16px] font-semibold mb-2">
-              Scan currently running
-            </h2>
+            <h2 className="text-[16px] font-semibold mb-2">Scan currently running</h2>
             <p className="text-[14px] text-text-secondary leading-relaxed">
-              A scan is currently running. Playing a channel while scanning may
-              interfere with the scan or cause playback issues if the server&apos;s
-              max connection limit is exceeded.
+              A scan is currently running. Playing a channel while scanning may interfere with the
+              scan or cause playback issues if the server&apos;s max connection limit is exceeded.
             </p>
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
@@ -1662,7 +1639,6 @@ export default function App() {
           </div>
         </div>
       )}
-
     </div>
   );
 }

--- a/src/components/AppBanners.tsx
+++ b/src/components/AppBanners.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useMemo } from "react";
 import { Download, ExternalLink, Info, X } from "lucide-react";
-import { useAppStore } from "../store";
+import { useEffect, useMemo } from "react";
 import { dismissUpdateNotice } from "../hooks/useUpdateCheck";
+import { validateSourceFilterPattern } from "../lib/sourceFilter";
 import {
   isManualInstall,
   updateActionLabel,
   updateBannerMessage,
   updateConfirmMessage,
 } from "../lib/updateState";
-import { validateSourceFilterPattern } from "../lib/sourceFilter";
+import { useAppStore } from "../store";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -62,9 +62,7 @@ export function AppBanners({ onInstallUpdate }: AppBannersProps) {
     () => getStore().setErrorDismissed(false),
   );
   useAutoDismiss(playbackError, 10000, () => getStore().setPlaybackError(null));
-  useAutoDismiss(playlistOpenError, 10000, () =>
-    getStore().setPlaylistOpenError(null),
-  );
+  useAutoDismiss(playlistOpenError, 10000, () => getStore().setPlaylistOpenError(null));
   useAutoDismiss(scanInputError, 8000, () => getStore().setScanInputError(null));
   useAutoDismiss(menuInfo, 8000, () => getStore().setMenuInfo(null));
 

--- a/src/components/AppBanners.tsx
+++ b/src/components/AppBanners.tsx
@@ -1,11 +1,14 @@
-import { openUrl } from "@tauri-apps/plugin-opener";
-import { ExternalLink, Info, X } from "lucide-react";
 import { useEffect, useMemo } from "react";
-import { dismissUpdateNotice } from "../hooks/useUpdateCheck";
-import { errorToString } from "../lib/errors";
-import { logger } from "../lib/logger";
-import { validateSourceFilterPattern } from "../lib/sourceFilter";
+import { Download, ExternalLink, Info, X } from "lucide-react";
 import { useAppStore } from "../store";
+import { dismissUpdateNotice } from "../hooks/useUpdateCheck";
+import {
+  isManualInstall,
+  updateActionLabel,
+  updateBannerMessage,
+  updateConfirmMessage,
+} from "../lib/updateState";
+import { validateSourceFilterPattern } from "../lib/sourceFilter";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -27,9 +30,15 @@ function useAutoDismiss(
   }, [value]);
 }
 
+interface AppBannersProps {
+  /** Installs the discovered update, or opens the distribution's update page
+   *  for package-manager-owned installations. */
+  onInstallUpdate: () => void | Promise<void>;
+}
+
 /** The transient error/info banners shown under the toolbar, with their
- *  auto-dismiss timers. */
-export function AppBanners() {
+ *  auto-dismiss timers. The update banner is the one persistent entry. */
+export function AppBanners({ onInstallUpdate }: AppBannersProps) {
   const scanError = useAppStore((s) => s.scanError);
   const errorDismissed = useAppStore((s) => s.errorDismissed);
   const playbackError = useAppStore((s) => s.playbackError);
@@ -37,6 +46,7 @@ export function AppBanners() {
   const scanInputError = useAppStore((s) => s.scanInputError);
   const menuInfo = useAppStore((s) => s.menuInfo);
   const updateNotice = useAppStore((s) => s.updateNotice);
+  const updatePhase = useAppStore((s) => s.updatePhase);
   const appVersion = useAppStore((s) => s.appVersion);
   const channelSearch = useAppStore((s) => s.channelSearch);
   const channelSearchError = useMemo(
@@ -52,7 +62,9 @@ export function AppBanners() {
     () => getStore().setErrorDismissed(false),
   );
   useAutoDismiss(playbackError, 10000, () => getStore().setPlaybackError(null));
-  useAutoDismiss(playlistOpenError, 10000, () => getStore().setPlaylistOpenError(null));
+  useAutoDismiss(playlistOpenError, 10000, () =>
+    getStore().setPlaylistOpenError(null),
+  );
   useAutoDismiss(scanInputError, 8000, () => getStore().setScanInputError(null));
   useAutoDismiss(menuInfo, 8000, () => getStore().setMenuInfo(null));
 
@@ -138,21 +150,22 @@ export function AppBanners() {
 
       {updateNotice && (
         <div className="flex items-center gap-2 px-4 py-2.5 bg-emerald-500/10 border-b border-emerald-500/20 text-emerald-300 text-[13px]">
-          <span className="flex-1">
-            Update available: <strong>v{updateNotice.latest_version}</strong>
-            {appVersion ? ` (current v${appVersion})` : ""}.
-          </span>
+          <span className="flex-1">{updateBannerMessage(updateNotice, appVersion)}</span>
           <button
             type="button"
+            disabled={updatePhase === "installing"}
             onClick={() => {
-              void openUrl(updateNotice.release_url).catch((err) => {
-                logger.error("[Update] Failed to open release URL:", errorToString(err));
-              });
+              if (!window.confirm(updateConfirmMessage(updateNotice))) return;
+              void onInstallUpdate();
             }}
-            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-emerald-400/30 hover:bg-emerald-500/15 transition-colors"
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-emerald-400/30 hover:bg-emerald-500/15 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Download
-            <ExternalLink className="w-3.5 h-3.5" />
+            {updateActionLabel(updateNotice, updatePhase)}
+            {isManualInstall(updateNotice.installMode) ? (
+              <ExternalLink className="w-3.5 h-3.5" />
+            ) : (
+              <Download className="w-3.5 h-3.5" />
+            )}
           </button>
           <button
             onClick={dismissUpdateNotice}

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { resultAtIndex } from "../hooks/useScan.helpers";
 import { channelRowHeightPixels } from "../lib/channelLogoSize";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { getChannelTableLayout } from "../lib/channelTableLayout";
@@ -133,7 +134,7 @@ export function ChannelTable({
   toolbarHeight,
 }: ChannelTableProps) {
   const completedResults = useAppStore((s) => s.flatResults);
-  const resultsByIndex = useAppStore((s) => s.results);
+  const resultPositions = useAppStore((s) => s.resultPositions);
   const duplicateIndices = useAppStore((s) => s.duplicateIndices);
   const groupFilter = useAppStore((s) => s.groupFilter);
   const statusFilter = useAppStore((s) => s.statusFilter);
@@ -1419,7 +1420,10 @@ export function ChannelTable({
           >
             {selectedIndices.size > 0 &&
             Array.from(selectedIndices).every((idx) => {
-              const r = resultsByIndex[idx];
+              const r = resultAtIndex(
+                { flatResults: completedResults, positions: resultPositions },
+                idx,
+              );
               return r != null && r.status !== "pending" && r.status !== "checking";
             })
               ? "Rescan"

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -160,10 +160,10 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
-  if (!playlist) {
-    return null;
-  }
-  const statusSnapshot = summary ?? progress;
+  // Every hook below must run unconditionally: the "no playlist" early return
+  // lives after them, because bailing out first would change the hook count
+  // between renders as soon as a playlist loads.
+  const channels = playlist?.channels;
 
   const latencyStats = useMemo(() => {
     const aliveLatencies = results
@@ -180,27 +180,21 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const languageSummary = useMemo(
     () =>
       summarizeLanguageDistribution(
-        playlist.channels.map((channel) => ({ language: channel.language })),
+        (channels ?? []).map((channel) => ({ language: channel.language })),
         5,
       ),
-    [playlist.channels],
-  );
-
-  const showHealthScore = hasScanStarted(scanState);
-  const showContentCounts = shouldShowContentCounts(playlist.movie_count, playlist.series_count);
-  const showLanguageDistribution = shouldShowLanguageDistribution(
-    playlist.channels.map((channel) => ({ language: channel.language })),
+    [channels],
   );
 
   const epgSummary = useMemo(
-    () => summarizeEpgCoverage(playlist.channels.map((channel) => ({ tvg_id: channel.tvg_id }))),
-    [playlist.channels],
+    () => summarizeEpgCoverage((channels ?? []).map((channel) => ({ tvg_id: channel.tvg_id }))),
+    [channels],
   );
 
   const protocolSummary = useMemo(() => {
     let http = 0;
     let https = 0;
-    for (const channel of playlist.channels) {
+    for (const channel of channels ?? []) {
       const lower = channel.url.trim().toLowerCase();
       if (lower.startsWith("https://")) {
         https += 1;
@@ -211,7 +205,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     const total = http + https;
     const httpsPct = total > 0 ? (https / total) * 100 : 0;
     return { http, https, total, httpsPct };
-  }, [playlist.channels]);
+  }, [channels]);
 
   const quality = useMemo(() => {
     const alive = results.filter(isAliveResult);
@@ -232,8 +226,19 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   }, [results]);
 
   const computedScore = useMemo(
-    () => computeLiveScore(results, playlist.total_channels),
-    [results, playlist.total_channels],
+    () => computeLiveScore(results, playlist?.total_channels ?? 0),
+    [results, playlist?.total_channels],
+  );
+
+  if (!playlist) {
+    return null;
+  }
+
+  const statusSnapshot = summary ?? progress;
+  const showHealthScore = hasScanStarted(scanState);
+  const showContentCounts = shouldShowContentCounts(playlist.movie_count, playlist.series_count);
+  const showLanguageDistribution = shouldShowLanguageDistribution(
+    playlist.channels.map((channel) => ({ language: channel.language })),
   );
   const displayScore = summary?.playlist_score ?? computedScore;
   const ringScore = displayScore?.overall ?? 0;

--- a/src/components/SFSymbols.tsx
+++ b/src/components/SFSymbols.tsx
@@ -42,7 +42,12 @@ function makeSFIcon(icon: SFIconDef) {
     return (
       <svg xmlns="http://www.w3.org/2000/svg" viewBox={icon.viewBox} fill="currentColor" {...props}>
         {icon.svgPathData.map((path, i) => (
-          <path key={i} d={path.d} fillOpacity={path.fillOpacity} />
+          <path
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed path list per icon; never reorders, children hold no state.
+            key={i}
+            d={path.d}
+            fillOpacity={path.fillOpacity}
+          />
         ))}
       </svg>
     );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,12 @@
+import { useState, useEffect, useRef, useCallback } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Gauge, Layers, Network, SlidersHorizontal, Wrench } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Gauge,
+  Layers,
+  Network,
+  SlidersHorizontal,
+  Wrench,
+} from "lucide-react";
 import {
   clearScreenshotCache,
   deleteScanPreset,
@@ -8,8 +14,8 @@ import {
   getScreenshotCacheStats,
   renameScanPreset,
   saveScanPreset,
-  setDefaultM3u8FileAssociation,
   setDefaultScanPreset,
+  setDefaultM3u8FileAssociation,
 } from "../lib/tauri";
 import type {
   AppSettings,
@@ -60,7 +66,10 @@ function buildScanPresetConfig(settings: AppSettings): ScanPresetConfig {
   };
 }
 
-function applyScanPresetConfig(base: AppSettings, config: ScanPresetConfig): AppSettings {
+function applyScanPresetConfig(
+  base: AppSettings,
+  config: ScanPresetConfig,
+): AppSettings {
   return {
     ...base,
     timeout: config.timeout,
@@ -111,7 +120,9 @@ function Switch({
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full border transition-colors ${
-        checked ? "border-blue-500 bg-blue-500/80" : "border-border-app bg-panel"
+        checked
+          ? "border-blue-500 bg-blue-500/80"
+          : "border-border-app bg-panel"
       }`}
     >
       <span
@@ -142,7 +153,9 @@ function SegmentedControl<T extends string>({
             type="button"
             onClick={() => onChange(option.value)}
             className={`rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
-              selected ? "bg-blue-600 text-white" : "text-text-secondary hover:bg-btn-hover"
+              selected
+                ? "bg-blue-600 text-white"
+                : "text-text-secondary hover:bg-btn-hover"
             }`}
           >
             {option.label}
@@ -212,7 +225,8 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   }, [presetCollection, selectedPresetName]);
 
   const selectedPreset: ScanSettingsPreset | null =
-    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ?? null;
+    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ??
+    null;
 
   const persist = useCallback(
     (next: AppSettings) => {
@@ -260,7 +274,11 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   );
 
   const updateSetting = useCallback(
-    <K extends keyof AppSettings>(key: K, value: AppSettings[K], options?: PersistOptions) => {
+    <K extends keyof AppSettings>(
+      key: K,
+      value: AppSettings[K],
+      options?: PersistOptions,
+    ) => {
       setDraft((prev) => {
         const next = { ...prev, [key]: value };
         schedulePersist(next, options);
@@ -362,7 +380,11 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
     setPresetError(null);
     setPresetNotice(null);
     try {
-      const next = await saveScanPreset(name, buildScanPresetConfig(draft), presetSetAsDefault);
+      const next = await saveScanPreset(
+        name,
+        buildScanPresetConfig(draft),
+        presetSetAsDefault,
+      );
       setPresetCollection(next);
       setSelectedPresetName(name);
       setPresetNameDraft(name);
@@ -389,7 +411,9 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       setPresetError("Select a preset to rename.");
       return;
     }
-    const nextName = window.prompt("Rename preset", selectedPreset.name)?.trim();
+    const nextName = window
+      .prompt("Rename preset", selectedPreset.name)
+      ?.trim();
     if (!nextName || nextName === selectedPreset.name) {
       return;
     }
@@ -430,7 +454,9 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       const next = await deleteScanPreset(selectedPreset.name);
       setPresetCollection(next);
       setPresetNameDraft("");
-      setSelectedPresetName(next.default_preset ?? next.presets[0]?.name ?? "");
+      setSelectedPresetName(
+        next.default_preset ?? next.presets[0]?.name ?? "",
+      );
       setPresetNotice(`Deleted preset "${selectedPreset.name}".`);
     } catch (error) {
       setPresetError(error instanceof Error ? error.message : String(error));
@@ -491,10 +517,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       tabIndex={-1}
       className="flex flex-col h-full bg-overlay focus:outline-none"
     >
-      <div
-        className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle"
-        data-tauri-drag-region
-      >
+      <div className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle" data-tauri-drag-region>
         <div className="flex items-center gap-1">
           {tabs.map(({ id, label, Icon }) => {
             const active = activeTab === id;
@@ -517,716 +540,748 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-5 space-y-4">
-        {saveError && (
-          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
-            Could not save one or more changes: {saveError}
-          </div>
-        )}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {saveError && (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
+              Could not save one or more changes: {saveError}
+            </div>
+          )}
 
-        {activeTab === "general" && (
-          <>
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Theme</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Choose system, light, or dark appearance.
-                  </p>
+          {activeTab === "general" && (
+            <>
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Theme</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Choose system, light, or dark appearance.
+                    </p>
+                  </div>
+                  <SegmentedControl
+                    value={draft.theme}
+                    options={[
+                      { value: "system", label: "System" },
+                      { value: "light", label: "Light" },
+                      { value: "dark", label: "Dark" },
+                    ]}
+                    onChange={(value) => updateSetting("theme", value, { immediate: true })}
+                  />
                 </div>
-                <SegmentedControl
-                  value={draft.theme}
-                  options={[
-                    { value: "system", label: "System" },
-                    { value: "light", label: "Light" },
-                    { value: "dark", label: "Dark" },
-                  ]}
-                  onChange={(value) => updateSetting("theme", value, { immediate: true })}
-                />
-              </div>
 
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Channel logo size</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Controls logo size in the channel name column.
-                  </p>
-                </div>
-                <select
-                  value={draft.channel_logo_size}
-                  onChange={(event) =>
-                    updateSetting(
-                      "channel_logo_size",
-                      event.target.value as AppSettings["channel_logo_size"],
-                      { immediate: true },
-                    )
-                  }
-                  className={`${inputClass} w-44`}
-                >
-                  <option value="small">Small (16px)</option>
-                  <option value="medium">Medium (24px)</option>
-                  <option value="large">Large (36px)</option>
-                  <option value="huge">Huge (48px)</option>
-                </select>
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Profile video bitrate</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Captures 10s of each stream for accurate video bitrate values. Much slower.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.profile_bitrate}
-                  onChange={(checked) =>
-                    updateSetting("profile_bitrate", checked, { immediate: true })
-                  }
-                  ariaLabel="Profile bitrate"
-                />
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Show source filter bar</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Display the regex source filter bar above the table.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.show_prescan_filter}
-                  onChange={(checked) =>
-                    updateSetting("show_prescan_filter", checked, { immediate: true })
-                  }
-                  ariaLabel="Show source filter bar"
-                />
-              </div>
-
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Hide VOD / series entries</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Remove movies and series from loaded playlists, scans, and exports until
-                    re-enabled.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.hide_vod_content}
-                  onChange={(checked) =>
-                    updateSetting("hide_vod_content", checked, { immediate: true })
-                  }
-                  ariaLabel="Hide VOD and series entries"
-                />
-              </div>
-
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Auto-reveal report panel</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Slide in the playlist report near scan completion.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.report_auto_reveal}
-                  onChange={(checked) =>
-                    updateSetting("report_auto_reveal", checked, { immediate: true })
-                  }
-                  ariaLabel="Auto-reveal report panel"
-                />
-              </div>
-
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Separate placeholder status</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Show placeholder streams as a distinct status. When off, they are grouped under
-                    Dead.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.separate_placeholder_status}
-                  onChange={(checked) =>
-                    updateSetting("separate_placeholder_status", checked, { immediate: true })
-                  }
-                  ariaLabel="Separate placeholder status"
-                />
-              </div>
-
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Show header button text</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    {platform === "macos"
-                      ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
-                      : "Display labels beside toolbar icons in the main window header."}
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.show_header_button_text}
-                  onChange={(checked) =>
-                    updateSetting("show_header_button_text", checked, {
-                      immediate: true,
-                    })
-                  }
-                  ariaLabel="Show header button text"
-                />
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Scan completion notifications</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Show native notifications when scans complete or are cancelled.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.scan_notifications}
-                  onChange={(checked) =>
-                    updateSetting("scan_notifications", checked, { immediate: true })
-                  }
-                  ariaLabel="Scan completion notifications"
-                />
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div className="min-w-0">
-                  <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Open playlist files in IPTV Checker by default.
-                  </p>
-                </div>
-                <button
-                  onClick={handleSetDefaultM3u8Association}
-                  disabled={associationBusy}
-                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                  type="button"
-                >
-                  {associationBusy ? "Applying..." : "Set as Default"}
-                </button>
-              </div>
-              {associationNotice && (
-                <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
-                  {associationNotice}
-                </p>
-              )}
-              {associationError && (
-                <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
-                  {associationError}
-                </p>
-              )}
-            </section>
-          </>
-        )}
-
-        {activeTab === "scanning" && (
-          <>
-            <section className={`${blockClass} px-4 py-3 space-y-2`}>
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
-                {presetCollection.default_preset && (
-                  <span className="text-[10px] text-text-tertiary">
-                    Default: {presetCollection.default_preset}
-                  </span>
-                )}
-              </div>
-
-              <div className="grid grid-cols-2 gap-1.5">
-                <div className="flex gap-1.5">
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Channel logo size</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Controls logo size in the channel name column.
+                    </p>
+                  </div>
                   <select
-                    value={selectedPresetName}
-                    onChange={(event) => {
-                      setSelectedPresetName(event.target.value);
-                      setPresetNameDraft(event.target.value);
-                    }}
-                    className={`${inputClass} min-w-0 flex-1`}
-                    disabled={presetBusy || presetCollection.presets.length === 0}
+                    value={draft.channel_logo_size}
+                    onChange={(event) =>
+                      updateSetting(
+                        "channel_logo_size",
+                        event.target.value as AppSettings["channel_logo_size"],
+                        { immediate: true },
+                      )
+                    }
+                    className={`${inputClass} w-44`}
                   >
-                    <option value="">
-                      {presetCollection.presets.length === 0 ? "No presets" : "Select preset"}
-                    </option>
-                    {presetCollection.presets.map((preset) => (
-                      <option key={preset.name} value={preset.name}>
-                        {preset.name}
-                        {presetCollection.default_preset === preset.name ? " (Default)" : ""}
-                      </option>
-                    ))}
+                    <option value="small">Small (16px)</option>
+                    <option value="medium">Medium (24px)</option>
+                    <option value="large">Large (36px)</option>
+                    <option value="huge">Huge (48px)</option>
                   </select>
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Profile video bitrate</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Captures 10s of each stream for accurate video bitrate values. Much slower.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.profile_bitrate}
+                    onChange={(checked) =>
+                      updateSetting("profile_bitrate", checked, { immediate: true })
+                    }
+                    ariaLabel="Profile bitrate"
+                  />
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Show source filter bar</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Display the regex source filter bar above the table.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.show_prescan_filter}
+                    onChange={(checked) =>
+                      updateSetting("show_prescan_filter", checked, { immediate: true })
+                    }
+                    ariaLabel="Show source filter bar"
+                  />
+                </div>
+
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Hide VOD / series entries</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Remove movies and series from loaded playlists, scans, and exports until re-enabled.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.hide_vod_content}
+                    onChange={(checked) =>
+                      updateSetting("hide_vod_content", checked, { immediate: true })
+                    }
+                    ariaLabel="Hide VOD and series entries"
+                  />
+                </div>
+
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Auto-reveal report panel</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Slide in the playlist report near scan completion.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.report_auto_reveal}
+                    onChange={(checked) =>
+                      updateSetting("report_auto_reveal", checked, { immediate: true })
+                    }
+                    ariaLabel="Auto-reveal report panel"
+                  />
+                </div>
+
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Separate placeholder status</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Show placeholder streams as a distinct status. When off, they are grouped under Dead.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.separate_placeholder_status}
+                    onChange={(checked) =>
+                      updateSetting("separate_placeholder_status", checked, { immediate: true })
+                    }
+                    ariaLabel="Separate placeholder status"
+                  />
+                </div>
+
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Show header button text</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      {platform === "macos"
+                        ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
+                        : "Display labels beside toolbar icons in the main window header."}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.show_header_button_text}
+                    onChange={(checked) =>
+                      updateSetting("show_header_button_text", checked, {
+                        immediate: true,
+                      })
+                    }
+                    ariaLabel="Show header button text"
+                  />
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Scan completion notifications</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Show native notifications when scans complete or are cancelled.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.scan_notifications}
+                    onChange={(checked) =>
+                      updateSetting("scan_notifications", checked, { immediate: true })
+                    }
+                    ariaLabel="Scan completion notifications"
+                  />
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Automatic update checks</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Look for a signed update on launch and every six hours. Updates are only
+                      ever installed after you confirm.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.automatic_update_checks}
+                    onChange={(checked) =>
+                      updateSetting("automatic_update_checks", checked, { immediate: true })
+                    }
+                    ariaLabel="Automatic update checks"
+                  />
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Open playlist files in IPTV Checker by default.
+                    </p>
+                  </div>
                   <button
+                    onClick={handleSetDefaultM3u8Association}
+                    disabled={associationBusy}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
                     type="button"
-                    onClick={handleLoadPreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
                   >
-                    Load
+                    {associationBusy ? "Applying..." : "Set as Default"}
                   </button>
                 </div>
-                <div className="flex gap-1.5">
+                {associationNotice && (
+                  <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
+                    {associationNotice}
+                  </p>
+                )}
+                {associationError && (
+                  <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
+                    {associationError}
+                  </p>
+                )}
+              </section>
+            </>
+          )}
+
+          {activeTab === "scanning" && (
+            <>
+              <section className={`${blockClass} px-4 py-3 space-y-2`}>
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
+                  {presetCollection.default_preset && (
+                    <span className="text-[10px] text-text-tertiary">
+                      Default: {presetCollection.default_preset}
+                    </span>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-1.5">
+                  <div className="flex gap-1.5">
+                    <select
+                      value={selectedPresetName}
+                      onChange={(event) => {
+                        setSelectedPresetName(event.target.value);
+                        setPresetNameDraft(event.target.value);
+                      }}
+                      className={`${inputClass} min-w-0 flex-1`}
+                      disabled={presetBusy || presetCollection.presets.length === 0}
+                    >
+                      <option value="">
+                        {presetCollection.presets.length === 0
+                          ? "No presets"
+                          : "Select preset"}
+                      </option>
+                      {presetCollection.presets.map((preset) => (
+                        <option key={preset.name} value={preset.name}>
+                          {preset.name}
+                          {presetCollection.default_preset === preset.name
+                            ? " (Default)"
+                            : ""}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handleLoadPreset}
+                      disabled={presetBusy || !selectedPreset}
+                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                    >
+                      Load
+                    </button>
+                  </div>
+                  <div className="flex gap-1.5">
+                    <input
+                      type="text"
+                      value={presetNameDraft}
+                      onChange={(event) =>
+                        setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
+                      }
+                      placeholder="Preset name"
+                      className={`${inputClass} min-w-0 flex-1`}
+                      disabled={presetBusy}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleSavePreset}
+                      disabled={presetBusy}
+                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
+                    <input
+                      type="checkbox"
+                      checked={presetSetAsDefault}
+                      onChange={(event) => setPresetSetAsDefault(event.target.checked)}
+                      disabled={presetBusy}
+                    />
+                    Save as default
+                  </label>
+                  <button
+                    type="button"
+                    onClick={handleSetDefaultPreset}
+                    disabled={presetBusy || !selectedPreset}
+                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Mark Default
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleClearDefaultPreset}
+                    disabled={presetBusy || !presetCollection.default_preset}
+                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Clear Default
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleRenamePreset}
+                    disabled={presetBusy || !selectedPreset}
+                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Rename
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDeletePreset}
+                    disabled={presetBusy || !selectedPreset}
+                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
+                  >
+                    Delete
+                  </button>
+                </div>
+
+                {presetNotice && (
+                  <p className="text-[11px] text-emerald-400">{presetNotice}</p>
+                )}
+                {presetError && (
+                  <p className="text-[11px] text-red-400">{presetError}</p>
+                )}
+              </section>
+
+              <section className={`${blockClass} p-4`}>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Timeout (seconds)
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.timeout}
+                      onChange={(event) => {
+                        const value = parseFloat(event.target.value);
+                        updateSetting(
+                          "timeout",
+                          Number.isNaN(value) ? 10 : Math.max(0.5, value),
+                        );
+                      }}
+                      step="0.5"
+                      min="0.5"
+                      className={inputClass}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Extended Timeout (seconds)
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.extended_timeout ?? ""}
+                      onChange={(event) => {
+                        if (!event.target.value) {
+                          updateSetting("extended_timeout", null);
+                          return;
+                        }
+                        const value = parseFloat(event.target.value);
+                        updateSetting(
+                          "extended_timeout",
+                          Number.isNaN(value) ? null : Math.max(1, value),
+                        );
+                      }}
+                      placeholder="Disabled"
+                      step="1"
+                      min="1"
+                      className={inputClass}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Concurrency
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.concurrency || ""}
+                      placeholder="Auto"
+                      onChange={(event) => {
+                        const raw = event.target.value.trim();
+                        if (raw === "") {
+                          updateSetting("concurrency", 0);
+                          return;
+                        }
+                        const value = parseInt(raw, 10);
+                        updateSetting(
+                          "concurrency",
+                          Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
+                        );
+                      }}
+                      min="0"
+                      max="20"
+                      className={inputClass}
+                    />
+                    <p className="text-[11px] text-text-quaternary mt-1">
+                      0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1
+                      for single-server)
+                    </p>
+                  </div>
+
+                </div>
+              </section>
+
+              <section className={`${blockClass} p-4`}>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Max Retries
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.retries}
+                      onChange={(event) => {
+                        const value = parseInt(event.target.value, 10);
+                        updateSetting(
+                          "retries",
+                          Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
+                        );
+                      }}
+                      min="0"
+                      max="10"
+                      className={inputClass}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Retry Backoff
+                    </label>
+                    <SegmentedControl
+                      value={draft.retry_backoff}
+                      options={[
+                        { value: "none", label: "None" },
+                        { value: "linear", label: "Linear" },
+                        { value: "exponential", label: "Exponential" },
+                      ]}
+                      onChange={(value) =>
+                        updateSetting("retry_backoff", value, { immediate: true })
+                      }
+                    />
+                  </div>
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Low FPS threshold</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Streams below this FPS are flagged as low framerate.
+                    </p>
+                  </div>
+                  <input
+                    type="number"
+                    value={draft.low_fps_threshold}
+                    onChange={(event) => {
+                      const value = parseFloat(event.target.value);
+                      updateSetting(
+                        "low_fps_threshold",
+                        Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
+                      );
+                    }}
+                    step="0.1"
+                    min="0"
+                    max="240"
+                    className={`${inputClass} w-24`}
+                  />
+                </div>
+              </section>
+
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium">User agent</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      HTTP user agent string sent with stream requests.
+                    </p>
+                  </div>
                   <input
                     type="text"
-                    value={presetNameDraft}
-                    onChange={(event) =>
-                      setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
+                    value={draft.user_agent}
+                    onChange={(event) => updateSetting("user_agent", event.target.value)}
+                    className={`${inputClass} w-56`}
+                  />
+                </div>
+              </section>
+
+            </>
+          )}
+
+          {activeTab === "media" && (
+            <>
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Skip screenshots</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Disable frame captures for faster checks.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.skip_screenshots}
+                    onChange={(checked) =>
+                      updateSetting("skip_screenshots", checked, { immediate: true })
                     }
-                    placeholder="Preset name"
-                    className={`${inputClass} min-w-0 flex-1`}
-                    disabled={presetBusy}
-                  />
-                  <button
-                    type="button"
-                    onClick={handleSavePreset}
-                    disabled={presetBusy}
-                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Save
-                  </button>
-                </div>
-              </div>
-
-              <div className="flex flex-wrap items-center gap-1.5">
-                <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={presetSetAsDefault}
-                    onChange={(event) => setPresetSetAsDefault(event.target.checked)}
-                    disabled={presetBusy}
-                  />
-                  Save as default
-                </label>
-                <button
-                  type="button"
-                  onClick={handleSetDefaultPreset}
-                  disabled={presetBusy || !selectedPreset}
-                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                >
-                  Mark Default
-                </button>
-                <button
-                  type="button"
-                  onClick={handleClearDefaultPreset}
-                  disabled={presetBusy || !presetCollection.default_preset}
-                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                >
-                  Clear Default
-                </button>
-                <button
-                  type="button"
-                  onClick={handleRenamePreset}
-                  disabled={presetBusy || !selectedPreset}
-                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                >
-                  Rename
-                </button>
-                <button
-                  type="button"
-                  onClick={handleDeletePreset}
-                  disabled={presetBusy || !selectedPreset}
-                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
-                >
-                  Delete
-                </button>
-              </div>
-
-              {presetNotice && <p className="text-[11px] text-emerald-400">{presetNotice}</p>}
-              {presetError && <p className="text-[11px] text-red-400">{presetError}</p>}
-            </section>
-
-            <section className={`${blockClass} p-4`}>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Timeout (seconds)
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.timeout}
-                    onChange={(event) => {
-                      const value = parseFloat(event.target.value);
-                      updateSetting("timeout", Number.isNaN(value) ? 10 : Math.max(0.5, value));
-                    }}
-                    step="0.5"
-                    min="0.5"
-                    className={inputClass}
+                    ariaLabel="Skip screenshots"
                   />
                 </div>
 
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Extended Timeout (seconds)
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.extended_timeout ?? ""}
-                    onChange={(event) => {
-                      if (!event.target.value) {
-                        updateSetting("extended_timeout", null);
-                        return;
-                      }
-                      const value = parseFloat(event.target.value);
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Screenshot format</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      WebP is faster and smaller. PNG is lossless.
+                    </p>
+                  </div>
+                  <select
+                    value={draft.screenshot_format}
+                    onChange={(event) =>
                       updateSetting(
-                        "extended_timeout",
-                        Number.isNaN(value) ? null : Math.max(1, value),
-                      );
-                    }}
-                    placeholder="Disabled"
-                    step="1"
-                    min="1"
-                    className={inputClass}
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Concurrency
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.concurrency || ""}
-                    placeholder="Auto"
-                    onChange={(event) => {
-                      const raw = event.target.value.trim();
-                      if (raw === "") {
-                        updateSetting("concurrency", 0);
-                        return;
-                      }
-                      const value = parseInt(raw, 10);
-                      updateSetting(
-                        "concurrency",
-                        Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
-                      );
-                    }}
-                    min="0"
-                    max="20"
-                    className={inputClass}
-                  />
-                  <p className="text-[11px] text-text-quaternary mt-1">
-                    0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1 for
-                    single-server)
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            <section className={`${blockClass} p-4`}>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Max Retries
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.retries}
-                    onChange={(event) => {
-                      const value = parseInt(event.target.value, 10);
-                      updateSetting(
-                        "retries",
-                        Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
-                      );
-                    }}
-                    min="0"
-                    max="10"
-                    className={inputClass}
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Retry Backoff
-                  </label>
-                  <SegmentedControl
-                    value={draft.retry_backoff}
-                    options={[
-                      { value: "none", label: "None" },
-                      { value: "linear", label: "Linear" },
-                      { value: "exponential", label: "Exponential" },
-                    ]}
-                    onChange={(value) => updateSetting("retry_backoff", value, { immediate: true })}
-                  />
-                </div>
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Low FPS threshold</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Streams below this FPS are flagged as low framerate.
-                  </p>
-                </div>
-                <input
-                  type="number"
-                  value={draft.low_fps_threshold}
-                  onChange={(event) => {
-                    const value = parseFloat(event.target.value);
-                    updateSetting(
-                      "low_fps_threshold",
-                      Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
-                    );
-                  }}
-                  step="0.1"
-                  min="0"
-                  max="240"
-                  className={`${inputClass} w-24`}
-                />
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div className="min-w-0">
-                  <p className="text-[13px] font-medium">User agent</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    HTTP user agent string sent with stream requests.
-                  </p>
-                </div>
-                <input
-                  type="text"
-                  value={draft.user_agent}
-                  onChange={(event) => updateSetting("user_agent", event.target.value)}
-                  className={`${inputClass} w-56`}
-                />
-              </div>
-            </section>
-          </>
-        )}
-
-        {activeTab === "media" && (
-          <>
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Skip screenshots</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Disable frame captures for faster checks.
-                  </p>
-                </div>
-                <Switch
-                  checked={draft.skip_screenshots}
-                  onChange={(checked) =>
-                    updateSetting("skip_screenshots", checked, { immediate: true })
-                  }
-                  ariaLabel="Skip screenshots"
-                />
-              </div>
-
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Screenshot format</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    WebP is faster and smaller. PNG is lossless.
-                  </p>
-                </div>
-                <select
-                  value={draft.screenshot_format}
-                  onChange={(event) =>
-                    updateSetting(
-                      "screenshot_format",
-                      event.target.value as AppSettings["screenshot_format"],
-                      { immediate: true },
-                    )
-                  }
-                  className={`${inputClass} w-44`}
-                  disabled={draft.skip_screenshots}
-                >
-                  <option value="webp">WebP</option>
-                  <option value="png">PNG</option>
-                </select>
-              </div>
-
-              <div className={rowClass}>
-                <div className="min-w-0 flex-1">
-                  <p className="text-[13px] font-medium">Save screenshots to</p>
-                  <p
-                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                    title={draft.screenshots_dir ?? "Not saved (preview only)"}
+                        "screenshot_format",
+                        event.target.value as AppSettings["screenshot_format"],
+                        { immediate: true },
+                      )
+                    }
+                    className={`${inputClass} w-44`}
+                    disabled={draft.skip_screenshots}
                   >
-                    {draft.screenshots_dir ?? "Not saved (preview only)"}
-                  </p>
+                    <option value="webp">WebP</option>
+                    <option value="png">PNG</option>
+                  </select>
                 </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={handleSelectScreenshotsDir}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                    type="button"
-                  >
-                    Browse
-                  </button>
-                  {draft.screenshots_dir && (
+
+                <div className={rowClass}>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[13px] font-medium">Save screenshots to</p>
+                    <p
+                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                      title={draft.screenshots_dir ?? "Not saved (preview only)"}
+                    >
+                      {draft.screenshots_dir ?? "Not saved (preview only)"}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
                     <button
-                      onClick={() => updateSetting("screenshots_dir", null, { immediate: true })}
+                      onClick={handleSelectScreenshotsDir}
                       className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                       type="button"
                     >
-                      Clear
+                      Browse
                     </button>
-                  )}
-                </div>
-              </div>
-            </section>
-
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div className="min-w-0">
-                  <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    {cacheStats
-                      ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
-                      : "Unavailable"}
-                    {cacheStats?.disk_space && (
-                      <span className="ml-1.5 text-text-tertiary/70">
-                        · {formatBytes(cacheStats.disk_space.available_bytes)} free
-                      </span>
+                    {draft.screenshots_dir && (
+                      <button
+                        onClick={() =>
+                          updateSetting("screenshots_dir", null, { immediate: true })
+                        }
+                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                        type="button"
+                      >
+                        Clear
+                      </button>
                     )}
-                  </p>
+                  </div>
                 </div>
-                <button
-                  onClick={handleClearScreenshotCache}
-                  disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
-                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                  type="button"
-                >
-                  {cacheBusy ? "Clearing..." : "Clear Cache"}
-                </button>
-              </div>
+              </section>
 
-              {cacheStats && (
-                <p
-                  className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
-                  title={cacheStats.cache_dir}
-                >
-                  {cacheStats.cache_dir}
-                </p>
-              )}
-
-              <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Screenshot Retention
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.screenshot_retention_count}
-                    onChange={(event) => {
-                      const value = parseInt(event.target.value, 10);
-                      updateSetting(
-                        "screenshot_retention_count",
-                        Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
-                      );
-                    }}
-                    min="0"
-                    max="100"
-                    className={inputClass}
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                    Low Space Threshold (GB)
-                  </label>
-                  <input
-                    type="number"
-                    value={draft.low_space_threshold_gb}
-                    onChange={(event) => {
-                      const value = parseFloat(event.target.value);
-                      updateSetting(
-                        "low_space_threshold_gb",
-                        Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
-                      );
-                    }}
-                    step="0.5"
-                    min="1"
-                    max="50"
-                    className={inputClass}
-                  />
-                </div>
-              </div>
-            </section>
-          </>
-        )}
-
-        {activeTab === "network" && (
-          <>
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div className="min-w-0 flex-1">
-                  <p className="text-[13px] font-medium">Proxy file</p>
-                  <p
-                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                    title={draft.proxy_file ?? "No proxy file selected"}
-                  >
-                    {draft.proxy_file ?? "No proxy file selected"}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      {cacheStats
+                        ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
+                        : "Unavailable"}
+                      {cacheStats?.disk_space && (
+                        <span className="ml-1.5 text-text-tertiary/70">
+                          · {formatBytes(cacheStats.disk_space.available_bytes)} free
+                        </span>
+                      )}
+                    </p>
+                  </div>
                   <button
-                    onClick={handleSelectProxy}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                    onClick={handleClearScreenshotCache}
+                    disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
                     type="button"
                   >
-                    Browse
+                    {cacheBusy ? "Clearing..." : "Clear Cache"}
                   </button>
-                  {draft.proxy_file && (
+                </div>
+
+                {cacheStats && (
+                  <p
+                    className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
+                    title={cacheStats.cache_dir}
+                  >
+                    {cacheStats.cache_dir}
+                  </p>
+                )}
+
+                <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Screenshot Retention
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.screenshot_retention_count}
+                      onChange={(event) => {
+                        const value = parseInt(event.target.value, 10);
+                        updateSetting(
+                          "screenshot_retention_count",
+                          Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
+                        );
+                      }}
+                      min="0"
+                      max="100"
+                      className={inputClass}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                      Low Space Threshold (GB)
+                    </label>
+                    <input
+                      type="number"
+                      value={draft.low_space_threshold_gb}
+                      onChange={(event) => {
+                        const value = parseFloat(event.target.value);
+                        updateSetting(
+                          "low_space_threshold_gb",
+                          Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
+                        );
+                      }}
+                      step="0.5"
+                      min="1"
+                      max="50"
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+              </section>
+            </>
+          )}
+
+          {activeTab === "network" && (
+            <>
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[13px] font-medium">Proxy file</p>
+                    <p
+                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                      title={draft.proxy_file ?? "No proxy file selected"}
+                    >
+                      {draft.proxy_file ?? "No proxy file selected"}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
                     <button
-                      onClick={() => updateSetting("proxy_file", null, { immediate: true })}
+                      onClick={handleSelectProxy}
                       className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                       type="button"
                     >
-                      Clear
+                      Browse
                     </button>
-                  )}
+                    {draft.proxy_file && (
+                      <button
+                        onClick={() => updateSetting("proxy_file", null, { immediate: true })}
+                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                        type="button"
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
                 </div>
-              </div>
 
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Re-test geoblocked streams through your proxy list.
-                  </p>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Re-test geoblocked streams through your proxy list.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.test_geoblock}
+                    onChange={(checked) =>
+                      updateSetting("test_geoblock", checked, { immediate: true })
+                    }
+                    ariaLabel="Confirm geoblocks with proxies"
+                  />
                 </div>
-                <Switch
-                  checked={draft.test_geoblock}
-                  onChange={(checked) =>
-                    updateSetting("test_geoblock", checked, { immediate: true })
-                  }
-                  ariaLabel="Confirm geoblocks with proxies"
-                />
-              </div>
-            </section>
+              </section>
 
-            <section className={blockClass}>
-              <div className={rowClass}>
-                <div>
-                  <p className="text-[13px] font-medium">
-                    Skip certificate verification (insecure)
-                  </p>
-                  <p className="text-[11px] text-text-tertiary mt-0.5">
-                    Accept invalid/self-signed TLS certificates during stream checks.
-                  </p>
+              <section className={blockClass}>
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Skip certificate verification (insecure)</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Accept invalid/self-signed TLS certificates during stream checks.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={draft.accept_invalid_certs}
+                    onChange={(checked) =>
+                      updateSetting("accept_invalid_certs", checked, { immediate: true })
+                    }
+                    ariaLabel="Skip certificate verification"
+                  />
                 </div>
-                <Switch
-                  checked={draft.accept_invalid_certs}
-                  onChange={(checked) =>
-                    updateSetting("accept_invalid_certs", checked, { immediate: true })
-                  }
-                  ariaLabel="Skip certificate verification"
-                />
-              </div>
-            </section>
-          </>
-        )}
+              </section>
+            </>
+          )}
 
-        {activeTab === "advanced" && (
-          <>
-            <section className={`${blockClass} p-4`}>
+          {activeTab === "advanced" && (
+            <>
+              <section className={`${blockClass} p-4`}>
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
@@ -1266,6 +1321,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                     className={inputClass}
                   />
                 </div>
+
               </div>
             </section>
 
@@ -1315,9 +1371,9 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                 </div>
               </div>
             </section>
-          </>
-        )}
-      </div>
+            </>
+          )}
+        </div>
     </div>
   );
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,12 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import {
-  Gauge,
-  Layers,
-  Network,
-  SlidersHorizontal,
-  Wrench,
-} from "lucide-react";
+import { Gauge, Layers, Network, SlidersHorizontal, Wrench } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   clearScreenshotCache,
   deleteScanPreset,
@@ -14,8 +8,8 @@ import {
   getScreenshotCacheStats,
   renameScanPreset,
   saveScanPreset,
-  setDefaultScanPreset,
   setDefaultM3u8FileAssociation,
+  setDefaultScanPreset,
 } from "../lib/tauri";
 import type {
   AppSettings,
@@ -66,10 +60,7 @@ function buildScanPresetConfig(settings: AppSettings): ScanPresetConfig {
   };
 }
 
-function applyScanPresetConfig(
-  base: AppSettings,
-  config: ScanPresetConfig,
-): AppSettings {
+function applyScanPresetConfig(base: AppSettings, config: ScanPresetConfig): AppSettings {
   return {
     ...base,
     timeout: config.timeout,
@@ -120,9 +111,7 @@ function Switch({
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full border transition-colors ${
-        checked
-          ? "border-blue-500 bg-blue-500/80"
-          : "border-border-app bg-panel"
+        checked ? "border-blue-500 bg-blue-500/80" : "border-border-app bg-panel"
       }`}
     >
       <span
@@ -153,9 +142,7 @@ function SegmentedControl<T extends string>({
             type="button"
             onClick={() => onChange(option.value)}
             className={`rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
-              selected
-                ? "bg-blue-600 text-white"
-                : "text-text-secondary hover:bg-btn-hover"
+              selected ? "bg-blue-600 text-white" : "text-text-secondary hover:bg-btn-hover"
             }`}
           >
             {option.label}
@@ -225,8 +212,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   }, [presetCollection, selectedPresetName]);
 
   const selectedPreset: ScanSettingsPreset | null =
-    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ??
-    null;
+    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ?? null;
 
   const persist = useCallback(
     (next: AppSettings) => {
@@ -274,11 +260,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   );
 
   const updateSetting = useCallback(
-    <K extends keyof AppSettings>(
-      key: K,
-      value: AppSettings[K],
-      options?: PersistOptions,
-    ) => {
+    <K extends keyof AppSettings>(key: K, value: AppSettings[K], options?: PersistOptions) => {
       setDraft((prev) => {
         const next = { ...prev, [key]: value };
         schedulePersist(next, options);
@@ -380,11 +362,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
     setPresetError(null);
     setPresetNotice(null);
     try {
-      const next = await saveScanPreset(
-        name,
-        buildScanPresetConfig(draft),
-        presetSetAsDefault,
-      );
+      const next = await saveScanPreset(name, buildScanPresetConfig(draft), presetSetAsDefault);
       setPresetCollection(next);
       setSelectedPresetName(name);
       setPresetNameDraft(name);
@@ -411,9 +389,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       setPresetError("Select a preset to rename.");
       return;
     }
-    const nextName = window
-      .prompt("Rename preset", selectedPreset.name)
-      ?.trim();
+    const nextName = window.prompt("Rename preset", selectedPreset.name)?.trim();
     if (!nextName || nextName === selectedPreset.name) {
       return;
     }
@@ -454,9 +430,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       const next = await deleteScanPreset(selectedPreset.name);
       setPresetCollection(next);
       setPresetNameDraft("");
-      setSelectedPresetName(
-        next.default_preset ?? next.presets[0]?.name ?? "",
-      );
+      setSelectedPresetName(next.default_preset ?? next.presets[0]?.name ?? "");
       setPresetNotice(`Deleted preset "${selectedPreset.name}".`);
     } catch (error) {
       setPresetError(error instanceof Error ? error.message : String(error));
@@ -517,7 +491,10 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       tabIndex={-1}
       className="flex flex-col h-full bg-overlay focus:outline-none"
     >
-      <div className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle" data-tauri-drag-region>
+      <div
+        className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle"
+        data-tauri-drag-region
+      >
         <div className="flex items-center gap-1">
           {tabs.map(({ id, label, Icon }) => {
             const active = activeTab === id;
@@ -540,748 +517,735 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
         </div>
       </div>
 
-        <div className="flex-1 overflow-y-auto p-5 space-y-4">
-          {saveError && (
-            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
-              Could not save one or more changes: {saveError}
-            </div>
-          )}
+      <div className="flex-1 overflow-y-auto p-5 space-y-4">
+        {saveError && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
+            Could not save one or more changes: {saveError}
+          </div>
+        )}
 
-          {activeTab === "general" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Theme</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Choose system, light, or dark appearance.
-                    </p>
-                  </div>
-                  <SegmentedControl
-                    value={draft.theme}
-                    options={[
-                      { value: "system", label: "System" },
-                      { value: "light", label: "Light" },
-                      { value: "dark", label: "Dark" },
-                    ]}
-                    onChange={(value) => updateSetting("theme", value, { immediate: true })}
-                  />
+        {activeTab === "general" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Theme</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Choose system, light, or dark appearance.
+                  </p>
                 </div>
+                <SegmentedControl
+                  value={draft.theme}
+                  options={[
+                    { value: "system", label: "System" },
+                    { value: "light", label: "Light" },
+                    { value: "dark", label: "Dark" },
+                  ]}
+                  onChange={(value) => updateSetting("theme", value, { immediate: true })}
+                />
+              </div>
 
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Channel logo size</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Controls logo size in the channel name column.
-                    </p>
-                  </div>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Channel logo size</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Controls logo size in the channel name column.
+                  </p>
+                </div>
+                <select
+                  value={draft.channel_logo_size}
+                  onChange={(event) =>
+                    updateSetting(
+                      "channel_logo_size",
+                      event.target.value as AppSettings["channel_logo_size"],
+                      { immediate: true },
+                    )
+                  }
+                  className={`${inputClass} w-44`}
+                >
+                  <option value="small">Small (16px)</option>
+                  <option value="medium">Medium (24px)</option>
+                  <option value="large">Large (36px)</option>
+                  <option value="huge">Huge (48px)</option>
+                </select>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Profile video bitrate</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Captures 10s of each stream for accurate video bitrate values. Much slower.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.profile_bitrate}
+                  onChange={(checked) =>
+                    updateSetting("profile_bitrate", checked, { immediate: true })
+                  }
+                  ariaLabel="Profile bitrate"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Show source filter bar</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Display the regex source filter bar above the table.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.show_prescan_filter}
+                  onChange={(checked) =>
+                    updateSetting("show_prescan_filter", checked, { immediate: true })
+                  }
+                  ariaLabel="Show source filter bar"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Hide VOD / series entries</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Remove movies and series from loaded playlists, scans, and exports until
+                    re-enabled.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.hide_vod_content}
+                  onChange={(checked) =>
+                    updateSetting("hide_vod_content", checked, { immediate: true })
+                  }
+                  ariaLabel="Hide VOD and series entries"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Auto-reveal report panel</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Slide in the playlist report near scan completion.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.report_auto_reveal}
+                  onChange={(checked) =>
+                    updateSetting("report_auto_reveal", checked, { immediate: true })
+                  }
+                  ariaLabel="Auto-reveal report panel"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Separate placeholder status</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Show placeholder streams as a distinct status. When off, they are grouped under
+                    Dead.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.separate_placeholder_status}
+                  onChange={(checked) =>
+                    updateSetting("separate_placeholder_status", checked, { immediate: true })
+                  }
+                  ariaLabel="Separate placeholder status"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Show header button text</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    {platform === "macos"
+                      ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
+                      : "Display labels beside toolbar icons in the main window header."}
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.show_header_button_text}
+                  onChange={(checked) =>
+                    updateSetting("show_header_button_text", checked, {
+                      immediate: true,
+                    })
+                  }
+                  ariaLabel="Show header button text"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Scan completion notifications</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Show native notifications when scans complete or are cancelled.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.scan_notifications}
+                  onChange={(checked) =>
+                    updateSetting("scan_notifications", checked, { immediate: true })
+                  }
+                  ariaLabel="Scan completion notifications"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Automatic update checks</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Look for a signed update on launch and every six hours. Updates are only ever
+                    installed after you confirm.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.automatic_update_checks}
+                  onChange={(checked) =>
+                    updateSetting("automatic_update_checks", checked, { immediate: true })
+                  }
+                  ariaLabel="Automatic update checks"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Open playlist files in IPTV Checker by default.
+                  </p>
+                </div>
+                <button
+                  onClick={handleSetDefaultM3u8Association}
+                  disabled={associationBusy}
+                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  type="button"
+                >
+                  {associationBusy ? "Applying..." : "Set as Default"}
+                </button>
+              </div>
+              {associationNotice && (
+                <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
+                  {associationNotice}
+                </p>
+              )}
+              {associationError && (
+                <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
+                  {associationError}
+                </p>
+              )}
+            </section>
+          </>
+        )}
+
+        {activeTab === "scanning" && (
+          <>
+            <section className={`${blockClass} px-4 py-3 space-y-2`}>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
+                {presetCollection.default_preset && (
+                  <span className="text-[10px] text-text-tertiary">
+                    Default: {presetCollection.default_preset}
+                  </span>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-1.5">
+                <div className="flex gap-1.5">
                   <select
-                    value={draft.channel_logo_size}
-                    onChange={(event) =>
-                      updateSetting(
-                        "channel_logo_size",
-                        event.target.value as AppSettings["channel_logo_size"],
-                        { immediate: true },
-                      )
-                    }
-                    className={`${inputClass} w-44`}
+                    value={selectedPresetName}
+                    onChange={(event) => {
+                      setSelectedPresetName(event.target.value);
+                      setPresetNameDraft(event.target.value);
+                    }}
+                    className={`${inputClass} min-w-0 flex-1`}
+                    disabled={presetBusy || presetCollection.presets.length === 0}
                   >
-                    <option value="small">Small (16px)</option>
-                    <option value="medium">Medium (24px)</option>
-                    <option value="large">Large (36px)</option>
-                    <option value="huge">Huge (48px)</option>
-                  </select>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Profile video bitrate</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Captures 10s of each stream for accurate video bitrate values. Much slower.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.profile_bitrate}
-                    onChange={(checked) =>
-                      updateSetting("profile_bitrate", checked, { immediate: true })
-                    }
-                    ariaLabel="Profile bitrate"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Show source filter bar</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Display the regex source filter bar above the table.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.show_prescan_filter}
-                    onChange={(checked) =>
-                      updateSetting("show_prescan_filter", checked, { immediate: true })
-                    }
-                    ariaLabel="Show source filter bar"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Hide VOD / series entries</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Remove movies and series from loaded playlists, scans, and exports until re-enabled.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.hide_vod_content}
-                    onChange={(checked) =>
-                      updateSetting("hide_vod_content", checked, { immediate: true })
-                    }
-                    ariaLabel="Hide VOD and series entries"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Auto-reveal report panel</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Slide in the playlist report near scan completion.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.report_auto_reveal}
-                    onChange={(checked) =>
-                      updateSetting("report_auto_reveal", checked, { immediate: true })
-                    }
-                    ariaLabel="Auto-reveal report panel"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Separate placeholder status</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Show placeholder streams as a distinct status. When off, they are grouped under Dead.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.separate_placeholder_status}
-                    onChange={(checked) =>
-                      updateSetting("separate_placeholder_status", checked, { immediate: true })
-                    }
-                    ariaLabel="Separate placeholder status"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Show header button text</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      {platform === "macos"
-                        ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
-                        : "Display labels beside toolbar icons in the main window header."}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.show_header_button_text}
-                    onChange={(checked) =>
-                      updateSetting("show_header_button_text", checked, {
-                        immediate: true,
-                      })
-                    }
-                    ariaLabel="Show header button text"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Scan completion notifications</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Show native notifications when scans complete or are cancelled.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.scan_notifications}
-                    onChange={(checked) =>
-                      updateSetting("scan_notifications", checked, { immediate: true })
-                    }
-                    ariaLabel="Scan completion notifications"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Automatic update checks</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Look for a signed update on launch and every six hours. Updates are only
-                      ever installed after you confirm.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.automatic_update_checks}
-                    onChange={(checked) =>
-                      updateSetting("automatic_update_checks", checked, { immediate: true })
-                    }
-                    ariaLabel="Automatic update checks"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Open playlist files in IPTV Checker by default.
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleSetDefaultM3u8Association}
-                    disabled={associationBusy}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    type="button"
-                  >
-                    {associationBusy ? "Applying..." : "Set as Default"}
-                  </button>
-                </div>
-                {associationNotice && (
-                  <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
-                    {associationNotice}
-                  </p>
-                )}
-                {associationError && (
-                  <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
-                    {associationError}
-                  </p>
-                )}
-              </section>
-            </>
-          )}
-
-          {activeTab === "scanning" && (
-            <>
-              <section className={`${blockClass} px-4 py-3 space-y-2`}>
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
-                  {presetCollection.default_preset && (
-                    <span className="text-[10px] text-text-tertiary">
-                      Default: {presetCollection.default_preset}
-                    </span>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-2 gap-1.5">
-                  <div className="flex gap-1.5">
-                    <select
-                      value={selectedPresetName}
-                      onChange={(event) => {
-                        setSelectedPresetName(event.target.value);
-                        setPresetNameDraft(event.target.value);
-                      }}
-                      className={`${inputClass} min-w-0 flex-1`}
-                      disabled={presetBusy || presetCollection.presets.length === 0}
-                    >
-                      <option value="">
-                        {presetCollection.presets.length === 0
-                          ? "No presets"
-                          : "Select preset"}
+                    <option value="">
+                      {presetCollection.presets.length === 0 ? "No presets" : "Select preset"}
+                    </option>
+                    {presetCollection.presets.map((preset) => (
+                      <option key={preset.name} value={preset.name}>
+                        {preset.name}
+                        {presetCollection.default_preset === preset.name ? " (Default)" : ""}
                       </option>
-                      {presetCollection.presets.map((preset) => (
-                        <option key={preset.name} value={preset.name}>
-                          {preset.name}
-                          {presetCollection.default_preset === preset.name
-                            ? " (Default)"
-                            : ""}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      onClick={handleLoadPreset}
-                      disabled={presetBusy || !selectedPreset}
-                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      Load
-                    </button>
-                  </div>
-                  <div className="flex gap-1.5">
-                    <input
-                      type="text"
-                      value={presetNameDraft}
-                      onChange={(event) =>
-                        setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
-                      }
-                      placeholder="Preset name"
-                      className={`${inputClass} min-w-0 flex-1`}
-                      disabled={presetBusy}
-                    />
-                    <button
-                      type="button"
-                      onClick={handleSavePreset}
-                      disabled={presetBusy}
-                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      Save
-                    </button>
-                  </div>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={handleLoadPreset}
+                    disabled={presetBusy || !selectedPreset}
+                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Load
+                  </button>
                 </div>
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    value={presetNameDraft}
+                    onChange={(event) =>
+                      setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
+                    }
+                    placeholder="Preset name"
+                    className={`${inputClass} min-w-0 flex-1`}
+                    disabled={presetBusy}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleSavePreset}
+                    disabled={presetBusy}
+                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
 
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
-                    <input
-                      type="checkbox"
-                      checked={presetSetAsDefault}
-                      onChange={(event) => setPresetSetAsDefault(event.target.checked)}
-                      disabled={presetBusy}
-                    />
-                    Save as default
+              <div className="flex flex-wrap items-center gap-1.5">
+                <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={presetSetAsDefault}
+                    onChange={(event) => setPresetSetAsDefault(event.target.checked)}
+                    disabled={presetBusy}
+                  />
+                  Save as default
+                </label>
+                <button
+                  type="button"
+                  onClick={handleSetDefaultPreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Mark Default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClearDefaultPreset}
+                  disabled={presetBusy || !presetCollection.default_preset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Clear Default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRenamePreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeletePreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
+                >
+                  Delete
+                </button>
+              </div>
+
+              {presetNotice && <p className="text-[11px] text-emerald-400">{presetNotice}</p>}
+              {presetError && <p className="text-[11px] text-red-400">{presetError}</p>}
+            </section>
+
+            <section className={`${blockClass} p-4`}>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Timeout (seconds)
                   </label>
-                  <button
-                    type="button"
-                    onClick={handleSetDefaultPreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Mark Default
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleClearDefaultPreset}
-                    disabled={presetBusy || !presetCollection.default_preset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Clear Default
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleRenamePreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Rename
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDeletePreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
-                  >
-                    Delete
-                  </button>
-                </div>
-
-                {presetNotice && (
-                  <p className="text-[11px] text-emerald-400">{presetNotice}</p>
-                )}
-                {presetError && (
-                  <p className="text-[11px] text-red-400">{presetError}</p>
-                )}
-              </section>
-
-              <section className={`${blockClass} p-4`}>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Timeout (seconds)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.timeout}
-                      onChange={(event) => {
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "timeout",
-                          Number.isNaN(value) ? 10 : Math.max(0.5, value),
-                        );
-                      }}
-                      step="0.5"
-                      min="0.5"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Extended Timeout (seconds)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.extended_timeout ?? ""}
-                      onChange={(event) => {
-                        if (!event.target.value) {
-                          updateSetting("extended_timeout", null);
-                          return;
-                        }
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "extended_timeout",
-                          Number.isNaN(value) ? null : Math.max(1, value),
-                        );
-                      }}
-                      placeholder="Disabled"
-                      step="1"
-                      min="1"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Concurrency
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.concurrency || ""}
-                      placeholder="Auto"
-                      onChange={(event) => {
-                        const raw = event.target.value.trim();
-                        if (raw === "") {
-                          updateSetting("concurrency", 0);
-                          return;
-                        }
-                        const value = parseInt(raw, 10);
-                        updateSetting(
-                          "concurrency",
-                          Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
-                        );
-                      }}
-                      min="0"
-                      max="20"
-                      className={inputClass}
-                    />
-                    <p className="text-[11px] text-text-quaternary mt-1">
-                      0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1
-                      for single-server)
-                    </p>
-                  </div>
-
-                </div>
-              </section>
-
-              <section className={`${blockClass} p-4`}>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Max Retries
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.retries}
-                      onChange={(event) => {
-                        const value = parseInt(event.target.value, 10);
-                        updateSetting(
-                          "retries",
-                          Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
-                        );
-                      }}
-                      min="0"
-                      max="10"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Retry Backoff
-                    </label>
-                    <SegmentedControl
-                      value={draft.retry_backoff}
-                      options={[
-                        { value: "none", label: "None" },
-                        { value: "linear", label: "Linear" },
-                        { value: "exponential", label: "Exponential" },
-                      ]}
-                      onChange={(value) =>
-                        updateSetting("retry_backoff", value, { immediate: true })
-                      }
-                    />
-                  </div>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Low FPS threshold</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Streams below this FPS are flagged as low framerate.
-                    </p>
-                  </div>
                   <input
                     type="number"
-                    value={draft.low_fps_threshold}
+                    value={draft.timeout}
+                    onChange={(event) => {
+                      const value = parseFloat(event.target.value);
+                      updateSetting("timeout", Number.isNaN(value) ? 10 : Math.max(0.5, value));
+                    }}
+                    step="0.5"
+                    min="0.5"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Extended Timeout (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.extended_timeout ?? ""}
+                    onChange={(event) => {
+                      if (!event.target.value) {
+                        updateSetting("extended_timeout", null);
+                        return;
+                      }
+                      const value = parseFloat(event.target.value);
+                      updateSetting(
+                        "extended_timeout",
+                        Number.isNaN(value) ? null : Math.max(1, value),
+                      );
+                    }}
+                    placeholder="Disabled"
+                    step="1"
+                    min="1"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Concurrency
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.concurrency || ""}
+                    placeholder="Auto"
+                    onChange={(event) => {
+                      const raw = event.target.value.trim();
+                      if (raw === "") {
+                        updateSetting("concurrency", 0);
+                        return;
+                      }
+                      const value = parseInt(raw, 10);
+                      updateSetting(
+                        "concurrency",
+                        Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
+                      );
+                    }}
+                    min="0"
+                    max="20"
+                    className={inputClass}
+                  />
+                  <p className="text-[11px] text-text-quaternary mt-1">
+                    0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1 for
+                    single-server)
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className={`${blockClass} p-4`}>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Max Retries
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.retries}
+                    onChange={(event) => {
+                      const value = parseInt(event.target.value, 10);
+                      updateSetting(
+                        "retries",
+                        Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
+                      );
+                    }}
+                    min="0"
+                    max="10"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Retry Backoff
+                  </label>
+                  <SegmentedControl
+                    value={draft.retry_backoff}
+                    options={[
+                      { value: "none", label: "None" },
+                      { value: "linear", label: "Linear" },
+                      { value: "exponential", label: "Exponential" },
+                    ]}
+                    onChange={(value) => updateSetting("retry_backoff", value, { immediate: true })}
+                  />
+                </div>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Low FPS threshold</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Streams below this FPS are flagged as low framerate.
+                  </p>
+                </div>
+                <input
+                  type="number"
+                  value={draft.low_fps_threshold}
+                  onChange={(event) => {
+                    const value = parseFloat(event.target.value);
+                    updateSetting(
+                      "low_fps_threshold",
+                      Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
+                    );
+                  }}
+                  step="0.1"
+                  min="0"
+                  max="240"
+                  className={`${inputClass} w-24`}
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">User agent</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    HTTP user agent string sent with stream requests.
+                  </p>
+                </div>
+                <input
+                  type="text"
+                  value={draft.user_agent}
+                  onChange={(event) => updateSetting("user_agent", event.target.value)}
+                  className={`${inputClass} w-56`}
+                />
+              </div>
+            </section>
+          </>
+        )}
+
+        {activeTab === "media" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Skip screenshots</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Disable frame captures for faster checks.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.skip_screenshots}
+                  onChange={(checked) =>
+                    updateSetting("skip_screenshots", checked, { immediate: true })
+                  }
+                  ariaLabel="Skip screenshots"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Screenshot format</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    WebP is faster and smaller. PNG is lossless.
+                  </p>
+                </div>
+                <select
+                  value={draft.screenshot_format}
+                  onChange={(event) =>
+                    updateSetting(
+                      "screenshot_format",
+                      event.target.value as AppSettings["screenshot_format"],
+                      { immediate: true },
+                    )
+                  }
+                  className={`${inputClass} w-44`}
+                  disabled={draft.skip_screenshots}
+                >
+                  <option value="webp">WebP</option>
+                  <option value="png">PNG</option>
+                </select>
+              </div>
+
+              <div className={rowClass}>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-medium">Save screenshots to</p>
+                  <p
+                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                    title={draft.screenshots_dir ?? "Not saved (preview only)"}
+                  >
+                    {draft.screenshots_dir ?? "Not saved (preview only)"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleSelectScreenshotsDir}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                    type="button"
+                  >
+                    Browse
+                  </button>
+                  {draft.screenshots_dir && (
+                    <button
+                      onClick={() => updateSetting("screenshots_dir", null, { immediate: true })}
+                      className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                      type="button"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    {cacheStats
+                      ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
+                      : "Unavailable"}
+                    {cacheStats?.disk_space && (
+                      <span className="ml-1.5 text-text-tertiary/70">
+                        · {formatBytes(cacheStats.disk_space.available_bytes)} free
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <button
+                  onClick={handleClearScreenshotCache}
+                  disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
+                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  type="button"
+                >
+                  {cacheBusy ? "Clearing..." : "Clear Cache"}
+                </button>
+              </div>
+
+              {cacheStats && (
+                <p
+                  className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
+                  title={cacheStats.cache_dir}
+                >
+                  {cacheStats.cache_dir}
+                </p>
+              )}
+
+              <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Screenshot Retention
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.screenshot_retention_count}
+                    onChange={(event) => {
+                      const value = parseInt(event.target.value, 10);
+                      updateSetting(
+                        "screenshot_retention_count",
+                        Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
+                      );
+                    }}
+                    min="0"
+                    max="100"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Low Space Threshold (GB)
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.low_space_threshold_gb}
                     onChange={(event) => {
                       const value = parseFloat(event.target.value);
                       updateSetting(
-                        "low_fps_threshold",
-                        Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
+                        "low_space_threshold_gb",
+                        Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
                       );
                     }}
-                    step="0.1"
-                    min="0"
-                    max="240"
-                    className={`${inputClass} w-24`}
+                    step="0.5"
+                    min="1"
+                    max="50"
+                    className={inputClass}
                   />
                 </div>
-              </section>
+              </div>
+            </section>
+          </>
+        )}
 
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">User agent</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      HTTP user agent string sent with stream requests.
-                    </p>
-                  </div>
-                  <input
-                    type="text"
-                    value={draft.user_agent}
-                    onChange={(event) => updateSetting("user_agent", event.target.value)}
-                    className={`${inputClass} w-56`}
-                  />
-                </div>
-              </section>
-
-            </>
-          )}
-
-          {activeTab === "media" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Skip screenshots</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Disable frame captures for faster checks.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.skip_screenshots}
-                    onChange={(checked) =>
-                      updateSetting("skip_screenshots", checked, { immediate: true })
-                    }
-                    ariaLabel="Skip screenshots"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Screenshot format</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      WebP is faster and smaller. PNG is lossless.
-                    </p>
-                  </div>
-                  <select
-                    value={draft.screenshot_format}
-                    onChange={(event) =>
-                      updateSetting(
-                        "screenshot_format",
-                        event.target.value as AppSettings["screenshot_format"],
-                        { immediate: true },
-                      )
-                    }
-                    className={`${inputClass} w-44`}
-                    disabled={draft.skip_screenshots}
+        {activeTab === "network" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-medium">Proxy file</p>
+                  <p
+                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                    title={draft.proxy_file ?? "No proxy file selected"}
                   >
-                    <option value="webp">WebP</option>
-                    <option value="png">PNG</option>
-                  </select>
+                    {draft.proxy_file ?? "No proxy file selected"}
+                  </p>
                 </div>
-
-                <div className={rowClass}>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-medium">Save screenshots to</p>
-                    <p
-                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                      title={draft.screenshots_dir ?? "Not saved (preview only)"}
-                    >
-                      {draft.screenshots_dir ?? "Not saved (preview only)"}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={handleSelectScreenshotsDir}
-                      className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                      type="button"
-                    >
-                      Browse
-                    </button>
-                    {draft.screenshots_dir && (
-                      <button
-                        onClick={() =>
-                          updateSetting("screenshots_dir", null, { immediate: true })
-                        }
-                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                        type="button"
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      {cacheStats
-                        ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
-                        : "Unavailable"}
-                      {cacheStats?.disk_space && (
-                        <span className="ml-1.5 text-text-tertiary/70">
-                          · {formatBytes(cacheStats.disk_space.available_bytes)} free
-                        </span>
-                      )}
-                    </p>
-                  </div>
+                <div className="flex items-center gap-2">
                   <button
-                    onClick={handleClearScreenshotCache}
-                    disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                    onClick={handleSelectProxy}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                     type="button"
                   >
-                    {cacheBusy ? "Clearing..." : "Clear Cache"}
+                    Browse
                   </button>
-                </div>
-
-                {cacheStats && (
-                  <p
-                    className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
-                    title={cacheStats.cache_dir}
-                  >
-                    {cacheStats.cache_dir}
-                  </p>
-                )}
-
-                <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Screenshot Retention
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.screenshot_retention_count}
-                      onChange={(event) => {
-                        const value = parseInt(event.target.value, 10);
-                        updateSetting(
-                          "screenshot_retention_count",
-                          Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
-                        );
-                      }}
-                      min="0"
-                      max="100"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Low Space Threshold (GB)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.low_space_threshold_gb}
-                      onChange={(event) => {
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "low_space_threshold_gb",
-                          Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
-                        );
-                      }}
-                      step="0.5"
-                      min="1"
-                      max="50"
-                      className={inputClass}
-                    />
-                  </div>
-                </div>
-              </section>
-            </>
-          )}
-
-          {activeTab === "network" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-medium">Proxy file</p>
-                    <p
-                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                      title={draft.proxy_file ?? "No proxy file selected"}
-                    >
-                      {draft.proxy_file ?? "No proxy file selected"}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
+                  {draft.proxy_file && (
                     <button
-                      onClick={handleSelectProxy}
+                      onClick={() => updateSetting("proxy_file", null, { immediate: true })}
                       className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                       type="button"
                     >
-                      Browse
+                      Clear
                     </button>
-                    {draft.proxy_file && (
-                      <button
-                        onClick={() => updateSetting("proxy_file", null, { immediate: true })}
-                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                        type="button"
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
+                  )}
                 </div>
+              </div>
 
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Re-test geoblocked streams through your proxy list.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.test_geoblock}
-                    onChange={(checked) =>
-                      updateSetting("test_geoblock", checked, { immediate: true })
-                    }
-                    ariaLabel="Confirm geoblocks with proxies"
-                  />
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Re-test geoblocked streams through your proxy list.
+                  </p>
                 </div>
-              </section>
+                <Switch
+                  checked={draft.test_geoblock}
+                  onChange={(checked) =>
+                    updateSetting("test_geoblock", checked, { immediate: true })
+                  }
+                  ariaLabel="Confirm geoblocks with proxies"
+                />
+              </div>
+            </section>
 
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Skip certificate verification (insecure)</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Accept invalid/self-signed TLS certificates during stream checks.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.accept_invalid_certs}
-                    onChange={(checked) =>
-                      updateSetting("accept_invalid_certs", checked, { immediate: true })
-                    }
-                    ariaLabel="Skip certificate verification"
-                  />
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">
+                    Skip certificate verification (insecure)
+                  </p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Accept invalid/self-signed TLS certificates during stream checks.
+                  </p>
                 </div>
-              </section>
-            </>
-          )}
+                <Switch
+                  checked={draft.accept_invalid_certs}
+                  onChange={(checked) =>
+                    updateSetting("accept_invalid_certs", checked, { immediate: true })
+                  }
+                  ariaLabel="Skip certificate verification"
+                />
+              </div>
+            </section>
+          </>
+        )}
 
-          {activeTab === "advanced" && (
-            <>
-              <section className={`${blockClass} p-4`}>
+        {activeTab === "advanced" && (
+          <>
+            <section className={`${blockClass} p-4`}>
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
@@ -1321,7 +1285,6 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                     className={inputClass}
                   />
                 </div>
-
               </div>
             </section>
 
@@ -1371,9 +1334,9 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                 </div>
               </div>
             </section>
-            </>
-          )}
-        </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1125,7 +1125,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                 </p>
               )}
 
-              <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
+              <div className="grid grid-cols-2 gap-3 p-4 border-t border-border-subtle">
                 <div>
                   <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
                     Screenshot Retention

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -202,35 +202,15 @@ export function ThumbnailPanel({
     return () => window.removeEventListener("keydown", handler, true);
   }, [theaterMode]);
 
-  if (!result) {
-    return (
-      <div className="flex items-center justify-center h-full text-text-tertiary text-[12px]">
-        Select a channel to view details
-      </div>
-    );
-  }
+  // Every hook below must run unconditionally, so the "no selection" early
+  // return lives after them — bailing out first would change the hook count
+  // between renders as soon as a channel is selected.
+  const resolvedUrl = result?.stream_url?.trim() || null;
 
-  const retryCount = result.retry_count ?? 0;
-  const lastErrorReason = getChannelErrorReason(result);
-  const thumbnailState = getThumbnailDisplayState({
-    result,
-    screenshotUrl,
-    screenshotLoading,
-    screenshotLoadError,
-    screenshotsEnabled,
-    scanState,
-  });
-  const scanActive = isScanActive(scanState);
-  const resolvedUrl = result.stream_url?.trim() || null;
-  const showResolvedUrl = !!resolvedUrl && resolvedUrl !== result.url;
   // Memoized so the prop identity is stable across renders — without this, any
   // useEffect downstream of `castRequest` would tear down and re-fire on every
   // parent re-render even when none of its inputs actually changed.
-  const castRequest = useMemo(() => buildCastRequest(result), [result]);
-  const mediaFrameClass =
-    "relative w-full aspect-video overflow-hidden rounded-lg border border-border-app";
-  const lightboxPlaceholderClass =
-    "w-[400px] max-w-[88vw] aspect-video rounded-xl border border-white/15 bg-black/60 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]";
+  const castRequest = useMemo(() => (result ? buildCastRequest(result) : null), [result]);
 
   const handleCopyResolvedUrl = useCallback(async () => {
     if (!resolvedUrl) return;
@@ -250,7 +230,32 @@ export function ThumbnailPanel({
 
   useEffect(() => {
     setResolvedUrlCopied(false);
-  }, [result.index, result.stream_url, result.url]);
+  }, [result?.index, result?.stream_url, result?.url]);
+
+  if (!result || !castRequest) {
+    return (
+      <div className="flex items-center justify-center h-full text-text-tertiary text-[12px]">
+        Select a channel to view details
+      </div>
+    );
+  }
+
+  const retryCount = result.retry_count ?? 0;
+  const lastErrorReason = getChannelErrorReason(result);
+  const thumbnailState = getThumbnailDisplayState({
+    result,
+    screenshotUrl,
+    screenshotLoading,
+    screenshotLoadError,
+    screenshotsEnabled,
+    scanState,
+  });
+  const scanActive = isScanActive(scanState);
+  const showResolvedUrl = !!resolvedUrl && resolvedUrl !== result.url;
+  const mediaFrameClass =
+    "relative w-full aspect-video overflow-hidden rounded-lg border border-border-app";
+  const lightboxPlaceholderClass =
+    "w-[400px] max-w-[88vw] aspect-video rounded-xl border border-white/15 bg-black/60 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]";
 
   return (
     <div className="native-scroll flex flex-col gap-3 p-4 overflow-y-auto select-none">
@@ -494,6 +499,7 @@ export function ThumbnailPanel({
         <div className="p-2 rounded bg-orange-500/10 border border-orange-500/20">
           <p className="text-[12px] font-medium text-orange-400">Label Mismatch</p>
           {result.label_mismatches.map((m, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: plain-text list; mismatch strings can repeat, so index is the only stable key.
             <p key={i} className="text-[11px] text-orange-300">
               {m}
             </p>

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -44,7 +44,7 @@ import type {
   StalkerOpenRequest,
   XtreamOpenRequest,
 } from "../lib/types";
-import { useAppStore } from "../store";
+import { selectResultByIndex, useAppStore } from "../store";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -461,7 +461,7 @@ export function usePlaylistSources({
         return;
       }
 
-      const refreshed = getStore().results[selectedIndex];
+      const refreshed = selectResultByIndex(getStore(), selectedIndex);
       if (refreshed) {
         getStore().setSelectedChannel(refreshed);
       }

--- a/src/hooks/useScan.helpers.ts
+++ b/src/hooks/useScan.helpers.ts
@@ -79,7 +79,10 @@ export function applyResultUpdates(
 
   for (const result of batch) {
     const position = positions.get(result.index);
-    const previousResult = position == null ? null : (previous.flatResults[position] ?? null);
+    // Read through the working array, not `previous.flatResults`: an index
+    // first seen earlier in this same batch already has a position past the
+    // end of the old array, and reading there would count it as new twice.
+    const previousResult = position == null ? null : (flatResults[position] ?? null);
 
     if (!previousResult) {
       presentCount += 1;

--- a/src/hooks/useScan.helpers.ts
+++ b/src/hooks/useScan.helpers.ts
@@ -1,5 +1,4 @@
 import type { ChannelResult } from "../lib/types";
-import type { ScanResultLookup } from "../store/types";
 
 export interface ScanUiMetrics {
   presentCount: number;
@@ -7,11 +6,44 @@ export interface ScanUiMetrics {
   mislabeledCount: number;
 }
 
+/**
+ * The scan results as the UI holds them.
+ *
+ * `flatResults` is the single store of record; `positions` only says where a
+ * channel index landed in it. There is deliberately no second copy of the
+ * results keyed by index — maintaining one meant spreading an N-key object on
+ * every batch, which made a whole scan quadratic (a 50k-channel playlist spent
+ * ~14s just folding results into the store).
+ */
 export interface ScanResultCollections {
-  resultsByIndex: ScanResultLookup;
   flatResults: ChannelResult[];
-  indexToFlatPos: Map<number, number>;
+  /**
+   * Channel index -> position in `flatResults`.
+   *
+   * Append-only and mutated in place: a result keeps its position for the
+   * lifetime of a scan, so this never needs copying. Readers must therefore
+   * depend on `flatResults` — whose identity does change per batch — rather
+   * than on this map's identity.
+   */
+  positions: Map<number, number>;
   metrics: ScanUiMetrics;
+}
+
+export function emptyResultCollections(): ScanResultCollections {
+  return {
+    flatResults: [],
+    positions: new Map(),
+    metrics: { presentCount: 0, lowFpsCount: 0, mislabeledCount: 0 },
+  };
+}
+
+/** The result for a channel index, or null if it has not been checked yet. */
+export function resultAtIndex(
+  collections: Pick<ScanResultCollections, "flatResults" | "positions">,
+  index: number,
+): ChannelResult | null {
+  const position = collections.positions.get(index);
+  return position == null ? null : (collections.flatResults[position] ?? null);
 }
 
 export function isRunScopedEventForActiveRun(
@@ -29,17 +61,25 @@ export function applyResultUpdates(
     return previous;
   }
 
-  const resultsByIndex = { ...previous.resultsByIndex };
+  const positions = previous.positions;
   let flatResults = previous.flatResults;
-  let indexToFlatPos = previous.indexToFlatPos;
   let presentCount = previous.metrics.presentCount;
   let lowFpsCount = previous.metrics.lowFpsCount;
   let mislabeledCount = previous.metrics.mislabeledCount;
   let metricsChanged = false;
 
+  // Copy once per batch, not once per result: React needs a fresh array
+  // identity to re-render, but only one per applied batch.
+  const ensureOwnFlatResults = () => {
+    if (flatResults === previous.flatResults) {
+      flatResults = [...previous.flatResults];
+    }
+    return flatResults;
+  };
+
   for (const result of batch) {
-    const previousResult = resultsByIndex[result.index] ?? null;
-    resultsByIndex[result.index] = result;
+    const position = positions.get(result.index);
+    const previousResult = position == null ? null : (previous.flatResults[position] ?? null);
 
     if (!previousResult) {
       presentCount += 1;
@@ -59,37 +99,21 @@ export function applyResultUpdates(
       metricsChanged = true;
     }
 
-    const flatPos = indexToFlatPos.get(result.index);
-    if (flatPos == null) {
-      if (flatResults === previous.flatResults) {
-        flatResults = [...previous.flatResults];
-      }
-      if (indexToFlatPos === previous.indexToFlatPos) {
-        indexToFlatPos = new Map(previous.indexToFlatPos);
-      }
-      indexToFlatPos.set(result.index, flatResults.length);
-      flatResults.push(result);
+    if (position == null) {
+      const next = ensureOwnFlatResults();
+      positions.set(result.index, next.length);
+      next.push(result);
       continue;
     }
 
-    if (flatResults[flatPos] !== result) {
-      if (flatResults === previous.flatResults) {
-        flatResults = [...previous.flatResults];
-      }
-      flatResults[flatPos] = result;
+    if (flatResults[position] !== result) {
+      ensureOwnFlatResults()[position] = result;
     }
   }
 
   return {
-    resultsByIndex,
     flatResults,
-    indexToFlatPos,
-    metrics: metricsChanged
-      ? {
-          presentCount,
-          lowFpsCount,
-          mislabeledCount,
-        }
-      : previous.metrics,
+    positions,
+    metrics: metricsChanged ? { presentCount, lowFpsCount, mislabeledCount } : previous.metrics,
   };
 }

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -21,10 +21,11 @@ import type {
 } from "../lib/types";
 import { useAppStore } from "../store";
 import { EMPTY_TELEMETRY } from "../store/slices/scanSlice";
-import type { ScanResultLookup } from "../store/types";
 import {
   applyResultUpdates,
   isRunScopedEventForActiveRun,
+  resultAtIndex,
+  type ScanResultCollections,
   type ScanUiMetrics,
 } from "./useScan.helpers";
 
@@ -50,21 +51,14 @@ interface RunClockState {
   accumulatedPausedMs: number;
 }
 
-function buildFlatResultsAndMetrics(source: ChannelResult[]): {
-  resultsByIndex: ScanResultLookup;
-  flatResults: ChannelResult[];
-  indexToFlatPos: Map<number, number>;
-  metrics: ScanUiMetrics;
-} {
-  const resultsByIndex: ScanResultLookup = {};
+function buildFlatResultsAndMetrics(source: ChannelResult[]): ScanResultCollections {
   const flatResults: ChannelResult[] = [];
-  const indexToFlatPos = new Map<number, number>();
+  const positions = new Map<number, number>();
   let lowFpsCount = 0;
   let mislabeledCount = 0;
 
   for (const result of source) {
-    resultsByIndex[result.index] = result;
-    indexToFlatPos.set(result.index, flatResults.length);
+    positions.set(result.index, flatResults.length);
     flatResults.push(result);
     if (result.low_framerate) {
       lowFpsCount += 1;
@@ -75,9 +69,8 @@ function buildFlatResultsAndMetrics(source: ChannelResult[]): {
   }
 
   return {
-    resultsByIndex,
     flatResults,
-    indexToFlatPos,
+    positions,
     metrics: {
       presentCount: flatResults.length,
       lowFpsCount,
@@ -101,9 +94,8 @@ const getStore = () => useAppStore.getState();
 export function useScan() {
   // Batch incoming results with requestAnimationFrame
   const pendingResults = useRef<ChannelResult[]>([]);
-  const resultsRef = useRef<ScanResultLookup>({});
   const flatResultsRef = useRef<ChannelResult[]>([]);
-  const indexToFlatPosRef = useRef<Map<number, number>>(new Map());
+  const resultPositionsRef = useRef<Map<number, number>>(new Map());
   const uiMetricsRef = useRef<ScanUiMetrics>(EMPTY_UI_METRICS);
   const rafId = useRef<number | null>(null);
   const eventCount = useRef(0);
@@ -123,26 +115,17 @@ export function useScan() {
     resetScan().catch(() => {});
   }, []);
 
-  const commitCollections = useCallback(
-    (next: {
-      resultsByIndex: ScanResultLookup;
-      flatResults: ChannelResult[];
-      indexToFlatPos: Map<number, number>;
-      metrics: ScanUiMetrics;
-    }) => {
-      resultsRef.current = next.resultsByIndex;
-      flatResultsRef.current = next.flatResults;
-      indexToFlatPosRef.current = next.indexToFlatPos;
-      uiMetricsRef.current = next.metrics;
+  const commitCollections = useCallback((next: ScanResultCollections) => {
+    flatResultsRef.current = next.flatResults;
+    resultPositionsRef.current = next.positions;
+    uiMetricsRef.current = next.metrics;
 
-      getStore().applyScanCollections({
-        results: next.resultsByIndex,
-        flatResults: next.flatResults,
-        uiMetrics: next.metrics,
-      });
-    },
-    [],
-  );
+    getStore().applyScanCollections({
+      flatResults: next.flatResults,
+      resultPositions: next.positions,
+      uiMetrics: next.metrics,
+    });
+  }, []);
 
   const flushResults = useCallback(() => {
     if (pendingResults.current.length > 0) {
@@ -150,9 +133,8 @@ export function useScan() {
       pendingResults.current = [];
       const next = applyResultUpdates(
         {
-          resultsByIndex: resultsRef.current,
           flatResults: flatResultsRef.current,
-          indexToFlatPos: indexToFlatPosRef.current,
+          positions: resultPositionsRef.current,
           metrics: uiMetricsRef.current,
         },
         batch,
@@ -440,12 +422,7 @@ export function useScan() {
           : resetChannelResultForRescan(existing),
       );
       const rebuilt = buildFlatResultsAndMetrics(updated);
-      commitCollections({
-        resultsByIndex: rebuilt.resultsByIndex,
-        flatResults: rebuilt.flatResults,
-        indexToFlatPos: rebuilt.indexToFlatPos,
-        metrics: rebuilt.metrics,
-      });
+      commitCollections(rebuilt);
       getStore().applyScanRuntime({
         progress: {
           completed: 0,
@@ -559,7 +536,10 @@ export function useScan() {
       }
 
       const synced = channels.map((channel) => {
-        const existing = resultsRef.current[channel.index];
+        const existing = resultAtIndex(
+          { flatResults: flatResultsRef.current, positions: resultPositionsRef.current },
+          channel.index,
+        );
         if (preserveExistingResults && existing) {
           return mergeChannelIntoResult(channel, existing);
         }
@@ -572,12 +552,7 @@ export function useScan() {
       logger.debug(
         `[useScan] syncFromPlaylist: ${synced.length} channels, preserveExistingResults=${preserveExistingResults}, rebuild=${rebuildMs.toFixed(1)}ms`,
       );
-      commitCollections({
-        resultsByIndex: rebuilt.resultsByIndex,
-        flatResults: rebuilt.flatResults,
-        indexToFlatPos: rebuilt.indexToFlatPos,
-        metrics: rebuilt.metrics,
-      });
+      commitCollections(rebuilt);
       getStore().applyScanRuntime({
         duplicateIndices: new Set(),
         progress: null,
@@ -630,9 +605,8 @@ export function useScan() {
     (result: ChannelResult) => {
       const next = applyResultUpdates(
         {
-          resultsByIndex: resultsRef.current,
           flatResults: flatResultsRef.current,
-          indexToFlatPos: indexToFlatPosRef.current,
+          positions: resultPositionsRef.current,
           metrics: uiMetricsRef.current,
         },
         [result],

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,200 +1,172 @@
-import { getVersion } from "@tauri-apps/api/app";
 import { useCallback, useEffect, useRef } from "react";
-import { errorToString } from "../lib/errors";
+import { getVersion } from "@tauri-apps/api/app";
+import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../store";
-import type { UpdateNotice } from "../store/types";
+import {
+  checkForUpdates as invokeCheckForUpdates,
+  discoveredUpdate,
+  installUpdate as invokeInstallUpdate,
+  openManualUpdate,
+  updateInstallMode,
+} from "../lib/tauri";
+import type { UpdateInstallMode } from "../lib/updateState";
+import { isManualInstall, updateFailureDetail } from "../lib/updateState";
+import { errorToString } from "../lib/errors";
+import { logger } from "../lib/logger";
 
-const UPDATE_CHECK_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-const UPDATE_CHECK_TIMEOUT_MS = 15_000;
-const UPDATE_LAST_CHECK_KEY = "updates:last-check-epoch-ms";
-const UPDATE_CACHE_KEY = "updates:last-available-release";
-const GITHUB_LATEST_RELEASE_API =
-  "https://api.github.com/repos/kristofferR/IPTVChecker/releases/latest";
-const GITHUB_RELEASES_PAGE = "https://github.com/kristofferR/IPTVChecker/releases";
+/** Emitted by the backend's periodic check when it finds a new version. */
+const UPDATE_AVAILABLE_EVENT = "updater://update-available";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
 
-function normalizeVersion(version: string): string {
-  return version.trim().replace(/^v/i, "");
-}
-
-function parseVersionParts(version: string): number[] {
-  const numeric = normalizeVersion(version)
-    .split(".")
-    .map((part) => {
-      const matched = part.match(/^\d+/);
-      return matched ? Number.parseInt(matched[0], 10) : 0;
-    });
-  return numeric.length > 0 ? numeric : [0];
-}
-
-function compareVersions(left: string, right: string): number {
-  const leftParts = parseVersionParts(left);
-  const rightParts = parseVersionParts(right);
-  const maxLength = Math.max(leftParts.length, rightParts.length);
-
-  for (let index = 0; index < maxLength; index += 1) {
-    const a = leftParts[index] ?? 0;
-    const b = rightParts[index] ?? 0;
-    if (a > b) return 1;
-    if (a < b) return -1;
-  }
-
-  return 0;
-}
-
-function readCachedUpdateNotice(): UpdateNotice | null {
-  const raw = localStorage.getItem(UPDATE_CACHE_KEY);
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as UpdateNotice;
-    if (!parsed.latest_version || !parsed.release_url) {
-      return null;
-    }
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function shouldSkipUpdateCheck(
-  force: boolean,
-  now: number,
-  lastCheckedRaw: string | null,
-): boolean {
-  const lastChecked = lastCheckedRaw ? Number.parseInt(lastCheckedRaw, 10) : Number.NaN;
-  return !force && Number.isFinite(lastChecked) && now - lastChecked < UPDATE_CHECK_COOLDOWN_MS;
-}
-
-/** Clears the update banner and its cached release info (used by the banner's
- *  dismiss button). */
+/** Clears the update banner. The backend keeps its own discovery, so a later
+ *  manual check can surface the same version again. */
 export function dismissUpdateNotice(): void {
   getStore().setUpdateNotice(null);
-  localStorage.removeItem(UPDATE_CACHE_KEY);
 }
 
-/** Checks GitHub releases for a newer version. Runs an initial (cooldown-gated)
- *  check on mount and returns `checkForUpdates` for the menu's manual check. */
+/**
+ * Drives the signed in-app updater.
+ *
+ * Discovery and installation are deliberately separate: nothing is downloaded
+ * until `installUpdate` is called, and installs on package-manager-owned
+ * copies (AUR, .deb/.rpm) are redirected to the distribution's page instead of
+ * replacing files the package manager owns.
+ */
 export function useUpdateCheck(): {
-  checkForUpdates: (force: boolean, knownCurrentVersion?: string) => Promise<void>;
+  checkForUpdates: (force: boolean) => Promise<void>;
+  installUpdate: () => Promise<void>;
 } {
   const requestIdRef = useRef(0);
-  const activeControllerRef = useRef<AbortController | null>(null);
+  const installModeRef = useRef<UpdateInstallMode | null>(null);
 
-  const checkForUpdates = useCallback(async (force: boolean, knownCurrentVersion?: string) => {
-    const now = Date.now();
-    const lastCheckedRaw = localStorage.getItem(UPDATE_LAST_CHECK_KEY);
-    if (shouldSkipUpdateCheck(force, now, lastCheckedRaw)) {
+  // The install mode cannot change while the app runs, and detecting it shells
+  // out to pacman on Linux, so resolve it once.
+  const resolveInstallMode = useCallback(async (): Promise<UpdateInstallMode> => {
+    if (installModeRef.current) return installModeRef.current;
+    const mode = await updateInstallMode();
+    installModeRef.current = mode;
+    return mode;
+  }, []);
+
+  const checkForUpdates = useCallback(
+    async (force: boolean) => {
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      const isCurrentRequest = () => requestIdRef.current === requestId;
+
+      getStore().setUpdatePhase("checking");
+      try {
+        const [result, installMode] = await Promise.all([
+          invokeCheckForUpdates(),
+          resolveInstallMode(),
+        ]);
+        if (!isCurrentRequest()) return;
+
+        if (result.version) {
+          getStore().setUpdateNotice({
+            version: result.version,
+            notes: result.notes,
+            installMode,
+          });
+          return;
+        }
+
+        getStore().setUpdateNotice(null);
+        if (force) {
+          const current = getStore().appVersion;
+          getStore().setMenuInfo(`You're up to date${current ? ` (v${current})` : ""}.`);
+        }
+      } catch (err) {
+        if (!isCurrentRequest()) return;
+        logger.error("[Update] Check failed:", errorToString(err));
+        if (force) {
+          getStore().setMenuInfo(`Update check failed: ${updateFailureDetail(errorToString(err))}`);
+        }
+      } finally {
+        if (isCurrentRequest()) getStore().setUpdatePhase("idle");
+      }
+    },
+    [resolveInstallMode],
+  );
+
+  /** Installs the discovered update, or opens the distribution's update page
+   *  when this copy is owned by a package manager. */
+  const installUpdate = useCallback(async () => {
+    const notice = getStore().updateNotice;
+    if (!notice) return;
+
+    if (isManualInstall(notice.installMode)) {
+      try {
+        await openManualUpdate();
+      } catch (err) {
+        logger.error("[Update] Failed to open the update page:", errorToString(err));
+        getStore().setMenuInfo(
+          `Could not open the update page: ${updateFailureDetail(errorToString(err))}`,
+        );
+      }
       return;
     }
 
-    const requestId = requestIdRef.current + 1;
-    requestIdRef.current = requestId;
-    activeControllerRef.current?.abort();
-    const controller = new AbortController();
-    activeControllerRef.current = controller;
-    const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS);
-    const isCurrentRequest = () => requestIdRef.current === requestId;
-
+    getStore().setUpdatePhase("installing");
     try {
-      const currentVersion = normalizeVersion(knownCurrentVersion ?? (await getVersion()));
-      if (!isCurrentRequest() || controller.signal.aborted) return;
-      getStore().setAppVersion(currentVersion);
-
-      const response = await fetch(GITHUB_LATEST_RELEASE_API, {
-        headers: {
-          Accept: "application/vnd.github+json",
-        },
-        signal: controller.signal,
-      });
-
-      if (!isCurrentRequest() || controller.signal.aborted) return;
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const release = (await response.json()) as {
-        tag_name?: string;
-        html_url?: string;
-      };
-
-      if (!isCurrentRequest() || controller.signal.aborted) return;
-      const latestVersion = normalizeVersion(release.tag_name ?? "");
-      if (!latestVersion) {
-        throw new Error("Latest release version is missing");
-      }
-
-      localStorage.setItem(UPDATE_LAST_CHECK_KEY, String(now));
-
-      if (compareVersions(latestVersion, currentVersion) > 0) {
-        const notice: UpdateNotice = {
-          latest_version: latestVersion,
-          release_url: release.html_url || GITHUB_RELEASES_PAGE,
-          checked_at_epoch_ms: now,
-        };
-        getStore().setUpdateNotice(notice);
-        localStorage.setItem(UPDATE_CACHE_KEY, JSON.stringify(notice));
-        return;
-      }
-
-      getStore().setUpdateNotice(null);
-      localStorage.removeItem(UPDATE_CACHE_KEY);
-      if (force) {
-        getStore().setMenuInfo(`You're up to date (v${currentVersion}).`);
+      // On success the app restarts, so nothing after this runs.
+      const installed = await invokeInstallUpdate();
+      if (!installed) {
+        getStore().setUpdateNotice(null);
+        getStore().setMenuInfo("IPTV Checker is already up to date.");
       }
     } catch (err) {
-      if (!isCurrentRequest()) return;
-      if (force) {
-        const detail = controller.signal.aborted ? "Request timed out." : errorToString(err);
-        getStore().setMenuInfo(`Update check failed: ${detail}`);
-      }
+      logger.error("[Update] Install failed:", errorToString(err));
+      getStore().setMenuInfo(`Update install failed: ${updateFailureDetail(errorToString(err))}`);
     } finally {
-      clearTimeout(timeout);
-      if (activeControllerRef.current === controller) {
-        activeControllerRef.current = null;
-      }
+      getStore().setUpdatePhase("idle");
     }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
 
-    const runInitialUpdateCheck = async () => {
-      let currentVersion = "";
+    // Adopt whatever the backend's startup check already found instead of
+    // issuing a second network request from the frontend.
+    const adoptExistingDiscovery = async () => {
       try {
-        currentVersion = normalizeVersion(await getVersion());
-        if (!cancelled) {
-          getStore().setAppVersion(currentVersion);
+        const [version, currentVersion, installMode] = await Promise.all([
+          discoveredUpdate(),
+          getVersion(),
+          resolveInstallMode(),
+        ]);
+        if (cancelled) return;
+        getStore().setAppVersion(currentVersion.replace(/^v/i, ""));
+        if (version) {
+          getStore().setUpdateNotice({ version, notes: null, installMode });
         }
-      } catch {
-        currentVersion = "";
+      } catch (err) {
+        logger.error("[Update] Initial update state failed:", errorToString(err));
       }
-
-      if (cancelled) return;
-
-      const cachedNotice = readCachedUpdateNotice();
-      if (
-        cachedNotice &&
-        currentVersion &&
-        compareVersions(cachedNotice.latest_version, currentVersion) > 0
-      ) {
-        getStore().setUpdateNotice(cachedNotice);
-      } else if (cachedNotice) {
-        localStorage.removeItem(UPDATE_CACHE_KEY);
-      }
-
-      await checkForUpdates(false, currentVersion || undefined);
     };
 
-    void runInitialUpdateCheck();
+    void adoptExistingDiscovery();
+
+    const unlisten = listen<string>(UPDATE_AVAILABLE_EVENT, (event) => {
+      void (async () => {
+        try {
+          const installMode = await resolveInstallMode();
+          if (cancelled) return;
+          getStore().setUpdateNotice({ version: event.payload, notes: null, installMode });
+        } catch (err) {
+          logger.error("[Update] Failed to surface a discovered update:", errorToString(err));
+        }
+      })();
+    });
+
     return () => {
       cancelled = true;
       requestIdRef.current += 1;
-      activeControllerRef.current?.abort();
-      activeControllerRef.current = null;
+      void unlisten.then((off) => off()).catch(() => {});
     };
-  }, [checkForUpdates]);
+  }, [resolveInstallMode]);
 
-  return { checkForUpdates };
+  return { checkForUpdates, installUpdate };
 }

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -97,7 +97,12 @@ export function useUpdateCheck(): {
           getStore().setMenuInfo(`Update check failed: ${updateFailureDetail(errorToString(err))}`);
         }
       } finally {
-        if (isCurrentRequest()) getStore().setUpdatePhase("idle");
+        // Only clear our own phase: an install may have started while this
+        // check was in flight, and resetting to idle would re-enable the
+        // button mid-download.
+        if (isCurrentRequest() && getStore().updatePhase === "checking") {
+          getStore().setUpdatePhase("idle");
+        }
       }
     },
     [resolveInstallMode],
@@ -163,8 +168,10 @@ export function useUpdateCheck(): {
       }
     };
 
-    void adoptExistingDiscovery();
-
+    // Subscribe before reading the snapshot. The backend's launch-time check
+    // emits once and then remembers the version, so an event landing between
+    // the snapshot returning and the listener attaching would be lost until
+    // the user checked manually.
     const unlisten = listen<string>(UPDATE_AVAILABLE_EVENT, (event) => {
       void (async () => {
         try {
@@ -176,6 +183,8 @@ export function useUpdateCheck(): {
         }
       })();
     });
+
+    void unlisten.then(() => adoptExistingDiscovery());
 
     return () => {
       cancelled = true;

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -108,6 +108,10 @@ export function useUpdateCheck(): {
   const installUpdate = useCallback(async () => {
     const notice = getStore().updateNotice;
     if (!notice) return;
+    // The banner disables its button while installing, but a menu action or a
+    // double activation could still re-enter; the backend would reject the
+    // second install anyway, so fail fast rather than surface that as an error.
+    if (getStore().updatePhase === "installing") return;
 
     if (isManualInstall(notice.installMode)) {
       try {

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -64,6 +64,11 @@ export function useUpdateCheck(): {
 
   const checkForUpdates = useCallback(
     async (force: boolean) => {
+      // Never take the phase from a running install: doing so drops the
+      // "Installing…" label and re-enables the button mid-download, which also
+      // defeats installUpdate's re-entry guard.
+      if (getStore().updatePhase === "installing") return;
+
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       const isCurrentRequest = () => requestIdRef.current === requestId;

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,18 +1,18 @@
-import { useCallback, useEffect, useRef } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
-import { useAppStore } from "../store";
+import { useCallback, useEffect, useRef } from "react";
+import { errorToString } from "../lib/errors";
+import { logger } from "../lib/logger";
 import {
-  checkForUpdates as invokeCheckForUpdates,
   discoveredUpdate,
+  checkForUpdates as invokeCheckForUpdates,
   installUpdate as invokeInstallUpdate,
   openManualUpdate,
   updateInstallMode,
 } from "../lib/tauri";
 import type { UpdateInstallMode } from "../lib/updateState";
 import { isManualInstall, updateFailureDetail } from "../lib/updateState";
-import { errorToString } from "../lib/errors";
-import { logger } from "../lib/logger";
+import { useAppStore } from "../store";
 
 /** Emitted by the backend's periodic check when it finds a new version. */
 const UPDATE_AVAILABLE_EVENT = "updater://update-available";

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -40,14 +40,26 @@ export function useUpdateCheck(): {
 } {
   const requestIdRef = useRef(0);
   const installModeRef = useRef<UpdateInstallMode | null>(null);
+  const installModeRequestRef = useRef<Promise<UpdateInstallMode> | null>(null);
 
   // The install mode cannot change while the app runs, and detecting it shells
-  // out to pacman on Linux, so resolve it once.
+  // out to pacman on Linux, so resolve it once. The in-flight promise is shared
+  // too: the mount effect and a manual check can ask concurrently, and that
+  // should not run detection twice.
   const resolveInstallMode = useCallback(async (): Promise<UpdateInstallMode> => {
     if (installModeRef.current) return installModeRef.current;
-    const mode = await updateInstallMode();
-    installModeRef.current = mode;
-    return mode;
+    if (!installModeRequestRef.current) {
+      installModeRequestRef.current = updateInstallMode()
+        .then((mode) => {
+          installModeRef.current = mode;
+          return mode;
+        })
+        .finally(() => {
+          // Clear on failure too, so a later attempt can retry.
+          installModeRequestRef.current = null;
+        });
+    }
+    return installModeRequestRef.current;
   }, []);
 
   const checkForUpdates = useCallback(

--- a/src/index.css
+++ b/src/index.css
@@ -531,6 +531,7 @@ body {
 }
 
 [data-platform="macos"] .glass-material {
+  /* biome-ignore lint/correctness/noUnknownProperty: real Safari/WebKit property. */
   -apple-visual-effect: -apple-system-glass-material;
   background: transparent !important;
   -webkit-backdrop-filter: blur(30px) saturate(180%);

--- a/src/lib/perf.ts
+++ b/src/lib/perf.ts
@@ -34,6 +34,7 @@ export function recordUiPerf(sample: Omit<UiPerfSample, "atEpochMs">): void {
     atEpochMs: Date.now(),
   };
 
+  // biome-ignore lint/suspicious/noAssignInExpressions: lazy-init of the shared buffer; splitting it needs a redundant check.
   const buffer = (window.__iptvUiPerfSamples ??= []);
   buffer.push(nextSample);
   if (buffer.length > PERF_BUFFER_LIMIT) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,4 @@
 import { invoke } from "@tauri-apps/api/core";
-import { toCommandChannelResult } from "./channelResults";
 import type {
   AppSettings,
   CastMediaRequest,
@@ -7,21 +6,24 @@ import type {
   ChannelResult,
   ChromecastDevice,
   PlaylistPreview,
+  ScanPresetCollection,
+  ScanPresetConfig,
+  ScanConfig,
+  ScanHistoryItem,
   RecentPlaylistEntry,
   RecentPlaylistKind,
   RenamePlaylistSourceInput,
   SavedPlaylistDraft,
   SavedPlaylistEntry,
   SavedPlaylistUpsertResult,
-  ScanConfig,
-  ScanHistoryItem,
-  ScanPresetCollection,
-  ScanPresetConfig,
   ScreenshotCacheStats,
   StalkerOpenRequest,
+  UpdateCheckResult,
   XtreamOpenRequest,
   XtreamServerTestReport,
 } from "./types";
+import type { UpdateInstallMode } from "./updateState";
+import { toCommandChannelResult } from "./channelResults";
 
 function toCommandChannelResults(results: ChannelResult[]) {
   return results.map(toCommandChannelResult);
@@ -113,21 +115,30 @@ export async function exportCsv(
   });
 }
 
-export async function exportSplit(results: ChannelResult[], basePath: string): Promise<void> {
+export async function exportSplit(
+  results: ChannelResult[],
+  basePath: string,
+): Promise<void> {
   return invoke("export_split", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportRenamed(results: ChannelResult[], basePath: string): Promise<void> {
+export async function exportRenamed(
+  results: ChannelResult[],
+  basePath: string,
+): Promise<void> {
   return invoke("export_renamed", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportM3u(results: ChannelResult[], path: string): Promise<void> {
+export async function exportM3u(
+  results: ChannelResult[],
+  path: string,
+): Promise<void> {
   return invoke("export_m3u", {
     results: toCommandChannelResults(results),
     path,
@@ -172,7 +183,9 @@ export async function deleteScanPreset(name: string): Promise<ScanPresetCollecti
   return invoke("delete_scan_preset", { name });
 }
 
-export async function setDefaultScanPreset(name: string | null): Promise<ScanPresetCollection> {
+export async function setDefaultScanPreset(
+  name: string | null,
+): Promise<ScanPresetCollection> {
   return invoke("set_default_scan_preset", { name });
 }
 
@@ -266,7 +279,9 @@ export async function openSavedPlaylist(
   });
 }
 
-export async function renamePlaylistSource(input: RenamePlaylistSourceInput): Promise<void> {
+export async function renamePlaylistSource(
+  input: RenamePlaylistSourceInput,
+): Promise<void> {
   return invoke("rename_playlist_source", { input });
 }
 
@@ -307,4 +322,33 @@ export async function stopCast(): Promise<void> {
 
 export async function getCastStatus(): Promise<CastSession | null> {
   return invoke("get_cast_status");
+}
+
+// --- Updater ---------------------------------------------------------------
+
+/** Look for a newer signed release. Never downloads or installs anything. */
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
+  return invoke("check_for_updates");
+}
+
+/** The version found by the last check, without a network request. */
+export async function discoveredUpdate(): Promise<string | null> {
+  return invoke("discovered_update");
+}
+
+/** Whether this installation can replace itself, or must go through its own
+ *  package manager (AUR, apt/dnf). */
+export async function updateInstallMode(): Promise<UpdateInstallMode> {
+  return invoke("update_install_mode");
+}
+
+/** Open the distribution's update page. Only valid in manual install mode. */
+export async function openManualUpdate(): Promise<void> {
+  return invoke("open_manual_update");
+}
+
+/** Install the discovered update and restart. Resolves to `false` if there
+ *  turned out to be nothing to install. */
+export async function installUpdate(): Promise<boolean> {
+  return invoke("install_update");
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { toCommandChannelResult } from "./channelResults";
 import type {
   AppSettings,
   CastMediaRequest,
@@ -6,16 +7,16 @@ import type {
   ChannelResult,
   ChromecastDevice,
   PlaylistPreview,
-  ScanPresetCollection,
-  ScanPresetConfig,
-  ScanConfig,
-  ScanHistoryItem,
   RecentPlaylistEntry,
   RecentPlaylistKind,
   RenamePlaylistSourceInput,
   SavedPlaylistDraft,
   SavedPlaylistEntry,
   SavedPlaylistUpsertResult,
+  ScanConfig,
+  ScanHistoryItem,
+  ScanPresetCollection,
+  ScanPresetConfig,
   ScreenshotCacheStats,
   StalkerOpenRequest,
   UpdateCheckResult,
@@ -23,7 +24,6 @@ import type {
   XtreamServerTestReport,
 } from "./types";
 import type { UpdateInstallMode } from "./updateState";
-import { toCommandChannelResult } from "./channelResults";
 
 function toCommandChannelResults(results: ChannelResult[]) {
   return results.map(toCommandChannelResult);
@@ -115,30 +115,21 @@ export async function exportCsv(
   });
 }
 
-export async function exportSplit(
-  results: ChannelResult[],
-  basePath: string,
-): Promise<void> {
+export async function exportSplit(results: ChannelResult[], basePath: string): Promise<void> {
   return invoke("export_split", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportRenamed(
-  results: ChannelResult[],
-  basePath: string,
-): Promise<void> {
+export async function exportRenamed(results: ChannelResult[], basePath: string): Promise<void> {
   return invoke("export_renamed", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportM3u(
-  results: ChannelResult[],
-  path: string,
-): Promise<void> {
+export async function exportM3u(results: ChannelResult[], path: string): Promise<void> {
   return invoke("export_m3u", {
     results: toCommandChannelResults(results),
     path,
@@ -183,9 +174,7 @@ export async function deleteScanPreset(name: string): Promise<ScanPresetCollecti
   return invoke("delete_scan_preset", { name });
 }
 
-export async function setDefaultScanPreset(
-  name: string | null,
-): Promise<ScanPresetCollection> {
+export async function setDefaultScanPreset(name: string | null): Promise<ScanPresetCollection> {
   return invoke("set_default_scan_preset", { name });
 }
 
@@ -279,9 +268,7 @@ export async function openSavedPlaylist(
   });
 }
 
-export async function renamePlaylistSource(
-  input: RenamePlaylistSourceInput,
-): Promise<void> {
+export async function renamePlaylistSource(input: RenamePlaylistSourceInput): Promise<void> {
   return invoke("rename_playlist_source", { input });
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -20,10 +20,10 @@ import type {
   ScreenshotCacheStats,
   StalkerOpenRequest,
   UpdateCheckResult,
+  UpdateInstallMode,
   XtreamOpenRequest,
   XtreamServerTestReport,
 } from "./types";
-import type { UpdateInstallMode } from "./updateState";
 
 function toCommandChannelResults(results: ChannelResult[]) {
   return results.map(toCommandChannelResult);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -460,6 +460,16 @@ export interface CastMediaRequest {
   streamKind: CastStreamKind;
 }
 
+export type UpdateInstallKind = "built-in" | "manual";
+
+/** Mirrors the Rust `UpdateInstallMode`. `buttonLabel`/`instructions` are only
+ *  set for installations that must be updated by their own package manager. */
+export interface UpdateInstallMode {
+  kind: UpdateInstallKind;
+  buttonLabel: string | null;
+  instructions: string | null;
+}
+
 /** Result of a `check_for_updates` call. `version` is null when up to date. */
 export interface UpdateCheckResult {
   version: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -321,6 +321,7 @@ export interface AppSettings {
   low_space_threshold_gb: number;
   separate_placeholder_status: boolean;
   show_header_button_text: boolean;
+  automatic_update_checks: boolean;
 }
 
 export interface ScanPresetConfig {
@@ -457,4 +458,10 @@ export interface CastMediaRequest {
   channelName: string | null;
   channelLogo: string | null;
   streamKind: CastStreamKind;
+}
+
+/** Result of a `check_for_updates` call. `version` is null when up to date. */
+export interface UpdateCheckResult {
+  version: string | null;
+  notes: string | null;
 }

--- a/src/lib/updateState.ts
+++ b/src/lib/updateState.ts
@@ -1,0 +1,55 @@
+/** Types and pure presentation logic for the in-app updater. The effectful
+ *  parts (IPC, listeners, cooldowns) live in `hooks/useUpdateCheck.ts`. */
+
+export type UpdateInstallKind = "built-in" | "manual";
+
+/** Mirrors the Rust `UpdateInstallMode`. `buttonLabel`/`instructions` are only
+ *  set for installations that must be updated by their own package manager. */
+export interface UpdateInstallMode {
+  kind: UpdateInstallKind;
+  buttonLabel: string | null;
+  instructions: string | null;
+}
+
+export interface UpdateNotice {
+  version: string;
+  notes: string | null;
+  installMode: UpdateInstallMode;
+}
+
+export type UpdatePhase = "idle" | "checking" | "installing";
+
+export function isManualInstall(mode: UpdateInstallMode): boolean {
+  return mode.kind === "manual";
+}
+
+/** Label for the banner's primary action. Manual installs use the label the
+ *  backend supplied, since only it knows which package manager owns this copy. */
+export function updateActionLabel(notice: UpdateNotice, phase: UpdatePhase): string {
+  if (phase === "installing") return "Installing…";
+  if (isManualInstall(notice.installMode)) {
+    return notice.installMode.buttonLabel ?? "How to update";
+  }
+  return `Install v${notice.version}`;
+}
+
+/** Banner text. Manual installs append the package-manager instructions,
+ *  because for them the action only opens a page. */
+export function updateBannerMessage(notice: UpdateNotice, currentVersion: string): string {
+  const current = currentVersion ? ` (current v${currentVersion})` : "";
+  const base = `Update available: v${notice.version}${current}.`;
+  const instructions = notice.installMode.instructions;
+  return instructions ? `${base} ${instructions}` : base;
+}
+
+/** Confirmation shown before an install replaces the running app. */
+export function updateConfirmMessage(notice: UpdateNotice): string {
+  return isManualInstall(notice.installMode)
+    ? `IPTV Checker ${notice.version} is available. Open the update instructions?`
+    : `Install IPTV Checker ${notice.version} now? The app will restart.`;
+}
+
+/** Trims a backend error into a single line suitable for the banner. */
+export function updateFailureDetail(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, 240);
+}

--- a/src/lib/updateState.ts
+++ b/src/lib/updateState.ts
@@ -1,15 +1,9 @@
 /** Types and pure presentation logic for the in-app updater. The effectful
  *  parts (IPC, listeners, cooldowns) live in `hooks/useUpdateCheck.ts`. */
 
-export type UpdateInstallKind = "built-in" | "manual";
+import type { UpdateInstallMode } from "./types";
 
-/** Mirrors the Rust `UpdateInstallMode`. `buttonLabel`/`instructions` are only
- *  set for installations that must be updated by their own package manager. */
-export interface UpdateInstallMode {
-  kind: UpdateInstallKind;
-  buttonLabel: string | null;
-  instructions: string | null;
-}
+export type { UpdateInstallKind, UpdateInstallMode } from "./types";
 
 export interface UpdateNotice {
   version: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,12 @@
+import { resultAtIndex } from "../hooks/useScan.helpers";
+import type { ChannelResult } from "../lib/types";
+import type { AppStore } from "./types";
+
 export { useAppStore } from "./store";
 export type { AppStore } from "./types";
+
+/** The scan result for a channel index, or null if it has not been checked
+ *  yet. Results live only in `flatResults`; `resultPositions` says where. */
+export function selectResultByIndex(state: AppStore, index: number): ChannelResult | null {
+  return resultAtIndex({ flatResults: state.flatResults, positions: state.resultPositions }, index);
+}

--- a/src/store/slices/scanSlice.ts
+++ b/src/store/slices/scanSlice.ts
@@ -13,8 +13,8 @@ export const EMPTY_TELEMETRY: ScanTelemetry = {
 };
 
 export const createScanSlice: StateCreator<AppStore, [], [], ScanSlice> = (set) => ({
-  results: {},
   flatResults: [],
+  resultPositions: new Map(),
   uiMetrics: { presentCount: 0, lowFpsCount: 0, mislabeledCount: 0 },
   duplicateIndices: new Set(),
   progress: null,
@@ -27,8 +27,8 @@ export const createScanSlice: StateCreator<AppStore, [], [], ScanSlice> = (set) 
 
   applyScanCollections: (update: ScanCollectionsUpdate) =>
     set({
-      results: update.results,
       flatResults: update.flatResults,
+      resultPositions: update.resultPositions,
       uiMetrics: update.uiMetrics,
     }),
   applyScanRuntime: (update: ScanRuntimeUpdate) => set(update),

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -35,6 +35,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   low_space_threshold_gb: 5.0,
   separate_placeholder_status: true,
   show_header_button_text: defaultShowHeaderButtonText,
+  automatic_update_checks: true,
 };
 
 function applyPresetConfig(base: AppSettings, config: ScanPresetConfig): AppSettings {

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -31,6 +31,7 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
   menuInfo: null,
   menuExportRequest: null,
   updateNotice: null,
+  updatePhase: "idle",
   appVersion: "",
   openSourceDialogState: null,
 
@@ -96,6 +97,7 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
       menuExportRequest: { id: (state.menuExportRequest?.id ?? 0) + 1, action },
     })),
   setUpdateNotice: (updateNotice) => set({ updateNotice }),
+  setUpdatePhase: (updatePhase) => set({ updatePhase }),
   setAppVersion: (appVersion) => set({ appVersion }),
   setOpenSourceDialogState: (openSourceDialogState) => set({ openSourceDialogState }),
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,3 +1,6 @@
+import type { ScanUiMetrics } from "../hooks/useScan.helpers";
+import type { Platform } from "../lib/platform";
+import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
@@ -12,10 +15,7 @@ import type {
   StalkerOpenRequest,
   XtreamRecentSource,
 } from "../lib/types";
-import type { Platform } from "../lib/platform";
-import type { ScanState } from "../lib/scanState";
 import type { UpdateNotice, UpdatePhase } from "../lib/updateState";
-import type { ScanUiMetrics } from "../hooks/useScan.helpers";
 
 // ---------------------------------------------------------------------------
 // Playlist

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,6 +1,3 @@
-import type { ScanUiMetrics } from "../hooks/useScan.helpers";
-import type { Platform } from "../lib/platform";
-import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
@@ -15,6 +12,10 @@ import type {
   StalkerOpenRequest,
   XtreamRecentSource,
 } from "../lib/types";
+import type { Platform } from "../lib/platform";
+import type { ScanState } from "../lib/scanState";
+import type { UpdateNotice, UpdatePhase } from "../lib/updateState";
+import type { ScanUiMetrics } from "../hooks/useScan.helpers";
 
 // ---------------------------------------------------------------------------
 // Playlist
@@ -134,11 +135,7 @@ export interface MenuExportRequest {
   action: "csv" | "split" | "renamed" | "m3u" | "scanlog";
 }
 
-export interface UpdateNotice {
-  latest_version: string;
-  release_url: string;
-  checked_at_epoch_ms: number;
-}
+export type { UpdateNotice, UpdatePhase } from "../lib/updateState";
 
 export interface UiSlice {
   platform: Platform;
@@ -160,6 +157,7 @@ export interface UiSlice {
   menuInfo: string | null;
   menuExportRequest: MenuExportRequest | null;
   updateNotice: UpdateNotice | null;
+  updatePhase: UpdatePhase;
   appVersion: string;
   openSourceDialogState: OpenSourceDialogState | null;
 
@@ -185,6 +183,7 @@ export interface UiSlice {
   setMenuExportRequest: (request: MenuExportRequest | null) => void;
   queueMenuExportRequest: (action: MenuExportRequest["action"]) => void;
   setUpdateNotice: (notice: UpdateNotice | null) => void;
+  setUpdatePhase: (phase: UpdatePhase) => void;
   setAppVersion: (version: string) => void;
   setOpenSourceDialogState: (state: OpenSourceDialogState | null) => void;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -52,11 +52,9 @@ export interface ScanTelemetry {
   etaSeconds: number | null;
 }
 
-export type ScanResultLookup = Record<number, ChannelResult | undefined>;
-
 export interface ScanCollectionsUpdate {
-  results: ScanResultLookup;
   flatResults: ChannelResult[];
+  resultPositions: Map<number, number>;
   uiMetrics: ScanUiMetrics;
 }
 
@@ -72,8 +70,10 @@ export interface ScanRuntimeUpdate {
 }
 
 export interface ScanSlice {
-  results: ScanResultLookup;
   flatResults: ChannelResult[];
+  /** Channel index -> position in `flatResults`. Mutated in place as results
+   *  arrive, so subscribe to `flatResults` to observe changes. */
+  resultPositions: Map<number, number>;
   uiMetrics: ScanUiMetrics;
   duplicateIndices: Set<number>;
   progress: ScanProgress | null;

--- a/tests/updateState.test.ts
+++ b/tests/updateState.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isManualInstall,
+  updateActionLabel,
+  updateBannerMessage,
+  updateConfirmMessage,
+  updateFailureDetail,
+  type UpdateInstallMode,
+  type UpdateNotice,
+} from "../src/lib/updateState";
+
+const builtIn: UpdateInstallMode = {
+  kind: "built-in",
+  buttonLabel: null,
+  instructions: null,
+};
+
+const aur: UpdateInstallMode = {
+  kind: "manual",
+  buttonLabel: "Open IPTV Checker on AUR",
+  instructions: "Run paru -S iptv-checker-gui to update.",
+};
+
+function notice(installMode: UpdateInstallMode): UpdateNotice {
+  return { version: "1.7.0", notes: null, installMode };
+}
+
+describe("updateActionLabel", () => {
+  it("offers to install directly when the app can replace itself", () => {
+    expect(updateActionLabel(notice(builtIn), "idle")).toBe("Install v1.7.0");
+  });
+
+  it("uses the backend's label for package-manager-owned installs", () => {
+    // Only the backend knows which package manager owns this copy, so the
+    // label must not be reconstructed in the UI.
+    expect(updateActionLabel(notice(aur), "idle")).toBe("Open IPTV Checker on AUR");
+  });
+
+  it("falls back when a manual mode arrives without a label", () => {
+    const unlabelled: UpdateInstallMode = { kind: "manual", buttonLabel: null, instructions: null };
+    expect(updateActionLabel(notice(unlabelled), "idle")).toBe("How to update");
+  });
+
+  it("reports progress while installing regardless of mode", () => {
+    expect(updateActionLabel(notice(builtIn), "installing")).toBe("Installing…");
+    expect(updateActionLabel(notice(aur), "installing")).toBe("Installing…");
+  });
+});
+
+describe("updateBannerMessage", () => {
+  it("names both versions when the current one is known", () => {
+    expect(updateBannerMessage(notice(builtIn), "1.6.0")).toBe(
+      "Update available: v1.7.0 (current v1.6.0).",
+    );
+  });
+
+  it("omits the current version before it has loaded", () => {
+    expect(updateBannerMessage(notice(builtIn), "")).toBe("Update available: v1.7.0.");
+  });
+
+  it("appends package-manager instructions, since the action only opens a page", () => {
+    expect(updateBannerMessage(notice(aur), "1.6.0")).toBe(
+      "Update available: v1.7.0 (current v1.6.0). Run paru -S iptv-checker-gui to update.",
+    );
+  });
+});
+
+describe("updateConfirmMessage", () => {
+  it("warns about the restart for built-in installs", () => {
+    expect(updateConfirmMessage(notice(builtIn))).toContain("restart");
+  });
+
+  it("does not promise a restart when it only opens a page", () => {
+    expect(updateConfirmMessage(notice(aur))).not.toContain("restart");
+  });
+});
+
+describe("isManualInstall", () => {
+  it("distinguishes the two modes", () => {
+    expect(isManualInstall(builtIn)).toBe(false);
+    expect(isManualInstall(aur)).toBe(true);
+  });
+});
+
+describe("updateFailureDetail", () => {
+  it("collapses multi-line backend errors into one line", () => {
+    expect(updateFailureDetail("update check failed:\n  network\tdown  ")).toBe(
+      "update check failed: network down",
+    );
+  });
+
+  it("caps runaway error text so the banner stays readable", () => {
+    expect(updateFailureDetail("x".repeat(400))).toHaveLength(240);
+  });
+});

--- a/tests/updateState.test.ts
+++ b/tests/updateState.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
   isManualInstall,
+  type UpdateInstallMode,
+  type UpdateNotice,
   updateActionLabel,
   updateBannerMessage,
   updateConfirmMessage,
   updateFailureDetail,
-  type UpdateInstallMode,
-  type UpdateNotice,
 } from "../src/lib/updateState";
 
 const builtIn: UpdateInstallMode = {

--- a/tests/useScan.helpers.test.ts
+++ b/tests/useScan.helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { applyResultUpdates, type ScanResultCollections } from "../src/hooks/useScan.helpers";
+import {
+  applyResultUpdates,
+  emptyResultCollections,
+  resultAtIndex,
+  type ScanResultCollections,
+} from "../src/hooks/useScan.helpers";
 import type { ChannelResult } from "../src/lib/types";
 
 function buildResult(index: number, overrides: Partial<ChannelResult> = {}): ChannelResult {
@@ -46,12 +51,8 @@ describe("useScan sparse result collections", () => {
     const initialA = buildResult(8);
     const initialB = buildResult(107, { status: "alive" });
     const previous: ScanResultCollections = {
-      resultsByIndex: {
-        [initialA.index]: initialA,
-        [initialB.index]: initialB,
-      },
       flatResults: [initialA, initialB],
-      indexToFlatPos: new Map([
+      positions: new Map([
         [initialA.index, 0],
         [initialB.index, 1],
       ]),
@@ -70,12 +71,42 @@ describe("useScan sparse result collections", () => {
     const addedC = buildResult(3005, { status: "alive" });
     const next = applyResultUpdates(previous, [updatedA, addedC]);
 
-    expect(next.resultsByIndex[8]?.status).toBe("dead");
-    expect(next.resultsByIndex[3005]?.status).toBe("alive");
+    expect(resultAtIndex(next, 8)?.status).toBe("dead");
+    expect(resultAtIndex(next, 3005)?.status).toBe("alive");
     expect(next.flatResults.map((result) => result.index)).toEqual([8, 107, 3005]);
-    expect(next.indexToFlatPos.get(3005)).toBe(2);
+    expect(next.positions.get(3005)).toBe(2);
     expect(next.metrics.presentCount).toBe(3);
     expect(next.metrics.lowFpsCount).toBe(1);
     expect(next.metrics.mislabeledCount).toBe(1);
+  });
+
+  it("keeps flatResults identity stable when a batch changes nothing", () => {
+    const existing = buildResult(1, { status: "alive" });
+    const previous: ScanResultCollections = {
+      flatResults: [existing],
+      positions: new Map([[1, 0]]),
+      metrics: { presentCount: 1, lowFpsCount: 0, mislabeledCount: 0 },
+    };
+
+    // Re-applying the identical object must not force a re-render.
+    const next = applyResultUpdates(previous, [existing]);
+    expect(next.flatResults).toBe(previous.flatResults);
+    expect(next.metrics).toBe(previous.metrics);
+  });
+
+  it("copies flatResults once per batch, not once per result", () => {
+    const previous = emptyResultCollections();
+    const batch = [buildResult(1), buildResult(2), buildResult(3)];
+
+    const next = applyResultUpdates(previous, batch);
+
+    // A fresh array so React re-renders, but the caller's is left alone.
+    expect(next.flatResults).not.toBe(previous.flatResults);
+    expect(previous.flatResults).toHaveLength(0);
+    expect(next.flatResults.map((result) => result.index)).toEqual([1, 2, 3]);
+  });
+
+  it("reports no result for an index that has not been checked", () => {
+    expect(resultAtIndex(emptyResultCollections(), 42)).toBeNull();
   });
 });

--- a/tests/useScan.helpers.test.ts
+++ b/tests/useScan.helpers.test.ts
@@ -110,3 +110,19 @@ describe("useScan sparse result collections", () => {
     expect(resultAtIndex(emptyResultCollections(), 42)).toBeNull();
   });
 });
+
+describe("useScan repeated indices within one batch", () => {
+  it("counts a channel once when the same index appears twice in a batch", () => {
+    // A per-channel event and the finalized batch entry can coalesce into one
+    // RAF flush, so the same index arrives twice in a single call.
+    const first = buildResult(4, { status: "checking" });
+    const second = buildResult(4, { status: "alive", low_framerate: true });
+
+    const next = applyResultUpdates(emptyResultCollections(), [first, second]);
+
+    expect(next.flatResults.map((r) => r.index)).toEqual([4]);
+    expect(next.metrics.presentCount).toBe(1);
+    expect(next.metrics.lowFpsCount).toBe(1);
+    expect(resultAtIndex(next, 4)?.status).toBe("alive");
+  });
+});


### PR DESCRIPTION
Adds the auto-updater from #173, mirroring how Carrier does it, plus a batch of
engineering-quality work that the updater's own CI run made worth doing first.

## Signed in-app updater

The app only ever polled the GitHub releases API and pointed users at a download
page. It now installs a discovered release in place via `tauri-plugin-updater`,
using the keypair whose secrets were already configured on this repo — only the
public half was ever missing from `tauri.conf.json`.

Discovery stays separate from installation: a check never downloads anything, and
installing always needs explicit confirmation. A background task checks on launch
and every six hours, behind a new **Automatic update checks** setting.

**Not every copy may replace itself.** AUR packages are pacman-owned even though
they reuse the signed `.deb`, and Tauri's Linux updater only knows how to replace
an AppImage — so `.deb`/`.rpm` installs are routed to manual instructions rather
than a failing install. (Carrier only detects the AUR case; IPTV Checker ships
deb/rpm too, so it needs the extra branch.)

**Two release artifacts are rewritten after tauri-action signs them**, which would
otherwise leave `latest.json` holding signatures that no longer verify:

- the macOS `.dmg` is notarized and stapled afterwards, and is what users actually
  download, so the updater should install it rather than the stock `.app.tar.gz`;
- the Linux AppImage is rewritten in place by `harden-appimage-runtime.sh`.

Both are now re-signed and their manifest entries repointed by a shared script,
which writes the installer-suffixed key as well as the bare one — the updater
resolves `{os}-{arch}-{installer}` first. macOS installs the verified DMG itself
(`engine::macos_dmg_update`); Tauri still does the download and minisign
verification, so the bytes are already trusted.

The Homebrew cask now declares `auto_updates true`, the correct convention for a
self-updating app.

## Quality work

- **CI gates** — there was no clippy, no `rustfmt --check`, and no frontend linter
  at all. All three now run. Adding them surfaced **two Rules-of-Hooks violations**
  React would have thrown on: `PlaylistReportPanel` and `ThumbnailPanel` both
  returned early above several hooks, so the hook count changed the moment a
  playlist loaded or a row was selected. Clippy also found a doc comment a helper
  extraction had stolen from `profile_bitrate`.

- **Store performance** — results were kept twice, in `flatResults` and in an
  index-keyed object spread on every batch, making a whole scan quadratic.
  Results now live only in `flatResults` with an append-only position map:

  | Channels | Before | After |
  |---------:|-------:|------:|
  | 1,000 | 3.0 ms | 0.4 ms |
  | 10,000 | 445 ms | 17.6 ms |
  | 50,000 | 13,761 ms | **213 ms** |

  Kept as `bun run perf:ui-batching` so it cannot silently regress.

- **Preset fields** — `ScanPresetConfig` listed its sixteen fields three times, so
  a new scan setting silently failed to round-trip unless all three were updated.
  A macro derives the struct and both copy directions from one list; a field
  `AppSettings` lacks now fails to compile. Persisted JSON is unchanged.

- **`scan.rs`** — `compute_playlist_score` was pure math sitting in the scan
  orchestrator. Moved to `engine::playlist_score` and tested at exact values
  rather than the previous "greater than zero".

- **Integration test** — parse → check → export across the real parser, checker
  (against a mock server serving one 404) and exporters, parsing the exported M3U
  back. No WebDriver, runs everywhere.

## Notes

- The ~60 pre-existing accessibility findings are set to **warn**, not suppressed,
  so the gate could land without hiding them. Clearing them is its own pass.
- `too_many_arguments` is allowed crate-wide and one `large_enum_variant` locally,
  both with reasoning inline.
- No GUI/WebDriver E2E: `tauri-driver` has no macOS support, so it could not be
  verified locally. The integration test covers the same spine below the UI.

Ref #173

## Validation

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, 283 Rust tests,
`biome check`, `tsc --noEmit`, 105 frontend tests, and `bun run build` all pass.
CodeRabbit preflight run before pushing: two findings fixed (shared in-flight
install-mode detection, bounded macOS relaunch wait). One declined — it assumed
the macOS path calls `download_and_install`, but it calls `download`, which does
signature verification only and no format inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed in-app updates, including automatic update checks, installation, and manual update guidance.
  * Added an “Automatic update checks” setting.
  * Improved macOS and Linux updater artifacts and Homebrew self-update support.
  * Added playlist performance benchmarking tools.

* **Bug Fixes**
  * Improved scan-result handling and history ordering.
  * Fixed update banners and installation flows across supported platforms.

* **Documentation**
  * Added performance benchmark instructions and baseline guidance.

* **Tests**
  * Expanded frontend, Rust, updater, scan pipeline, and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->