### PR TITLE
Adopt Biome and reformat the frontend

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "files": {
+    // Only the hand-written frontend and its tests. dist/ is generated, and
+    // agent worktrees under .worktrees/ carry their own root configs.
+    "includes": ["src/**", "tests/**", "scripts/**", "!!**/.worktrees", "!!dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "correctness": {
+        // Not React-Compiler-aware, and this codebase deliberately mirrors
+        // callbacks into refs so effects can run with `[]` deps — see the menu
+        // event bridge, where re-running the effect orphaned listeners. The
+        // compiler validates the hooks it can; this rule only fights the
+        // pattern that fixed that bug.
+        "useExhaustiveDependencies": "off"
+      },
+      "style": {
+        // Regex capture groups read as possibly-undefined under
+        // noUncheckedIndexedAccess; `!` on a capture the match guarantees is
+        // the sanctioned pattern here.
+        "noNonNullAssertion": "off"
+      },
+      // The app predates any linter and has a real accessibility backlog
+      // (~60 findings: unlabelled controls, click handlers on non-interactive
+      // elements, untitled SVGs). Demoted to warnings so the gate can land
+      // now and the findings stay visible — clearing them is its own pass,
+      // not something to bury under blanket suppressions.
+      "a11y": "warn"
+    }
+  },
+  "css": {
+    "parser": {
+      // Tailwind v4 directives (@theme, @apply, …) are used throughout.
+      "tailwindDirectives": true
+    },
+    "linter": {
+      "enabled": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "overrides": [
+    {
+      // The vibrancy/glass styles override WebKit defaults that are themselves
+      // set with high specificity, so `!important` and deliberately overlapping
+      // selectors are load-bearing here.
+      "includes": ["src/index.css"],
+      "linter": {
+        "rules": {
+          "complexity": { "noImportantStyles": "off" },
+          "style": { "noDescendingSpecificity": "off" }
+        }
+      }
+    }
+  ]
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -2,8 +2,9 @@
   "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     // Only the hand-written frontend and its tests. dist/ is generated, and
-    // agent worktrees under .worktrees/ carry their own root configs.
-    "includes": ["src/**", "tests/**", "scripts/**", "!!**/.worktrees", "!!dist"]
+    // agent worktrees under .worktrees/ carry their own root configs. scripts/
+    // is narrowed to .ts because the rest of it is shell and plain text.
+    "includes": ["src/**", "tests/**", "scripts/**/*.ts", "!!**/.worktrees", "!!dist"]
   },
   "formatter": {
     "enabled": true,

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "zustand": "^5.0.12",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.5",
         "@rolldown/plugin-babel": "^0.2.2",
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/cli": "^2.10.1",
@@ -71,6 +72,24 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g=="],
 
     "@bradleyhodges/sfsymbols": ["@bradleyhodges/sfsymbols@7.0.4", "", { "dependencies": { "@bradleyhodges/sfsymbols-types": "7.0.4" } }, "sha512-GlZX1gvdQTLCcA8Pm+KR4eDUe12a8zDhRQtkUcyKdu3CFtDgKTEfwvenCg78SWvr84+ZXACHgHmQOkJPDrJNJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "perf:ui-filter": "bun run scripts/benchmark-ui-filter.ts",
     "perf:backend-scan": "cd src-tauri && cargo run --release --example backend_bench --",
     "setup:ffmpeg": "bash scripts/download-ffmpeg.sh",
-    "clean:fuzz-local": "bash scripts/clean-fuzz-local.sh"
+    "clean:fuzz-local": "bash scripts/clean-fuzz-local.sh",
+    "lint": "biome check .",
+    "format": "biome check --write ."
   },
   "dependencies": {
     "@bradleyhodges/sfsymbols": "^7.0.4",
@@ -37,6 +39,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.5",
     "@rolldown/plugin-babel": "^0.2.2",
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/cli": "^2.10.1",

--- a/scripts/benchmark-ui-filter.ts
+++ b/scripts/benchmark-ui-filter.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { filterResults, sortResults, type SortDirection, type SortField } from "../src/lib/filters";
+import { filterResults, type SortDirection, type SortField, sortResults } from "../src/lib/filters";
 import type { ChannelResult, ChannelStatus } from "../src/lib/types";
 
 interface PlaylistCase {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
+import { listen } from "@tauri-apps/api/event";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
+import {
+  isPermissionGranted,
+  onAction,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
 import {
   lazy,
   Profiler,
+  type ProfilerOnRenderCallback,
   Suspense,
   useCallback,
   useEffect,
@@ -8,47 +18,37 @@ import {
   useMemo,
   useRef,
   useState,
-  type ProfilerOnRenderCallback,
 } from "react";
-import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow, ProgressBarStatus } from "@tauri-apps/api/window";
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { setLiquidGlassEffect } from "tauri-plugin-liquid-glass-api";
-import {
-  isPermissionGranted,
-  onAction,
-  requestPermission,
-  sendNotification,
-} from "@tauri-apps/plugin-notification";
-import type { AppSettings, ChannelResult, ScanConfig } from "./lib/types";
-import {
-  clearScanHistory,
-  getScanHistory,
-  checkFfmpegAvailable,
-  readScreenshot,
-  openChannelInPlayer,
-  quickCheckChannel,
-} from "./lib/tauri";
+import { AppBanners } from "./components/AppBanners";
+import { ChannelTable } from "./components/ChannelTable";
+import { FilterBar } from "./components/FilterBar";
+import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
+import { ProgressBar } from "./components/ProgressBar";
+import { StartScreen } from "./components/StartScreen";
+import { StatsPanel } from "./components/StatsPanel";
+import { ThumbnailPanel } from "./components/ThumbnailPanel";
+import { Toolbar } from "./components/Toolbar";
+import { type UseChromecastResult, useChromecast } from "./hooks/useChromecast";
+import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
+import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
-import { useChromecast, type UseChromecastResult } from "./hooks/useChromecast";
 import { useStreamPlayer } from "./hooks/useStreamPlayer";
-import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
-import type { ChromecastDevice } from "./lib/types";
+import {
+  checkFfmpegAvailable,
+  clearScanHistory,
+  getScanHistory,
+  openChannelInPlayer,
+  quickCheckChannel,
+  readScreenshot,
+} from "./lib/tauri";
+import type { AppSettings, ChannelResult, ChromecastDevice, ScanConfig } from "./lib/types";
 import { useAppStore } from "./store";
 import type { AppStore, OpenSourceDialogState } from "./store/types";
-import { Toolbar } from "./components/Toolbar";
-import { FilterBar } from "./components/FilterBar";
-import { ChannelTable } from "./components/ChannelTable";
-import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
-import { ThumbnailPanel } from "./components/ThumbnailPanel";
-import { StatsPanel } from "./components/StatsPanel";
-import { ProgressBar } from "./components/ProgressBar";
-import { AppBanners } from "./components/AppBanners";
-import { StartScreen } from "./components/StartScreen";
+
 const KeyboardShortcutsDialog = lazy(() => import("./components/KeyboardShortcutsDialog"));
 const HistoryPanel = lazy(() => import("./components/HistoryPanel"));
 const OpenSourceDialog = lazy(() => import("./components/OpenSourceDialog"));
@@ -58,23 +58,19 @@ const XtreamServerTestDialog = lazy(() =>
   })),
 );
 const SavedPlaylistsDialog = lazy(() => import("./components/SavedPlaylistsDialog"));
-const SavedPlaylistEditorDialog = lazy(
-  () => import("./components/SavedPlaylistEditorDialog"),
-);
+const SavedPlaylistEditorDialog = lazy(() => import("./components/SavedPlaylistEditorDialog"));
+
 import { AlertTriangle } from "lucide-react";
-import { detectPlatform } from "./lib/platform";
-import { logger } from "./lib/logger";
+import { toPendingChannelResult } from "./lib/channelResults";
 import { errorToString } from "./lib/errors";
 import { HapticFeedbackPattern, PerformanceTime, triggerHaptic } from "./lib/haptics";
-import { toPendingChannelResult } from "./lib/channelResults";
+import { logger } from "./lib/logger";
+import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
+import { detectPlatform } from "./lib/platform";
+import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
 import { isScanActive } from "./lib/scanState";
 import { isInputLikeTarget, isPrimaryModifierPressed } from "./lib/shortcuts";
-import { recordUiPerf, startLongTaskObserver, uiPerfEnabled } from "./lib/perf";
-import { shouldAutoRevealReportPanel } from "./lib/playlistReportVisibility";
-import {
-  normalizeSourceFilter,
-  validateSourceFilterPattern,
-} from "./lib/sourceFilter";
+import { normalizeSourceFilter, validateSourceFilterPattern } from "./lib/sourceFilter";
 
 async function restoreAndFocusWindow(window: {
   unminimize: () => Promise<void>;
@@ -156,7 +152,9 @@ function ScanPauseBanners() {
       {networkPaused && isScanActive(scanState) && (
         <div className="flex items-center gap-2 px-4 py-2 bg-orange-500/10 border-b border-orange-500/20 text-orange-400 text-[13px]">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span className="flex-1">Scan paused — network connectivity lost. Waiting for recovery...</span>
+          <span className="flex-1">
+            Scan paused — network connectivity lost. Waiting for recovery...
+          </span>
         </div>
       )}
     </>
@@ -302,11 +300,7 @@ function SelectedChannelSidebar({
   );
 }
 
-function ScanRuntimeEffects({
-  refreshHistory,
-}: {
-  refreshHistory: () => Promise<void>;
-}) {
+function ScanRuntimeEffects({ refreshHistory }: { refreshHistory: () => Promise<void> }) {
   const playlist = useAppStore((s) => s.playlist);
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
@@ -327,9 +321,7 @@ function ScanRuntimeEffects({
 
   useEffect(() => {
     const previous = reportAutoRevealPreviousScanStateRef.current;
-    const scanJustStarted =
-      scanState === "scanning" &&
-      !isScanActive(previous);
+    const scanJustStarted = scanState === "scanning" && !isScanActive(previous);
 
     if (scanJustStarted) {
       getStore().prepareReportAutoRevealForScanStart();
@@ -350,10 +342,7 @@ function ScanRuntimeEffects({
       return;
     }
 
-    const active =
-      scanState === "scanning" ||
-      scanState === "paused" ||
-      scanState === "complete";
+    const active = scanState === "scanning" || scanState === "paused" || scanState === "complete";
     if (!active) {
       return;
     }
@@ -376,10 +365,7 @@ function ScanRuntimeEffects({
     if (!justFinished) return;
 
     if (scanState === "complete") {
-      void triggerHaptic(
-        HapticFeedbackPattern.Generic,
-        PerformanceTime.DrawCompleted,
-      );
+      void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.DrawCompleted);
     }
 
     if (!scanNotifications || !summary) return;
@@ -418,14 +404,13 @@ function ScanRuntimeEffects({
         progress && progress.total > 0
           ? Math.min(100, Math.max(0, (progress.completed / progress.total) * 100))
           : 0;
-      const status =
-        networkPaused
-          ? ProgressBarStatus.Error
-          : scanState === "paused"
-            ? ProgressBarStatus.Paused
-            : progress
-              ? ProgressBarStatus.Normal
-              : ProgressBarStatus.Indeterminate;
+      const status = networkPaused
+        ? ProgressBarStatus.Error
+        : scanState === "paused"
+          ? ProgressBarStatus.Paused
+          : progress
+            ? ProgressBarStatus.Normal
+            : ProgressBarStatus.Indeterminate;
 
       void appWindow
         .setProgressBar({
@@ -435,9 +420,7 @@ function ScanRuntimeEffects({
         .catch(() => {});
 
       if (isMac) {
-        const badgeLabel = progress
-          ? `${progress.alive + progress.drm}/${progress.dead}`
-          : "...";
+        const badgeLabel = progress ? `${progress.alive + progress.drm}/${progress.dead}` : "...";
         void appWindow.setBadgeLabel(badgeLabel).catch(() => {});
       }
     };
@@ -461,8 +444,7 @@ function ScanRuntimeEffects({
       const now = Date.now();
       const elapsed = now - lastOsProgressUpdateMsRef.current;
       const shouldUpdateNow =
-        lastOsProgressUpdateMsRef.current === 0 ||
-        elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
+        lastOsProgressUpdateMsRef.current === 0 || elapsed >= OS_PROGRESS_UPDATE_INTERVAL_MS;
 
       clearScheduledUpdate();
       if (shouldUpdateNow) {
@@ -580,15 +562,8 @@ export default function App() {
   const isCasting = isCastSessionActive(castSession);
 
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
-  const {
-    start,
-    cancel,
-    pause,
-    resume,
-    initFromPlaylist,
-    syncFromPlaylist,
-    updateResult,
-  } = useScan();
+  const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
+    useScan();
   const { checkForUpdates } = useUpdateCheck();
   const {
     handleClearRecentPlaylists,
@@ -637,7 +612,9 @@ export default function App() {
   useEffect(() => {
     const title = playlist ? `${playlist.file_name} | IPTV Checker` : "IPTV Checker";
     document.title = title;
-    void getCurrentWindow().setTitle(title).catch(() => {});
+    void getCurrentWindow()
+      .setTitle(title)
+      .catch(() => {});
   }, [playlist]);
 
   // Detect platform via native plugin and refresh the initial fallback.
@@ -728,10 +705,7 @@ export default function App() {
     getStore().setHistoryLoading(true);
     getStore().setHistoryError(null);
     try {
-      const items = await getScanHistory(
-        playlist.file_path,
-        playlist.source_identity,
-      );
+      const items = await getScanHistory(playlist.file_path, playlist.source_identity);
       getStore().setHistoryEntries(items);
     } catch (err) {
       getStore().setHistoryError(errorToString(err));
@@ -805,32 +779,36 @@ export default function App() {
     void refreshHistory();
   }, [playlist, refreshHistory]);
 
-  const handleExternalOpenPaths = useCallback((paths: string[]) => {
-    const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
-    if (!targetPath) {
-      return;
-    }
+  const handleExternalOpenPaths = useCallback(
+    (paths: string[]) => {
+      const targetPath = paths.find((path) => path.trim().length > 0) ?? null;
+      if (!targetPath) {
+        return;
+      }
 
-    if (paths.length > 1) {
-      getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
-    }
+      if (paths.length > 1) {
+        getStore().setMenuInfo(`Opened ${paths.length} items. Loaded the first one.`);
+      }
 
-    void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
-    void openPlaylistPath(targetPath);
-  }, [openPlaylistPath]);
+      void restoreAndFocusWindow(getCurrentWindow()).catch(() => {});
+      void openPlaylistPath(targetPath);
+    },
+    [openPlaylistPath],
+  );
 
-  const handleDroppedPaths = useCallback((paths: string[]) => {
-    const playlistPath = paths.find((path) =>
-      isPlaylistLikePath(path),
-    );
+  const handleDroppedPaths = useCallback(
+    (paths: string[]) => {
+      const playlistPath = paths.find((path) => isPlaylistLikePath(path));
 
-    if (!playlistPath) {
-      getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
-      return;
-    }
+      if (!playlistPath) {
+        getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
+        return;
+      }
 
-    void openPlaylistPath(playlistPath);
-  }, [openPlaylistPath]);
+      void openPlaylistPath(playlistPath);
+    },
+    [openPlaylistPath],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -882,69 +860,66 @@ export default function App() {
     return () => window.removeEventListener("contextmenu", handler);
   }, []);
 
-  const startScanWithSelection = useCallback(async (selection: number[]) => {
-    const state = getStore();
-    const currentChannelSearchError = validateSourceFilterPattern(
-      state.channelSearch,
-    );
+  const startScanWithSelection = useCallback(
+    async (selection: number[]) => {
+      const state = getStore();
+      const currentChannelSearchError = validateSourceFilterPattern(state.channelSearch);
 
-    if (currentChannelSearchError) {
-      state.setScanInputError(
-        `Invalid source filter regex: ${currentChannelSearchError}`,
-      );
-      return false;
-    }
+      if (currentChannelSearchError) {
+        state.setScanInputError(`Invalid source filter regex: ${currentChannelSearchError}`);
+        return false;
+      }
 
-    const applyResult = await ensureSourceFilterApplied();
-    if (!applyResult.ok) {
-      return false;
-    }
+      const applyResult = await ensureSourceFilterApplied();
+      if (!applyResult.ok) {
+        return false;
+      }
 
-    const refreshedState = getStore();
-    const currentPlaylist = refreshedState.playlist;
-    const currentChannelSearch = normalizeSourceFilter(
-      refreshedState.channelSearch,
-    );
-    const currentGroupFilter = refreshedState.groupFilter;
-    const currentSettings = refreshedState.settings;
-    const effectiveSelection = applyResult.reapplied ? [] : selection;
+      const refreshedState = getStore();
+      const currentPlaylist = refreshedState.playlist;
+      const currentChannelSearch = normalizeSourceFilter(refreshedState.channelSearch);
+      const currentGroupFilter = refreshedState.groupFilter;
+      const currentSettings = refreshedState.settings;
+      const effectiveSelection = applyResult.reapplied ? [] : selection;
 
-    if (!currentPlaylist) return false;
+      if (!currentPlaylist) return false;
 
-    const config: ScanConfig = {
-      file_path: currentPlaylist.file_path,
-      source_identity: currentPlaylist.source_identity ?? null,
-      playlist_display_name: currentPlaylist.file_name,
-      group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
-      channel_search: currentChannelSearch || null,
-      selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
-      hide_vod_content: currentSettings.hide_vod_content,
-      timeout: currentSettings.timeout,
-      extended_timeout: currentSettings.extended_timeout,
-      concurrency: resolveSmartConcurrency(
-        currentSettings.concurrency,
-        currentPlaylist.single_provider,
-        currentPlaylist.xtream_max_connections ?? null,
-      ),
-      retries: currentSettings.retries,
-      retry_backoff: currentSettings.retry_backoff,
-      user_agent: currentSettings.user_agent,
-      skip_screenshots: currentSettings.skip_screenshots,
-      profile_bitrate: currentSettings.profile_bitrate,
-      ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
-      ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
-      accept_invalid_certs: currentSettings.accept_invalid_certs,
-      proxy_file: currentSettings.proxy_file,
-      test_geoblock: currentSettings.test_geoblock,
-      screenshots_dir: currentSettings.screenshots_dir,
-      client_capabilities: {
-        event_batch_v1: true,
-      },
-    };
+      const config: ScanConfig = {
+        file_path: currentPlaylist.file_path,
+        source_identity: currentPlaylist.source_identity ?? null,
+        playlist_display_name: currentPlaylist.file_name,
+        group_filter: currentGroupFilter !== "all" ? currentGroupFilter : null,
+        channel_search: currentChannelSearch || null,
+        selected_indices: effectiveSelection.length > 0 ? effectiveSelection : null,
+        hide_vod_content: currentSettings.hide_vod_content,
+        timeout: currentSettings.timeout,
+        extended_timeout: currentSettings.extended_timeout,
+        concurrency: resolveSmartConcurrency(
+          currentSettings.concurrency,
+          currentPlaylist.single_provider,
+          currentPlaylist.xtream_max_connections ?? null,
+        ),
+        retries: currentSettings.retries,
+        retry_backoff: currentSettings.retry_backoff,
+        user_agent: currentSettings.user_agent,
+        skip_screenshots: currentSettings.skip_screenshots,
+        profile_bitrate: currentSettings.profile_bitrate,
+        ffprobe_timeout_secs: currentSettings.ffprobe_timeout_secs,
+        ffmpeg_bitrate_timeout_secs: currentSettings.ffmpeg_bitrate_timeout_secs,
+        accept_invalid_certs: currentSettings.accept_invalid_certs,
+        proxy_file: currentSettings.proxy_file,
+        test_geoblock: currentSettings.test_geoblock,
+        screenshots_dir: currentSettings.screenshots_dir,
+        client_capabilities: {
+          event_batch_v1: true,
+        },
+      };
 
-    await start(config, currentPlaylist.total_channels, effectiveSelection);
-    return true;
-  }, [ensureSourceFilterApplied, start]);
+      await start(config, currentPlaylist.total_channels, effectiveSelection);
+      return true;
+    },
+    [ensureSourceFilterApplied, start],
+  );
 
   const handleStartScan = useCallback(async () => {
     const started = await startScanWithSelection(getStore().selectedChannelIndices);
@@ -975,61 +950,67 @@ export default function App() {
     );
   };
 
-  const handleSidebarDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
+  const handleSidebarDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      sidebarDragRef.current = { startX: e.clientX, startWidth: sidebarWidth };
 
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!sidebarDragRef.current) return;
-      const delta = ev.clientX - sidebarDragRef.current.startX;
-      const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
-      getStore().setSidebarWidth(newWidth);
-    };
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!sidebarDragRef.current) return;
+        const delta = ev.clientX - sidebarDragRef.current.startX;
+        const newWidth = Math.max(100, Math.min(600, sidebarDragRef.current.startWidth + delta));
+        getStore().setSidebarWidth(newWidth);
+      };
 
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      sidebarDragRef.current = null;
-    };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        sidebarDragRef.current = null;
+      };
 
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, [sidebarWidth]);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [sidebarWidth],
+  );
 
-  const handleReportSidebarDragStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    reportSidebarDragRef.current = {
-      startX: e.clientX,
-      startWidth: reportSidebarWidth,
-    };
+  const handleReportSidebarDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      reportSidebarDragRef.current = {
+        startX: e.clientX,
+        startWidth: reportSidebarWidth,
+      };
 
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!reportSidebarDragRef.current) return;
-      const delta = reportSidebarDragRef.current.startX - ev.clientX;
-      const newWidth = Math.max(
-        260,
-        Math.min(700, reportSidebarDragRef.current.startWidth + delta),
-      );
-      getStore().setReportSidebarWidth(newWidth);
-    };
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!reportSidebarDragRef.current) return;
+        const delta = reportSidebarDragRef.current.startX - ev.clientX;
+        const newWidth = Math.max(
+          260,
+          Math.min(700, reportSidebarDragRef.current.startWidth + delta),
+        );
+        getStore().setReportSidebarWidth(newWidth);
+      };
 
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      reportSidebarDragRef.current = null;
-    };
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        reportSidebarDragRef.current = null;
+      };
 
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }, [reportSidebarWidth]);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [reportSidebarWidth],
+  );
 
   useEffect(() => {
     localStorage.setItem("sidebar-width", String(sidebarWidth));
@@ -1129,9 +1110,7 @@ export default function App() {
         const session = currentChromecast.session;
         const device =
           currentChromecast.devices.find((d) => d.id === session.deviceId) ??
-          (lastCastDeviceRef.current?.id === session.deviceId
-            ? lastCastDeviceRef.current
-            : null);
+          (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
         if (device) {
           void currentChromecast.cast(device, buildCastRequest(result));
           return;
@@ -1169,7 +1148,10 @@ export default function App() {
   }, [pendingPlaybackChannel, playStream]);
 
   // Merge player-derived metadata into ChannelResult for unscanned channels
-  const lastMergedMetaRef = useRef<{ index: number; meta: typeof streamPlayer.streamMetadata } | null>(null);
+  const lastMergedMetaRef = useRef<{
+    index: number;
+    meta: typeof streamPlayer.streamMetadata;
+  } | null>(null);
   useEffect(() => {
     const meta = streamPlayer.streamMetadata;
     const idx = streamPlayer.activeChannelIndex;
@@ -1187,14 +1169,38 @@ export default function App() {
     let changed = false;
     const updated = { ...existing };
 
-    if (meta.width != null && existing.width == null) { updated.width = meta.width; changed = true; }
-    if (meta.height != null && existing.height == null) { updated.height = meta.height; changed = true; }
-    if (meta.resolution && !existing.resolution) { updated.resolution = meta.resolution; changed = true; }
-    if (meta.codec && !existing.codec) { updated.codec = meta.codec; changed = true; }
-    if (meta.fps != null && existing.fps == null) { updated.fps = meta.fps; changed = true; }
-    if (meta.videoBitrate && !existing.video_bitrate) { updated.video_bitrate = meta.videoBitrate; changed = true; }
-    if (meta.audioCodec && !existing.audio_codec) { updated.audio_codec = meta.audioCodec; changed = true; }
-    if (meta.audioBitrate && !existing.audio_bitrate) { updated.audio_bitrate = meta.audioBitrate; changed = true; }
+    if (meta.width != null && existing.width == null) {
+      updated.width = meta.width;
+      changed = true;
+    }
+    if (meta.height != null && existing.height == null) {
+      updated.height = meta.height;
+      changed = true;
+    }
+    if (meta.resolution && !existing.resolution) {
+      updated.resolution = meta.resolution;
+      changed = true;
+    }
+    if (meta.codec && !existing.codec) {
+      updated.codec = meta.codec;
+      changed = true;
+    }
+    if (meta.fps != null && existing.fps == null) {
+      updated.fps = meta.fps;
+      changed = true;
+    }
+    if (meta.videoBitrate && !existing.video_bitrate) {
+      updated.video_bitrate = meta.videoBitrate;
+      changed = true;
+    }
+    if (meta.audioCodec && !existing.audio_codec) {
+      updated.audio_codec = meta.audioCodec;
+      changed = true;
+    }
+    if (meta.audioBitrate && !existing.audio_bitrate) {
+      updated.audio_bitrate = meta.audioBitrate;
+      changed = true;
+    }
 
     if (changed) {
       updateResult(updated);
@@ -1215,9 +1221,7 @@ export default function App() {
         if (state.flatResults.length > 0) {
           getStore().setSelectedChannel(state.flatResults[0]);
         } else if (state.playlist && state.playlist.channels.length > 0) {
-          getStore().setSelectedChannel(
-            toPendingChannelResult(state.playlist.channels[0]),
-          );
+          getStore().setSelectedChannel(toPendingChannelResult(state.playlist.channels[0]));
         }
       }
       getStore().setSidebarHidden(false);
@@ -1266,13 +1270,7 @@ export default function App() {
       handleStartScan,
       cancel,
     };
-  }, [
-    handleOpen,
-    handleOpenSettings,
-    handleOpenLog,
-    handleStartScan,
-    cancel,
-  ]);
+  }, [handleOpen, handleOpenSettings, handleOpenLog, handleStartScan, cancel]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -1317,14 +1315,7 @@ export default function App() {
         }
         return;
       }
-      if (
-        !e.repeat &&
-        e.key === " " &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.shiftKey &&
-        !e.altKey
-      ) {
+      if (!e.repeat && e.key === " " && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
         if (inputLikeTarget) return;
         e.preventDefault();
         getStore().toggleLightboxOpen();
@@ -1385,8 +1376,7 @@ export default function App() {
   const headerPortalRef = useRef<HTMLDivElement>(null);
   const [toolbarHeight, setToolbarHeight] = useState(0);
   const tableProfilerEnabled =
-    uiPerfEnabled() &&
-    (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
+    uiPerfEnabled() && (playlist?.channels.length ?? 0) <= TABLE_PROFILER_ROW_LIMIT;
   const channelTableElement = (
     <ChannelTable
       onSelectChannel={handleSelectChannel}
@@ -1404,9 +1394,7 @@ export default function App() {
     if (!el) return;
     const update = () => {
       const nextToolbarHeight = el.offsetHeight;
-      setToolbarHeight((prev) =>
-        prev === nextToolbarHeight ? prev : nextToolbarHeight,
-      );
+      setToolbarHeight((prev) => (prev === nextToolbarHeight ? prev : nextToolbarHeight));
     };
     update();
     const observer = new ResizeObserver(update);
@@ -1416,22 +1404,14 @@ export default function App() {
 
   const tableChromeStyle = isMac
     ? {
-        marginLeft:
-          liveSelectedChannel && !sidebarHidden
-            ? `${sidebarWidth}px`
-            : undefined,
-        marginRight:
-          playlist && showReportPanel
-            ? `${reportSidebarWidth}px`
-            : undefined,
+        marginLeft: liveSelectedChannel && !sidebarHidden ? `${sidebarWidth}px` : undefined,
+        marginRight: playlist && showReportPanel ? `${reportSidebarWidth}px` : undefined,
       }
     : undefined;
 
   return (
     <div className="flex flex-col h-screen bg-surface">
-      <ScanRuntimeEffects
-        refreshHistory={refreshHistory}
-      />
+      <ScanRuntimeEffects refreshHistory={refreshHistory} />
       <div
         ref={toolbarMeasureRef}
         className={`relative z-20 ${isMac && playlist ? "glass-material bg-panel" : ""} ${isMac && !playlist ? "pb-4" : ""}`}
@@ -1467,73 +1447,73 @@ export default function App() {
       </div>
 
       <div className="flex flex-col flex-1 min-h-0">
-      {ffmpegWarning && (
-        <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
-          <AlertTriangle className="w-4 h-4" />
-          ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
-        </div>
-      )}
-      <ScanPauseBanners />
+        {ffmpegWarning && (
+          <div className="flex items-center gap-2 px-4 py-2.5 bg-yellow-500/10 border-b border-yellow-500/20 text-yellow-400 text-[13px]">
+            <AlertTriangle className="w-4 h-4" />
+            ffmpeg/ffprobe not found. Screenshots and media info will be disabled.
+          </div>
+        )}
+        <ScanPauseBanners />
 
-      <AppBanners />
+        <AppBanners />
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="flex flex-1 min-h-0 bg-content">
-          {liveSelectedChannel && !sidebarHidden && (
-            <SelectedChannelSidebar
-              sidebarWidth={sidebarWidth}
-              onResizeStart={handleSidebarDragStart}
-              streamPlayer={streamPlayer}
-              chromecast={chromecast}
-              onPlayChannel={handlePlayInApp}
-              onScanChannel={handleScanSelected}
-              onStopPlayer={handleStopPlayer}
-              onOpenExternal={handleOpenExternal}
-              onPip={handlePip}
-            />
-          )}
-          <div className="flex flex-col flex-1 min-w-0">
-            {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
-            {playlist ? (
-              tableProfilerEnabled ? (
-                <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
-                  {channelTableElement}
-                </Profiler>
-              ) : (
-                channelTableElement
-              )
-            ) : (
-              <StartScreen
-                playlistLoading={playlistLoading}
-                playlistLoadProgress={playlistLoadProgress}
-                modKey={modKey}
-                recentPlaylists={recentPlaylists}
-                savedPlaylists={savedPlaylists}
-                onOpen={handleOpen}
-                onOpenFolder={handleOpenFolder}
-                onOpenUrl={handleOpenUrl}
-                onOpenXtream={handleOpenXtream}
-                onManageSavedPlaylists={handleManageSavedPlaylists}
-                onOpenSaved={handleOpenSaved}
-                onOpenRecent={handleOpenRecent}
-                onClearRecent={handleClearRecentPlaylists}
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="flex flex-1 min-h-0 bg-content">
+            {liveSelectedChannel && !sidebarHidden && (
+              <SelectedChannelSidebar
+                sidebarWidth={sidebarWidth}
+                onResizeStart={handleSidebarDragStart}
+                streamPlayer={streamPlayer}
+                chromecast={chromecast}
+                onPlayChannel={handlePlayInApp}
+                onScanChannel={handleScanSelected}
+                onStopPlayer={handleStopPlayer}
+                onOpenExternal={handleOpenExternal}
+                onPip={handlePip}
               />
             )}
+            <div className="flex flex-col flex-1 min-w-0">
+              {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
+              {playlist ? (
+                tableProfilerEnabled ? (
+                  <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
+                    {channelTableElement}
+                  </Profiler>
+                ) : (
+                  channelTableElement
+                )
+              ) : (
+                <StartScreen
+                  playlistLoading={playlistLoading}
+                  playlistLoadProgress={playlistLoadProgress}
+                  modKey={modKey}
+                  recentPlaylists={recentPlaylists}
+                  savedPlaylists={savedPlaylists}
+                  onOpen={handleOpen}
+                  onOpenFolder={handleOpenFolder}
+                  onOpenUrl={handleOpenUrl}
+                  onOpenXtream={handleOpenXtream}
+                  onManageSavedPlaylists={handleManageSavedPlaylists}
+                  onOpenSaved={handleOpenSaved}
+                  onOpenRecent={handleOpenRecent}
+                  onClearRecent={handleClearRecentPlaylists}
+                />
+              )}
+            </div>
+
+            {playlist && showReportPanel && (
+              <PlaylistReportPanel
+                placement="right"
+                widthPx={reportSidebarWidth}
+                onResizeStart={handleReportSidebarDragStart}
+                onClose={handleCloseReport}
+              />
+            )}
+          </div>
+
+          <StatsPanel />
+          <ProgressBar />
         </div>
-
-        {playlist && showReportPanel && (
-          <PlaylistReportPanel
-            placement="right"
-            widthPx={reportSidebarWidth}
-            onResizeStart={handleReportSidebarDragStart}
-            onClose={handleCloseReport}
-          />
-        )}
-      </div>
-
-      <StatsPanel />
-      <ProgressBar />
-      </div>
       </div>
 
       {openSourceDialogState && (
@@ -1635,13 +1615,10 @@ export default function App() {
       {pendingPlaybackChannel && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
           <div className="w-full max-w-xl rounded-xl border border-border-app bg-overlay p-5 shadow-2xl">
-            <h2 className="text-[16px] font-semibold mb-2">
-              Scan currently running
-            </h2>
+            <h2 className="text-[16px] font-semibold mb-2">Scan currently running</h2>
             <p className="text-[14px] text-text-secondary leading-relaxed">
-              A scan is currently running. Playing a channel while scanning may
-              interfere with the scan or cause playback issues if the server&apos;s
-              max connection limit is exceeded.
+              A scan is currently running. Playing a channel while scanning may interfere with the
+              scan or cause playback issues if the server&apos;s max connection limit is exceeded.
             </p>
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
@@ -1662,7 +1639,6 @@ export default function App() {
           </div>
         </div>
       )}
-
     </div>
   );
 }

--- a/src/SettingsWindow.tsx
+++ b/src/SettingsWindow.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { emit } from "@tauri-apps/api/event";
+import { useEffect } from "react";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { useSettings } from "./hooks/useSettings";
 

--- a/src/components/AppBanners.tsx
+++ b/src/components/AppBanners.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ExternalLink, Info, X } from "lucide-react";
-import { useAppStore } from "../store";
+import { useEffect, useMemo } from "react";
 import { dismissUpdateNotice } from "../hooks/useUpdateCheck";
 import { errorToString } from "../lib/errors";
 import { logger } from "../lib/logger";
 import { validateSourceFilterPattern } from "../lib/sourceFilter";
+import { useAppStore } from "../store";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -52,9 +52,7 @@ export function AppBanners() {
     () => getStore().setErrorDismissed(false),
   );
   useAutoDismiss(playbackError, 10000, () => getStore().setPlaybackError(null));
-  useAutoDismiss(playlistOpenError, 10000, () =>
-    getStore().setPlaylistOpenError(null),
-  );
+  useAutoDismiss(playlistOpenError, 10000, () => getStore().setPlaylistOpenError(null));
   useAutoDismiss(scanInputError, 8000, () => getStore().setScanInputError(null));
   useAutoDismiss(menuInfo, 8000, () => getStore().setMenuInfo(null));
 

--- a/src/components/CastMenu.tsx
+++ b/src/components/CastMenu.tsx
@@ -1,11 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { Cast, ChevronDown, RefreshCw, Square } from "lucide-react";
-import type {
-  CastMediaRequest,
-  CastSession,
-  ChromecastDevice,
-} from "../lib/types";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isCastSessionActive } from "../lib/cast";
+import type { CastMediaRequest, CastSession, ChromecastDevice } from "../lib/types";
 
 interface UseChromecastShape {
   devices: ChromecastDevice[];
@@ -48,11 +44,7 @@ export function CastMenu({
     );
   }
   return (
-    <CastMenuInline
-      chromecast={chromecast}
-      castRequest={castRequest}
-      onCastStart={onCastStart}
-    />
+    <CastMenuInline chromecast={chromecast} castRequest={castRequest} onCastStart={onCastStart} />
   );
 }
 
@@ -144,7 +136,9 @@ function CastMenuPopover({
               className="p-1 text-white/70 hover:text-white disabled:opacity-50"
               title="Refresh devices"
             >
-              <RefreshCw className={`w-3.5 h-3.5 ${chromecast.discovering ? "animate-spin" : ""}`} />
+              <RefreshCw
+                className={`w-3.5 h-3.5 ${chromecast.discovering ? "animate-spin" : ""}`}
+              />
             </button>
           </div>
           {isCasting && chromecast.session && (
@@ -202,11 +196,7 @@ function CastMenuPopover({
 
 // ---------- Inline (sidebar) ----------
 
-function CastMenuInline({
-  chromecast,
-  castRequest,
-  onCastStart,
-}: Omit<CastMenuProps, "mode">) {
+function CastMenuInline({ chromecast, castRequest, onCastStart }: Omit<CastMenuProps, "mode">) {
   const [expanded, setExpanded] = useState(false);
   const [starting, setStarting] = useState(false);
   const isCasting = isCastSessionActive(chromecast.session);
@@ -303,7 +293,8 @@ function CastMenuInline({
             <div className="border-t border-border-subtle">
               <div className="flex items-center justify-between px-3 py-1.5 text-[11px] text-text-tertiary">
                 <span>
-                  {chromecast.devices.length} device{chromecast.devices.length === 1 ? "" : "s"} found
+                  {chromecast.devices.length} device{chromecast.devices.length === 1 ? "" : "s"}{" "}
+                  found
                 </span>
                 <button
                   type="button"

--- a/src/components/ChannelRow.tsx
+++ b/src/components/ChannelRow.tsx
@@ -1,13 +1,13 @@
-import { memo, useEffect, useMemo, useState } from "react";
-import type { ChannelLogoSize, ChannelResult } from "../lib/types";
-import type { ColumnDefinition } from "../lib/tableColumns";
 import { Radio, Tv } from "lucide-react";
-import { getChannelErrorReason } from "../lib/channelResults";
-import { StatusBadge } from "./StatusBadge";
-import { extractTvgLogoUrl, normalizeTvgLogoUrl } from "../lib/extinf";
+import { memo, useEffect, useMemo, useState } from "react";
 import { channelLogoPixels, channelRowHeightPixels } from "../lib/channelLogoSize";
-import { detectChannelProtocol } from "../lib/streamProtocol";
+import { getChannelErrorReason } from "../lib/channelResults";
+import { extractTvgLogoUrl, normalizeTvgLogoUrl } from "../lib/extinf";
 import { useLogoCacheStatus } from "../lib/logoCache";
+import { detectChannelProtocol } from "../lib/streamProtocol";
+import type { ColumnDefinition } from "../lib/tableColumns";
+import type { ChannelLogoSize, ChannelResult } from "../lib/types";
+import { StatusBadge } from "./StatusBadge";
 
 function formatLatency(latencyMs: number): string {
   if (latencyMs < 1000) {
@@ -57,23 +57,16 @@ function ChannelRowImpl({
 }: ChannelRowProps) {
   const isAlive = result.status === "alive";
   const logoUrl = useMemo(
-    () =>
-      normalizeTvgLogoUrl(result.tvg_logo) ??
-      extractTvgLogoUrl(result.extinf_line),
+    () => normalizeTvgLogoUrl(result.tvg_logo) ?? extractTvgLogoUrl(result.extinf_line),
     [result.extinf_line, result.tvg_logo],
   );
   const logoStatus = useLogoCacheStatus(logoUrl);
   const [logoLoadFailed, setLogoLoadFailed] = useState(false);
   const logoSizePx = useMemo(() => channelLogoPixels(channelLogoSize), [channelLogoSize]);
   const rowHeightPx = useMemo(() => channelRowHeightPixels(channelLogoSize), [channelLogoSize]);
-  const kindIconSizePx = useMemo(
-    () => Math.max(12, Math.round(logoSizePx * 0.68)),
-    [logoSizePx],
-  );
+  const kindIconSizePx = useMemo(() => Math.max(12, Math.round(logoSizePx * 0.68)), [logoSizePx]);
   const errorReason = getChannelErrorReason(result);
-  const drmStatusTitle = result.drm_system
-    ? `DRM: ${result.drm_system}`
-    : "DRM-protected stream";
+  const drmStatusTitle = result.drm_system ? `DRM: ${result.drm_system}` : "DRM-protected stream";
   const streamProtocol = useMemo(() => detectChannelProtocol(result), [result]);
 
   useEffect(() => {
@@ -83,11 +76,7 @@ function ChannelRowImpl({
   const renderCell = (column: ColumnDefinition) => {
     switch (column.key) {
       case "index":
-        return (
-          <span className="text-text-tertiary tabular-nums">
-            {result.index + 1}
-          </span>
-        );
+        return <span className="text-text-tertiary tabular-nums">{result.index + 1}</span>;
       case "status":
         return (
           <StatusBadge
@@ -168,34 +157,16 @@ function ChannelRowImpl({
           </span>
         );
       case "group":
-        return (
-          <span className="truncate px-2 text-text-secondary">
-            {result.group}
-          </span>
-        );
+        return <span className="truncate px-2 text-text-secondary">{result.group}</span>;
       case "resolution":
-        return (
-          <span className="text-text-secondary tabular-nums">
-            {result.resolution ?? "—"}
-          </span>
-        );
+        return <span className="text-text-secondary tabular-nums">{result.resolution ?? "—"}</span>;
       case "codec":
-        return (
-          <span className="text-text-secondary">
-            {result.codec ?? "—"}
-          </span>
-        );
+        return <span className="text-text-secondary">{result.codec ?? "—"}</span>;
       case "hdr":
-        return (
-          <span className="text-text-secondary">
-            {result.hdr_format ?? "—"}
-          </span>
-        );
+        return <span className="text-text-secondary">{result.hdr_format ?? "—"}</span>;
       case "fps":
         return (
-          <span className="text-text-secondary tabular-nums">
-            {result.fps ? result.fps : "—"}
-          </span>
+          <span className="text-text-secondary tabular-nums">{result.fps ? result.fps : "—"}</span>
         );
       case "latency": {
         if (result.latency_ms == null) {
@@ -216,25 +187,17 @@ function ChannelRowImpl({
       case "audio":
         return (
           <span className="text-text-secondary tabular-nums">
-            {result.audio_bitrate
-              ? `${result.audio_bitrate} kbps`
-              : "—"}
+            {result.audio_bitrate ? `${result.audio_bitrate} kbps` : "—"}
           </span>
         );
       case "audio_codec":
         return (
           <span className="text-text-secondary">
-            {result.audio_codec && result.audio_codec !== "Unknown"
-              ? result.audio_codec
-              : "—"}
+            {result.audio_codec && result.audio_codec !== "Unknown" ? result.audio_codec : "—"}
           </span>
         );
       case "audio_layout":
-        return (
-          <span className="text-text-secondary">
-            {result.audio_channel_layout ?? "—"}
-          </span>
-        );
+        return <span className="text-text-secondary">{result.audio_channel_layout ?? "—"}</span>;
       default:
         return null;
     }
@@ -267,10 +230,7 @@ function ChannelRowImpl({
               : "justify-start text-left";
 
         return (
-          <div
-            key={column.key}
-            className={`h-full flex items-center ${alignClass}`}
-          >
+          <div key={column.key} className={`h-full flex items-center ${alignClass}`}>
             {renderCell(column)}
           </div>
         );

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -1,32 +1,40 @@
-import { useRef, useState, useMemo, useCallback, useEffect, useDeferredValue, type RefObject } from "react";
-import { createPortal } from "react-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { ChannelResult } from "../lib/types";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import {
+  type RefObject,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { channelRowHeightPixels } from "../lib/channelLogoSize";
+import { getChannelErrorReason } from "../lib/channelResults";
+import { getChannelTableLayout } from "../lib/channelTableLayout";
 import type { SortDirection, SortField } from "../lib/filters";
 import { filterResultsShared, sortResults } from "../lib/filters";
-import {
-  COLUMN_ORDER_STORAGE_KEY,
-  COLUMN_WIDTH_STORAGE_KEY,
-  COLUMN_DEFINITIONS,
-  COLUMN_DEFINITION_MAP,
-  DEFAULT_COLUMN_ORDER,
-  DEFAULT_VISIBLE_COLUMN_ORDER,
-  DEFAULT_COLUMN_WIDTHS,
-  parseStoredColumnOrder,
-  parseStoredColumnWidths,
-  type ColumnKey,
-} from "../lib/tableColumns";
-import { ChannelRow } from "./ChannelRow";
-import { ArrowDown, ArrowUp } from "lucide-react";
-import { getChannelErrorReason } from "../lib/channelResults";
 import { statusLabel } from "../lib/format";
 import { measureUiPerf } from "../lib/perf";
 import { isScanActive } from "../lib/scanState";
 import { isInputLikeTarget, isPrimaryModifierPressed } from "../lib/shortcuts";
-import { channelRowHeightPixels } from "../lib/channelLogoSize";
 import { detectChannelProtocol } from "../lib/streamProtocol";
-import { getChannelTableLayout } from "../lib/channelTableLayout";
+import {
+  COLUMN_DEFINITION_MAP,
+  COLUMN_DEFINITIONS,
+  COLUMN_ORDER_STORAGE_KEY,
+  COLUMN_WIDTH_STORAGE_KEY,
+  type ColumnKey,
+  DEFAULT_COLUMN_ORDER,
+  DEFAULT_COLUMN_WIDTHS,
+  DEFAULT_VISIBLE_COLUMN_ORDER,
+  parseStoredColumnOrder,
+  parseStoredColumnWidths,
+} from "../lib/tableColumns";
+import type { ChannelResult } from "../lib/types";
 import { useAppStore } from "../store";
+import { ChannelRow } from "./ChannelRow";
 
 interface ChannelTableProps {
   onSelectChannel: (result: ChannelResult) => void;
@@ -59,15 +67,12 @@ const DEFAULT_VISIBLE_SINGLE_PLAYLIST_COLUMN_ORDER: ColumnKey[] =
 
 function buildChannelMetadataSummary(channel: ChannelResult): string {
   const videoBitrate = channel.video_bitrate ?? "Unknown";
-  const audioBitrate = channel.audio_bitrate
-    ? `${channel.audio_bitrate} kbps`
-    : "Unknown";
+  const audioBitrate = channel.audio_bitrate ? `${channel.audio_bitrate} kbps` : "Unknown";
   const audioCodec = channel.audio_codec ?? "Unknown";
   const hdrFormat = channel.hdr_format ?? "Unknown";
   const audioLayout = channel.audio_channel_layout ?? "Unknown";
   const resolvedStreamUrl = channel.stream_url?.trim() || null;
-  const hasResolvedStreamUrl =
-    !!resolvedStreamUrl && resolvedStreamUrl !== channel.url;
+  const hasResolvedStreamUrl = !!resolvedStreamUrl && resolvedStreamUrl !== channel.url;
   const protocol = detectChannelProtocol(channel) ?? "Unknown";
   const errorReason = getChannelErrorReason(channel) ?? "N/A";
 
@@ -94,20 +99,13 @@ function buildChannelMetadataSummary(channel: ChannelResult): string {
   return lines.join("\n");
 }
 
-function columnOrderMatchesDefaults(
-  columnOrder: ColumnKey[],
-  defaults: ColumnKey[],
-): boolean {
+function columnOrderMatchesDefaults(columnOrder: ColumnKey[], defaults: ColumnKey[]): boolean {
   if (columnOrder.length !== defaults.length) return false;
-  return defaults.every(
-    (key, index) => columnOrder[index] === key,
-  );
+  return defaults.every((key, index) => columnOrder[index] === key);
 }
 
 function columnWidthsMatchDefaults(widths: Record<ColumnKey, number>): boolean {
-  return DEFAULT_COLUMN_ORDER.every(
-    (key) => widths[key] === DEFAULT_COLUMN_WIDTHS[key],
-  );
+  return DEFAULT_COLUMN_ORDER.every((key) => widths[key] === DEFAULT_COLUMN_WIDTHS[key]);
 }
 
 function keepMenuInViewport(
@@ -151,9 +149,7 @@ export function ChannelTable({
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const copyFeedbackTimerRef = useRef<number | null>(null);
   const columnMenuRef = useRef<HTMLDivElement>(null);
-  const columnHeaderRefs = useRef<
-    Partial<Record<ColumnKey, HTMLDivElement | null>>
-  >({});
+  const columnHeaderRefs = useRef<Partial<Record<ColumnKey, HTMLDivElement | null>>>({});
   const [sortField, setSortField] = useState<SortField>("index");
   const [sortDir, setSortDir] = useState<SortDirection>("asc");
   const [focusedRow, setFocusedRow] = useState<number | null>(null);
@@ -163,9 +159,7 @@ export function ChannelTable({
     setFocusedRow(next);
   }, []);
   const [selectionAnchor, setSelectionAnchor] = useState<number | null>(null);
-  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(
-    () => new Set(),
-  );
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(() => new Set());
   const [contextMenuState, setContextMenuState] = useState<{
     x: number;
     y: number;
@@ -194,8 +188,8 @@ export function ChannelTable({
       DEFAULT_VISIBLE_SINGLE_PLAYLIST_COLUMN_ORDER,
     ),
   );
-  const [columnWidths, setColumnWidths] = useState<Record<ColumnKey, number>>(
-    () => parseStoredColumnWidths(localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)),
+  const [columnWidths, setColumnWidths] = useState<Record<ColumnKey, number>>(() =>
+    parseStoredColumnWidths(localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)),
   );
   const filteredResultsRef = useRef<ChannelResult[]>([]);
   const selectedIndicesRef = useRef(selectedIndices);
@@ -296,8 +290,8 @@ export function ChannelTable({
   const gridTemplateColumns = useMemo(
     () =>
       columns
-        .map((column) =>
-          `${column.key === "name" ? effectiveNameWidth : columnWidths[column.key]}px`,
+        .map(
+          (column) => `${column.key === "name" ? effectiveNameWidth : columnWidths[column.key]}px`,
         )
         .join(" "),
     [columns, columnWidths, effectiveNameWidth],
@@ -410,15 +404,11 @@ export function ChannelTable({
       return next.size === prev.size ? prev : next;
     });
 
-    setSelectionAnchor((prev) =>
-      prev !== null && visible.has(prev) ? prev : null,
-    );
+    setSelectionAnchor((prev) => (prev !== null && visible.has(prev) ? prev : null));
 
     const previous = focusedRowRef.current;
     const next =
-      filteredResults.length === 0
-        ? null
-        : Math.min(previous ?? 0, filteredResults.length - 1);
+      filteredResults.length === 0 ? null : Math.min(previous ?? 0, filteredResults.length - 1);
     if (next !== previous) updateFocusedRow(next);
   }, [filteredResults, updateFocusedRow, updateSelection]);
 
@@ -548,9 +538,7 @@ export function ChannelTable({
         return;
       }
 
-      const anchorRow = filteredResults.findIndex(
-        (result) => result.index === selectionAnchor,
-      );
+      const anchorRow = filteredResults.findIndex((result) => result.index === selectionAnchor);
       if (anchorRow < 0) {
         selectSingle(clickedResult, clickedRow);
         return;
@@ -652,10 +640,7 @@ export function ChannelTable({
       }
 
       const next = [...prev, key];
-      next.sort(
-        (a, b) =>
-          DEFAULT_COLUMN_ORDER.indexOf(a) - DEFAULT_COLUMN_ORDER.indexOf(b),
-      );
+      next.sort((a, b) => DEFAULT_COLUMN_ORDER.indexOf(a) - DEFAULT_COLUMN_ORDER.indexOf(b));
       return next;
     });
   }, []);
@@ -695,15 +680,9 @@ export function ChannelTable({
       // All side effects (selection emit, playback/cast redirect, scroll) run
       // outside the focused-row state update — updaters must stay pure, and
       // StrictMode double-invocation here used to double-start playback.
-      const selectedRow = filteredResults.findIndex((result) =>
-        selectedIndices.has(result.index),
-      );
-      const current =
-        focusedRowRef.current ?? (selectedRow >= 0 ? selectedRow : 0);
-      const next = Math.min(
-        filteredResults.length - 1,
-        Math.max(0, current + delta),
-      );
+      const selectedRow = filteredResults.findIndex((result) => selectedIndices.has(result.index));
+      const current = focusedRowRef.current ?? (selectedRow >= 0 ? selectedRow : 0);
+      const next = Math.min(filteredResults.length - 1, Math.max(0, current + delta));
 
       const result = filteredResults[next];
       if (result) {
@@ -787,11 +766,7 @@ export function ChannelTable({
   );
 
   const handleRowClickAt = useCallback(
-    (
-      event: React.MouseEvent<HTMLDivElement>,
-      result: ChannelResult,
-      rowIndex: number,
-    ) => {
+    (event: React.MouseEvent<HTMLDivElement>, result: ChannelResult, rowIndex: number) => {
       setContextMenuState(null);
       setColumnMenuState(null);
 
@@ -854,11 +829,7 @@ export function ChannelTable({
   );
 
   const handleRowContextMenuAt = useCallback(
-    (
-      event: React.MouseEvent<HTMLDivElement>,
-      result: ChannelResult,
-      rowIndex: number,
-    ) => {
+    (event: React.MouseEvent<HTMLDivElement>, result: ChannelResult, rowIndex: number) => {
       event.preventDefault();
       setColumnMenuState(null);
 
@@ -942,9 +913,7 @@ export function ChannelTable({
       return [contextMenuState.channel];
     }
     const indexSet = selectedIndices;
-    return completedResults
-      .filter((r) => indexSet.has(r.index))
-      .sort((a, b) => a.index - b.index);
+    return completedResults.filter((r) => indexSet.has(r.index)).sort((a, b) => a.index - b.index);
   }, [selectedIndices, contextMenuState, completedResults]);
 
   const handleCopyChannelName = useCallback(async () => {
@@ -968,10 +937,7 @@ export function ChannelTable({
   const handleCopyAllMetadata = useCallback(async () => {
     if (!contextMenuState) return;
     const channels = getSelectedChannels();
-    await copyText(
-      "metadata",
-      channels.map(buildChannelMetadataSummary).join("\n\n"),
-    );
+    await copyText("metadata", channels.map(buildChannelMetadataSummary).join("\n\n"));
   }, [contextMenuState, copyText, getSelectedChannels]);
 
   const handlePreviewChannel = useCallback(() => {
@@ -1016,10 +982,7 @@ export function ChannelTable({
       let dropTarget: ColumnKey | null = null;
       const sourceNode = columnHeaderRefs.current[key];
       const sourceRect = sourceNode?.getBoundingClientRect();
-      const previewWidth = Math.max(
-        72,
-        Math.round(sourceRect?.width ?? columnWidths[key]),
-      );
+      const previewWidth = Math.max(72, Math.round(sourceRect?.width ?? columnWidths[key]));
 
       const onMove = (moveEvent: PointerEvent) => {
         const delta = Math.abs(moveEvent.clientX - startX);
@@ -1138,10 +1101,7 @@ export function ChannelTable({
       }
 
       const previous = lastRevealScrollStateRef.current;
-      if (
-        previous.scrollTop === nextScrollTop &&
-        previous.scrollLeft === nextScrollLeft
-      ) {
+      if (previous.scrollTop === nextScrollTop && previous.scrollLeft === nextScrollLeft) {
         return;
       }
 
@@ -1215,10 +1175,7 @@ export function ChannelTable({
   });
 
   const renderVirtualRows = useCallback(
-    (
-      items: typeof virtualItems,
-      mode: "main" | "reveal",
-    ) =>
+    (items: typeof virtualItems, mode: "main" | "reveal") =>
       items.map((virtualRow) => {
         const result = filteredResults[virtualRow.index];
         if (!result) {
@@ -1248,12 +1205,8 @@ export function ChannelTable({
               result={result}
               channelLogoSize={channelLogoSize}
               onRowClick={mode === "main" ? handleRowClick : noopRowEvent}
-              onRowDoubleClick={
-                mode === "main" ? handleRowDoubleClick : noopRowEvent
-              }
-              onRowContextMenu={
-                mode === "main" ? handleRowContextMenu : noopRowEvent
-              }
+              onRowDoubleClick={mode === "main" ? handleRowDoubleClick : noopRowEvent}
+              onRowContextMenu={mode === "main" ? handleRowContextMenu : noopRowEvent}
               selected={selectedIndices.has(result.index)}
               duplicate={duplicateIndices.has(result.index)}
               focused={focusedRow === virtualRow.index}
@@ -1285,11 +1238,19 @@ export function ChannelTable({
   const headerElement = (
     <div
       ref={headerRef}
-      className={portalTarget
-        ? "h-8 select-none overflow-hidden"
-        : "absolute top-0 left-0 right-0 z-10 h-8 bg-panel select-none overflow-hidden"
+      className={
+        portalTarget
+          ? "h-8 select-none overflow-hidden"
+          : "absolute top-0 left-0 right-0 z-10 h-8 bg-panel select-none overflow-hidden"
       }
-      style={portalTarget ? { maskImage: "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)" } : undefined}
+      style={
+        portalTarget
+          ? {
+              maskImage:
+                "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)",
+            }
+          : undefined
+      }
     >
       <div
         className="grid items-center h-8 px-4 text-[11px] font-semibold text-text-secondary"
@@ -1322,15 +1283,11 @@ export function ChannelTable({
                   y: event.clientY,
                 });
               }}
-              onPointerDown={(event) =>
-                handleColumnPointerDown(column.key, event)
-              }
+              onPointerDown={(event) => handleColumnPointerDown(column.key, event)}
               className={`relative flex items-center h-full w-full ${alignClass} ${
                 draggedColumn === column.key ? "opacity-45" : ""
               } ${
-                dragOverColumn === column.key
-                  ? "bg-blue-500/10 rounded-sm"
-                  : ""
+                dragOverColumn === column.key ? "bg-blue-500/10 rounded-sm" : ""
               } cursor-grab active:cursor-grabbing`}
               title={`Drag to reorder ${column.label}. Right-click for column visibility.`}
             >
@@ -1409,7 +1366,6 @@ export function ChannelTable({
             minHeight: "100%",
           }}
         >
-
           {filteredResults.length === 0 ? (
             <div className="flex items-center justify-center text-text-tertiary text-sm min-h-64">
               No channels match the current filters
@@ -1423,9 +1379,7 @@ export function ChannelTable({
               }}
             >
               {hasMacHeaderReveal ? (
-                <div
-                  className="sticky top-0 left-0 h-0 overflow-visible"
-                >
+                <div className="sticky top-0 left-0 h-0 overflow-visible">
                   <div
                     className="channel-table-viewport"
                     style={{
@@ -1492,28 +1446,44 @@ export function ChannelTable({
             className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
             type="button"
           >
-            {copiedAction === "name" ? "Copied!" : selectedIndices.size > 1 ? `Copy ${selectedIndices.size} Names` : "Copy Channel Name"}
+            {copiedAction === "name"
+              ? "Copied!"
+              : selectedIndices.size > 1
+                ? `Copy ${selectedIndices.size} Names`
+                : "Copy Channel Name"}
           </button>
           <button
             onClick={handleCopyChannelUrl}
             className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
             type="button"
           >
-            {copiedAction === "url" ? "Copied!" : selectedIndices.size > 1 ? `Copy ${selectedIndices.size} URLs` : "Copy URL"}
+            {copiedAction === "url"
+              ? "Copied!"
+              : selectedIndices.size > 1
+                ? `Copy ${selectedIndices.size} URLs`
+                : "Copy URL"}
           </button>
           <button
             onClick={handleCopyM3uEntry}
             className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
             type="button"
           >
-            {copiedAction === "m3u" ? "Copied!" : selectedIndices.size > 1 ? `Copy ${selectedIndices.size} M3U Entries` : "Copy M3U Entry"}
+            {copiedAction === "m3u"
+              ? "Copied!"
+              : selectedIndices.size > 1
+                ? `Copy ${selectedIndices.size} M3U Entries`
+                : "Copy M3U Entry"}
           </button>
           <button
             onClick={handleCopyAllMetadata}
             className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
             type="button"
           >
-            {copiedAction === "metadata" ? "Copied!" : selectedIndices.size > 1 ? `Copy ${selectedIndices.size} Metadata` : "Copy All Metadata"}
+            {copiedAction === "metadata"
+              ? "Copied!"
+              : selectedIndices.size > 1
+                ? `Copy ${selectedIndices.size} Metadata`
+                : "Copy All Metadata"}
           </button>
         </div>
       )}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
+import type { ErrorInfo, ReactNode } from "react";
 import { Component } from "react";
-import type { ReactNode, ErrorInfo } from "react";
 
 interface Props {
   children: ReactNode;

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,34 +1,13 @@
-import { useState, useRef, useEffect, useCallback } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
-import {
-  Download,
-  ChevronDown,
-  LoaderCircle,
-  CircleCheck,
-  CircleAlert,
-  Info,
-} from "lucide-react";
-import { SFSquareArrowUp, SFChevronDown } from "./SFSymbols";
-import type { ChannelResult } from "../lib/types";
-import {
-  exportCsv,
-  exportM3u,
-  exportScanLogJson,
-  exportSplit,
-  exportRenamed,
-} from "../lib/tauri";
-import {
-  exportScopeFileSuffix,
-  exportScopeLabel,
-  type ExportScope,
-} from "../lib/exportScope";
-import { readStoredVisibleColumnOrder } from "../lib/tableColumns";
-import {
-  HapticFeedbackPattern,
-  PerformanceTime,
-  triggerHaptic,
-} from "../lib/haptics";
+import { ChevronDown, CircleAlert, CircleCheck, Download, Info, LoaderCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type ExportScope, exportScopeFileSuffix, exportScopeLabel } from "../lib/exportScope";
+import { HapticFeedbackPattern, PerformanceTime, triggerHaptic } from "../lib/haptics";
 import { isScanActive, type ScanState } from "../lib/scanState";
+import { readStoredVisibleColumnOrder } from "../lib/tableColumns";
+import { exportCsv, exportM3u, exportRenamed, exportScanLogJson, exportSplit } from "../lib/tauri";
+import type { ChannelResult } from "../lib/types";
+import { SFChevronDown, SFSquareArrowUp } from "./SFSymbols";
 
 interface ExportMenuProps {
   scopeCounts: Record<ExportScope, number>;
@@ -59,7 +38,9 @@ export function ExportMenu({
   const IconExport = isMac ? SFSquareArrowUp : Download;
   const IconChevron = isMac ? SFChevronDown : ChevronDown;
   const [open, setOpen] = useState(false);
-  const [busyAction, setBusyAction] = useState<"csv" | "split" | "renamed" | "m3u" | "scanlog" | null>(null);
+  const [busyAction, setBusyAction] = useState<
+    "csv" | "split" | "renamed" | "m3u" | "scanlog" | null
+  >(null);
   const [feedback, setFeedback] = useState<{
     kind: "success" | "error" | "info";
     message: string;
@@ -324,20 +305,21 @@ export function ExportMenu({
         aria-label={exporting ? "Exporting" : "Export"}
       >
         {exporting ? (
-          <LoaderCircle className={isMac ? "w-[22px] h-[22px] animate-spin" : "w-4 h-4 animate-spin"} />
+          <LoaderCircle
+            className={isMac ? "w-[22px] h-[22px] animate-spin" : "w-4 h-4 animate-spin"}
+          />
         ) : (
           <IconExport className={isMac ? "w-[22px] h-[22px]" : "w-4 h-4"} />
         )}
-        {showButtonText && (
-          exporting ? (
+        {showButtonText &&
+          (exporting ? (
             <span className="leading-none">Exporting...</span>
           ) : (
             <span className="inline-flex items-center gap-1 leading-none">
               <span>Export</span>
               <IconChevron className="h-3 w-3" />
             </span>
-          )
-        )}
+          ))}
       </button>
       {open && (
         <div className="macos-popover absolute right-0 top-full mt-1 w-64 bg-dropdown backdrop-blur-xl border border-border-app rounded-lg shadow-xl z-50 py-1">

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,10 +1,7 @@
 import { CircleHelp, Filter } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { isScanActive } from "../lib/scanState";
-import {
-  hasDirtySourceFilter,
-  validateSourceFilterPattern,
-} from "../lib/sourceFilter";
+import { hasDirtySourceFilter, validateSourceFilterPattern } from "../lib/sourceFilter";
 import { useAppStore } from "../store";
 
 interface FilterBarProps {
@@ -12,10 +9,7 @@ interface FilterBarProps {
   variant?: "content" | "chrome";
 }
 
-export function FilterBar({
-  onApply,
-  variant = "content",
-}: FilterBarProps) {
+export function FilterBar({ onApply, variant = "content" }: FilterBarProps) {
   const channelSearch = useAppStore((s) => s.channelSearch);
   const setChannelSearch = useAppStore((s) => s.setChannelSearch);
   const scanState = useAppStore((s) => s.scanState);
@@ -30,19 +24,10 @@ export function FilterBar({
   );
   const isScanning = isScanActive(scanState);
   const sourceFilterDirty = useMemo(
-    () =>
-      hasDirtySourceFilter(
-        channelSearch,
-        lastAppliedSourceFilter,
-        currentSourceDescriptor,
-    ),
+    () => hasDirtySourceFilter(channelSearch, lastAppliedSourceFilter, currentSourceDescriptor),
     [channelSearch, currentSourceDescriptor, lastAppliedSourceFilter],
   );
-  const showApplyButton =
-    !!playlist &&
-    !isScanning &&
-    !channelSearchError &&
-    sourceFilterDirty;
+  const showApplyButton = !!playlist && !isScanning && !channelSearchError && sourceFilterDirty;
   const canApply = showApplyButton && !playlistLoading;
   const [showRegexHelp, setShowRegexHelp] = useState(false);
   const regexHelpRef = useRef<HTMLDivElement>(null);

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
 import { Clock3, RefreshCw, Trash2, X } from "lucide-react";
+import { useMemo } from "react";
 import type { ScanHistoryItem } from "../lib/types";
 
 interface HistoryPanelProps {
@@ -39,15 +39,17 @@ export default function HistoryPanel({
 }: HistoryPanelProps) {
   const hasEntries = entries.length > 0;
   const sortedEntries = useMemo(
-    () =>
-      [...entries].sort(
-        (a, b) => b.scanned_at_epoch_ms - a.scanned_at_epoch_ms,
-      ),
+    () => [...entries].sort((a, b) => b.scanned_at_epoch_ms - a.scanned_at_epoch_ms),
     [entries],
   );
 
   return (
-    <div className="fixed inset-0 z-50 flex" role="dialog" aria-modal="true" aria-label="Scan history">
+    <div
+      className="fixed inset-0 z-50 flex"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Scan history"
+    >
       <div className="flex-1 bg-black/40" onClick={onClose} />
       <div className="w-[44rem] max-w-[96vw] border-l border-border-app bg-overlay backdrop-blur-xl flex flex-col">
         <div className="flex items-start justify-between px-6 pt-5 pb-4 border-b border-border-app">
@@ -55,9 +57,7 @@ export default function HistoryPanel({
             <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">
               Scan History
             </p>
-            <h2 className="text-[17px] font-semibold">
-              {playlistName || "Current Playlist"}
-            </h2>
+            <h2 className="text-[17px] font-semibold">{playlistName || "Current Playlist"}</h2>
             <p className="text-[12px] text-text-secondary mt-1">
               Completed scans are saved automatically and compared against the previous run.
             </p>
@@ -118,15 +118,16 @@ export default function HistoryPanel({
           {sortedEntries.map((entry) => {
             const when = new Date(entry.scanned_at_epoch_ms).toLocaleString();
             return (
-              <article key={entry.id} className="rounded-xl border border-border-app bg-panel-subtle p-3.5">
+              <article
+                key={entry.id}
+                className="rounded-xl border border-border-app bg-panel-subtle p-3.5"
+              >
                 <div className="flex items-center gap-2 text-[12px] text-text-tertiary mb-2">
                   <Clock3 className="w-3.5 h-3.5" />
                   <span>{when}</span>
                 </div>
 
-                <p className="text-[12px] text-text-secondary mb-2">
-                  {formatScope(entry)}
-                </p>
+                <p className="text-[12px] text-text-secondary mb-2">{formatScope(entry)}</p>
 
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px]">
                   <span className="text-text-secondary">{entry.summary.total} total</span>

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { X } from "lucide-react";
+import { useEffect } from "react";
 
 interface ShortcutEntry {
   keys: string;
@@ -74,17 +74,18 @@ export default function KeyboardShortcutsDialog({
   }, [onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
       <div className="absolute inset-0 bg-black/45" onClick={onClose} />
       <div className="relative w-full max-w-3xl rounded-2xl border border-border-app bg-overlay shadow-2xl">
         <div className="flex items-start justify-between px-6 pt-5 pb-4 border-b border-border-app">
           <div>
-            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">
-              Help
-            </p>
-            <h2 className="text-[18px] font-semibold text-text-primary">
-              Keyboard Shortcuts
-            </h2>
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">Help</p>
+            <h2 className="text-[18px] font-semibold text-text-primary">Keyboard Shortcuts</h2>
           </div>
           <button
             type="button"

--- a/src/components/LogWindowContent.tsx
+++ b/src/components/LogWindowContent.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { attachLogger, LogLevel } from "@tauri-apps/plugin-log";
 import { ArrowDown, Search, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface LogEntry {
   id: number;
@@ -12,10 +12,7 @@ interface LogEntry {
 
 const MAX_LOG_ENTRIES = 10_000;
 
-const LEVEL_META: Record<
-  LogLevel,
-  { label: string; color: string; activeColor: string }
-> = {
+const LEVEL_META: Record<LogLevel, { label: string; color: string; activeColor: string }> = {
   [LogLevel.Trace]: {
     label: "TRACE",
     color: "text-zinc-500",
@@ -43,19 +40,9 @@ const LEVEL_META: Record<
   },
 };
 
-const ALL_LEVELS: LogLevel[] = [
-  LogLevel.Debug,
-  LogLevel.Info,
-  LogLevel.Warn,
-  LogLevel.Error,
-];
+const ALL_LEVELS: LogLevel[] = [LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error];
 
-const DEFAULT_ENABLED = new Set([
-  LogLevel.Debug,
-  LogLevel.Info,
-  LogLevel.Warn,
-  LogLevel.Error,
-]);
+const DEFAULT_ENABLED = new Set([LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error]);
 
 function formatTimestamp(date: Date): string {
   const h = String(date.getHours()).padStart(2, "0");
@@ -69,9 +56,7 @@ let nextId = 0;
 
 export function LogWindowContent() {
   const [entries, setEntries] = useState<LogEntry[]>([]);
-  const [levelFilter, setLevelFilter] = useState<Set<LogLevel>>(
-    () => new Set(DEFAULT_ENABLED),
-  );
+  const [levelFilter, setLevelFilter] = useState<Set<LogLevel>>(() => new Set(DEFAULT_ENABLED));
   const [searchText, setSearchText] = useState("");
 
   const bufferRef = useRef<LogEntry[]>([]);
@@ -100,9 +85,10 @@ export function LogWindowContent() {
           bufferRef.current = [];
           if (batch.length === 0) return;
           setEntries((prev) => {
-            const combined = prev.length + batch.length > MAX_LOG_ENTRIES
-              ? [...prev, ...batch].slice(-MAX_LOG_ENTRIES)
-              : [...prev, ...batch];
+            const combined =
+              prev.length + batch.length > MAX_LOG_ENTRIES
+                ? [...prev, ...batch].slice(-MAX_LOG_ENTRIES)
+                : [...prev, ...batch];
             return combined;
           });
         }, 32);
@@ -129,8 +115,7 @@ export function LogWindowContent() {
   const filteredEntries = useMemo(() => {
     return entries.filter((entry) => {
       if (!levelFilter.has(entry.level)) return false;
-      if (searchLower && !entry.message.toLowerCase().includes(searchLower))
-        return false;
+      if (searchLower && !entry.message.toLowerCase().includes(searchLower)) return false;
       return true;
     });
   }, [entries, levelFilter, searchLower]);
@@ -292,14 +277,10 @@ export function LogWindowContent() {
                 <span className="text-text-tertiary shrink-0 select-all">
                   {formatTimestamp(entry.timestamp)}
                 </span>
-                <span
-                  className={`${meta.color} font-semibold shrink-0 w-[5ch] text-right`}
-                >
+                <span className={`${meta.color} font-semibold shrink-0 w-[5ch] text-right`}>
                   {meta.label}
                 </span>
-                <span className="text-text-primary break-all select-all">
-                  {entry.message}
-                </span>
+                <span className="text-text-primary break-all select-all">{entry.message}</span>
               </div>
             );
           })}

--- a/src/components/OpenSourceDialog.tsx
+++ b/src/components/OpenSourceDialog.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
-import { Cpu, KeyRound, Link2, Server, X, Loader2 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
+import { Cpu, KeyRound, Link2, Loader2, Server, X } from "lucide-react";
+import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { testXtreamServers } from "../lib/tauri";
 import type {
   StalkerOpenRequest,
   XtreamOpenRequest,
   XtreamRecentSource,
   XtreamServerTestReport,
 } from "../lib/types";
-import { testXtreamServers } from "../lib/tauri";
 import PasswordField from "./PasswordField";
 
 type OpenSourceMode = "url" | "xtream" | "stalker";
@@ -116,9 +116,7 @@ export function ServerTestModal({
             <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">
               Xtream
             </p>
-            <h2 className="text-[18px] font-semibold text-text-primary">
-              Test Servers
-            </h2>
+            <h2 className="text-[18px] font-semibold text-text-primary">Test Servers</h2>
           </div>
           <button
             type="button"
@@ -167,9 +165,7 @@ export function ServerTestModal({
             )}
           </div>
 
-          {testError && (
-            <p className="text-[12px] text-red-400">{testError}</p>
-          )}
+          {testError && <p className="text-[12px] text-red-400">{testError}</p>}
 
           {testReport && (
             <div className="space-y-4 max-h-[65vh] overflow-y-auto pr-1">
@@ -178,7 +174,8 @@ export function ServerTestModal({
                   {testReport.same_cdn ? "Same CDN" : "Different CDNs"}
                 </span>
                 <span>
-                  Tested {testReport.channels_probed} channel{testReport.channels_probed !== 1 ? "s" : ""} per server
+                  Tested {testReport.channels_probed} channel
+                  {testReport.channels_probed !== 1 ? "s" : ""} per server
                 </span>
               </div>
 
@@ -192,13 +189,14 @@ export function ServerTestModal({
                     hostLabel = result.server;
                   }
 
-                  const streamLatencyColor = result.avg_stream_latency_ms == null
-                    ? "text-text-muted"
-                    : result.avg_stream_latency_ms < 200
-                      ? "text-green-400"
-                      : result.avg_stream_latency_ms < 500
-                        ? "text-yellow-400"
-                        : "text-orange-400";
+                  const streamLatencyColor =
+                    result.avg_stream_latency_ms == null
+                      ? "text-text-muted"
+                      : result.avg_stream_latency_ms < 200
+                        ? "text-green-400"
+                        : result.avg_stream_latency_ms < 500
+                          ? "text-yellow-400"
+                          : "text-orange-400";
 
                   const qualitySummary = result.channel_probes
                     .filter((p) => p.resolution)
@@ -228,7 +226,11 @@ export function ServerTestModal({
                           onClose();
                         }
                       }}
-                      title={result.success ? `Click to use ${result.server}` : result.error ?? undefined}
+                      title={
+                        result.success
+                          ? `Click to use ${result.server}`
+                          : (result.error ?? undefined)
+                      }
                     >
                       {/* Header */}
                       <div className="px-4 py-3 bg-surface">
@@ -257,15 +259,17 @@ export function ServerTestModal({
                         ) : (
                           <div className="flex items-center gap-5 text-[12px]">
                             <span className="text-text-secondary tabular-nums">
-                              <span className="text-text-muted">API</span> {result.api_latency_ms != null ? `${result.api_latency_ms}ms` : "—"}
+                              <span className="text-text-muted">API</span>{" "}
+                              {result.api_latency_ms != null ? `${result.api_latency_ms}ms` : "—"}
                             </span>
                             <span className={`tabular-nums ${streamLatencyColor}`}>
-                              <span className="text-text-muted">Stream</span> {result.avg_stream_latency_ms != null ? `${result.avg_stream_latency_ms}ms` : "—"}
+                              <span className="text-text-muted">Stream</span>{" "}
+                              {result.avg_stream_latency_ms != null
+                                ? `${result.avg_stream_latency_ms}ms`
+                                : "—"}
                             </span>
                             {qualitySummary && (
-                              <span className="text-text-secondary truncate">
-                                {qualitySummary}
-                              </span>
+                              <span className="text-text-secondary truncate">{qualitySummary}</span>
                             )}
                           </div>
                         )}
@@ -321,12 +325,8 @@ export default function OpenSourceDialog({
   const [url, setUrl] = useState(initialUrl ?? "");
   const [xtreamServer, setXtreamServer] = useState(initialXtream?.server ?? "");
   const [xtreamUsername, setXtreamUsername] = useState(initialXtream?.username ?? "");
-  const [xtreamPassword, setXtreamPassword] = useState(
-    initialXtream?.password ?? "",
-  );
-  const [xtreamSavePassword, setXtreamSavePassword] = useState(
-    !!initialXtream?.password,
-  );
+  const [xtreamPassword, setXtreamPassword] = useState(initialXtream?.password ?? "");
+  const [xtreamSavePassword, setXtreamSavePassword] = useState(!!initialXtream?.password);
   const [stalkerPortal, setStalkerPortal] = useState(initialStalker?.portal ?? "");
   const [stalkerMac, setStalkerMac] = useState(initialStalker?.mac ?? "");
   const [localError, setLocalError] = useState<string | null>(null);
@@ -388,7 +388,6 @@ export default function OpenSourceDialog({
         setXtreamServer(`${url.protocol}//${url.host}`);
         setXtreamUsername(u);
         setXtreamPassword(p);
-
 
         // exit if we already set credentials
         return;
@@ -507,9 +506,7 @@ export default function OpenSourceDialog({
 
   const tabClass = (tab: OpenSourceMode) =>
     `inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] transition-colors ${
-      mode === tab
-        ? "bg-blue-600 text-white"
-        : "bg-btn text-text-secondary hover:bg-btn-hover"
+      mode === tab ? "bg-blue-600 text-white" : "bg-btn text-text-secondary hover:bg-btn-hover"
     }`;
 
   return (
@@ -522,9 +519,7 @@ export default function OpenSourceDialog({
               <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">
                 Source
               </p>
-              <h2 className="text-[18px] font-semibold text-text-primary">
-                Open Playlist Source
-              </h2>
+              <h2 className="text-[18px] font-semibold text-text-primary">Open Playlist Source</h2>
             </div>
             <button
               type="button"
@@ -538,11 +533,7 @@ export default function OpenSourceDialog({
 
           <form onSubmit={handleSubmit} className="p-5">
             <div className="mb-4 flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => switchMode("url")}
-                className={tabClass("url")}
-              >
+              <button type="button" onClick={() => switchMode("url")} className={tabClass("url")}>
                 <Link2 className="w-4 h-4" />
                 URL
               </button>
@@ -635,9 +626,7 @@ export default function OpenSourceDialog({
                     <input
                       type="checkbox"
                       checked={xtreamSavePassword}
-                      onChange={(event) =>
-                        setXtreamSavePassword(event.target.checked)
-                      }
+                      onChange={(event) => setXtreamSavePassword(event.target.checked)}
                       className="rounded border-border-app accent-blue-600"
                     />
                     <span className="text-[12px] text-text-secondary">
@@ -692,9 +681,7 @@ export default function OpenSourceDialog({
               </div>
             )}
 
-            {localError && (
-              <p className="mt-3 text-[12px] text-red-400">{localError}</p>
-            )}
+            {localError && <p className="mt-3 text-[12px] text-red-400">{localError}</p>}
 
             <div className="mt-5 flex items-center justify-end gap-2">
               <button

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -1,5 +1,5 @@
-import { useId, useState, type ComponentPropsWithoutRef } from "react";
 import { Eye, EyeOff } from "lucide-react";
+import { type ComponentPropsWithoutRef, useId, useState } from "react";
 
 interface PasswordFieldProps extends Omit<ComponentPropsWithoutRef<"input">, "type"> {
   wrapperClassName?: string;

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -1,17 +1,14 @@
-import { memo, useMemo } from "react";
 import { BarChart3, X } from "lucide-react";
-import type {
-  ChannelResult,
-  PlaylistScore,
-} from "../lib/types";
-import { summarizeLanguageDistribution } from "../lib/languageDistribution";
+import { memo, useMemo } from "react";
 import { summarizeEpgCoverage } from "../lib/epgCoverage";
-import { useAppStore } from "../store";
+import { summarizeLanguageDistribution } from "../lib/languageDistribution";
 import {
   hasScanStarted,
   shouldShowContentCounts,
   shouldShowLanguageDistribution,
 } from "../lib/playlistReportVisibility";
+import type { ChannelResult, PlaylistScore } from "../lib/types";
+import { useAppStore } from "../store";
 
 interface PlaylistReportPanelProps {
   placement?: "left" | "right";
@@ -45,9 +42,7 @@ function median(values: number[]): number | null {
   if (values.length === 0) return null;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 1
-    ? sorted[mid]
-    : (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 function isAliveResult(result: ChannelResult): boolean {
@@ -78,7 +73,8 @@ function qualityBucket(result: ChannelResult): keyof QualityBuckets {
   }
 
   const resolution = result.resolution?.toLowerCase() ?? "";
-  if (resolution.includes("2160") || resolution.includes("4k") || resolution.includes("uhd")) return "uhd4k";
+  if (resolution.includes("2160") || resolution.includes("4k") || resolution.includes("uhd"))
+    return "uhd4k";
   if (resolution.includes("1080")) return "hd1080";
   if (resolution.includes("720")) return "hd720";
   return "sd";
@@ -87,7 +83,12 @@ function qualityBucket(result: ChannelResult): keyof QualityBuckets {
 function codecTier(codec: string | null): number {
   const value = codec?.toLowerCase() ?? "";
   if (!value) return 0.4;
-  if (value.includes("hevc") || value.includes("h265") || value.includes("h.265") || value.includes("av1")) {
+  if (
+    value.includes("hevc") ||
+    value.includes("h265") ||
+    value.includes("h.265") ||
+    value.includes("av1")
+  ) {
     return 1;
   }
   if (value.includes("h264") || value.includes("h.264") || value.includes("avc")) {
@@ -114,7 +115,8 @@ function computeLiveScore(results: ChannelResult[], total: number): PlaylistScor
     results.map((result) => result.group.trim().toLowerCase()).filter(Boolean),
   ).size;
   const diversity = clamp01(uniqueGroups / 20);
-  const epgCoverage = results.filter((result) => (result.tvg_id ?? "").trim().length > 0).length / total;
+  const epgCoverage =
+    results.filter((result) => (result.tvg_id ?? "").trim().length > 0).length / total;
   const contentScore = clampScore10((aliveRatio * 0.6 + diversity * 0.2 + epgCoverage * 0.2) * 10);
 
   let qualityScore = 0;
@@ -122,9 +124,8 @@ function computeLiveScore(results: ChannelResult[], total: number): PlaylistScor
     const hdRatio = alive.filter((result) => isHdOrUhd(result)).length / alive.length;
     const codecAvg = alive.reduce((sum, result) => sum + codecTier(result.codec), 0) / alive.length;
     const fpsKnown = alive.filter((result) => typeof result.fps === "number").length;
-    const fpsRatio = fpsKnown === 0
-      ? 0
-      : alive.filter((result) => (result.fps ?? 0) >= 25).length / fpsKnown;
+    const fpsRatio =
+      fpsKnown === 0 ? 0 : alive.filter((result) => (result.fps ?? 0) >= 25).length / fpsKnown;
     qualityScore = clampScore10((hdRatio * 0.5 + codecAvg * 0.3 + fpsRatio * 0.2) * 10);
   }
 
@@ -172,21 +173,21 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     if (aliveLatencies.length === 0) {
       return { average: null as number | null, p50: null as number | null };
     }
-    const average =
-      aliveLatencies.reduce((sum, value) => sum + value, 0) / aliveLatencies.length;
+    const average = aliveLatencies.reduce((sum, value) => sum + value, 0) / aliveLatencies.length;
     return { average, p50: median(aliveLatencies) };
   }, [results]);
 
   const languageSummary = useMemo(
-    () => summarizeLanguageDistribution(playlist.channels.map((channel) => ({ language: channel.language })), 5),
+    () =>
+      summarizeLanguageDistribution(
+        playlist.channels.map((channel) => ({ language: channel.language })),
+        5,
+      ),
     [playlist.channels],
   );
 
   const showHealthScore = hasScanStarted(scanState);
-  const showContentCounts = shouldShowContentCounts(
-    playlist.movie_count,
-    playlist.series_count,
-  );
+  const showContentCounts = shouldShowContentCounts(playlist.movie_count, playlist.series_count);
   const showLanguageDistribution = shouldShowLanguageDistribution(
     playlist.channels.map((channel) => ({ language: channel.language })),
   );
@@ -247,7 +248,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   return (
     <aside
       className={`relative h-full shrink-0 ${
-        placement === "right" ? "border-l report-panel-enter-right" : "border-r report-panel-enter-left"
+        placement === "right"
+          ? "border-l report-panel-enter-right"
+          : "border-r report-panel-enter-left"
       } border-border-app bg-panel/70 backdrop-blur-sm overflow-auto select-none`}
       style={{ width: `${widthPx}px` }}
     >
@@ -255,19 +258,22 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
         <div
           onMouseDown={onResizeStart}
           className={`absolute top-0 bottom-0 w-1 cursor-col-resize z-10 hover:bg-blue-500/30 active:bg-blue-500/40 transition-colors ${
-            placement === "right"
-              ? "left-0 -translate-x-1/2"
-              : "right-0 translate-x-1/2"
+            placement === "right" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2"
           }`}
         />
       )}
       <div className="sticky top-0 z-10 px-4 py-3 border-b border-border-app bg-panel/85 backdrop-blur-sm">
         <div className="flex items-start justify-between gap-2">
           <div>
-            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">Playlist Report</p>
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+              Playlist Report
+            </p>
             <div className="flex items-center gap-2 mt-1">
               <BarChart3 className="w-4 h-4 text-blue-300" />
-              <p className="text-[14px] font-semibold text-text-primary truncate" title={playlist.file_name}>
+              <p
+                className="text-[14px] font-semibold text-text-primary truncate"
+                title={playlist.file_name}
+              >
                 {playlist.file_name}
               </p>
             </div>
@@ -294,7 +300,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
           )}
           <span className="text-text-tertiary">•</span>
           <span className="text-text-secondary">
-            {latencyStats.average == null ? "Ping N/A" : `Avg ${Math.round(latencyStats.average)} ms`}
+            {latencyStats.average == null
+              ? "Ping N/A"
+              : `Avg ${Math.round(latencyStats.average)} ms`}
           </span>
         </div>
       </div>
@@ -302,11 +310,20 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
       <div className="p-4 space-y-5">
         {showHealthScore && (
           <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Health Score</p>
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+              Health Score
+            </p>
             <div className="flex items-center gap-3">
               <div className="relative w-24 h-24 shrink-0">
                 <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
-                  <circle cx="50" cy="50" r={ringRadius} stroke="rgba(148,163,184,0.22)" strokeWidth="9" fill="none" />
+                  <circle
+                    cx="50"
+                    cy="50"
+                    r={ringRadius}
+                    stroke="rgba(148,163,184,0.22)"
+                    strokeWidth="9"
+                    fill="none"
+                  />
                   <circle
                     cx="50"
                     cy="50"
@@ -331,11 +348,15 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                 </div>
                 <div className="flex items-center justify-between rounded-md bg-input/60 px-2 py-1">
                   <span className="text-text-tertiary">Content</span>
-                  <span className="text-text-primary">{(displayScore?.content ?? 0).toFixed(1)}</span>
+                  <span className="text-text-primary">
+                    {(displayScore?.content ?? 0).toFixed(1)}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between rounded-md bg-input/60 px-2 py-1">
                   <span className="text-text-tertiary">Quality</span>
-                  <span className="text-text-primary">{(displayScore?.quality ?? 0).toFixed(1)}</span>
+                  <span className="text-text-primary">
+                    {(displayScore?.quality ?? 0).toFixed(1)}
+                  </span>
                 </div>
               </div>
             </div>
@@ -347,7 +368,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
 
         {showContentCounts && (
           <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Content Counts</p>
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+              Content Counts
+            </p>
             <div className="grid grid-cols-2 gap-2 text-[12px]">
               <div className="rounded-md bg-input/60 px-2 py-1.5">
                 <p className="text-text-tertiary">Live</p>
@@ -371,7 +394,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
 
         {showLanguageDistribution && (
           <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Language Distribution</p>
+            <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+              Language Distribution
+            </p>
             {languageSummary.entries.length === 0 ? (
               <p className="text-[12px] text-text-tertiary">No language metadata detected.</p>
             ) : (
@@ -394,7 +419,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                   </div>
                 ))}
                 {languageSummary.otherCount > 0 && (
-                  <p className="text-[11px] text-text-tertiary">Other: {languageSummary.otherPercentage.toFixed(1)}%</p>
+                  <p className="text-[11px] text-text-tertiary">
+                    Other: {languageSummary.otherPercentage.toFixed(1)}%
+                  </p>
                 )}
               </div>
             )}
@@ -402,14 +429,18 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
         )}
 
         <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Video Quality Distribution</p>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+            Video Quality Distribution
+          </p>
           <div className="flex h-3 rounded-full overflow-hidden bg-input">
-            {([
-              ["uhd4k", "#0ea5e9"],
-              ["hd1080", "#22c55e"],
-              ["hd720", "#f59e0b"],
-              ["sd", "#f87171"],
-            ] as const).map(([key, color]) => {
+            {(
+              [
+                ["uhd4k", "#0ea5e9"],
+                ["hd1080", "#22c55e"],
+                ["hd720", "#f59e0b"],
+                ["sd", "#f87171"],
+              ] as const
+            ).map(([key, color]) => {
               const total = Math.max(1, quality.aliveCount);
               const value = quality.buckets[key];
               const width = (value / total) * 100;
@@ -425,7 +456,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
         </section>
 
         <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">EPG Coverage</p>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+            EPG Coverage
+          </p>
           <div className="flex items-center gap-3">
             <div
               className="w-20 h-20 rounded-full relative"
@@ -438,14 +471,18 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
               </div>
             </div>
             <div className="text-[12px] space-y-1">
-              <p className="text-text-secondary">{epgSummary.channelsWithEpg} / {epgSummary.totalChannels} channels</p>
+              <p className="text-text-secondary">
+                {epgSummary.channelsWithEpg} / {epgSummary.totalChannels} channels
+              </p>
               <p className="text-text-secondary">Unique EPG IDs: {epgSummary.uniqueEpgSources}</p>
             </div>
           </div>
         </section>
 
         <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Technical Details</p>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+            Technical Details
+          </p>
           <div className="space-y-1 text-[12px]">
             <div className="flex items-center justify-between">
               <span className="text-text-tertiary">Quality (HD+4K)</span>
@@ -464,7 +501,11 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
             <div className="flex items-center justify-between">
               <span className="text-text-tertiary">Security</span>
               <span className="text-text-primary">
-                {protocolSummary.httpsPct >= 80 ? "Mostly secure" : protocolSummary.httpsPct > 0 ? "Mixed" : "Insecure"}
+                {protocolSummary.httpsPct >= 80
+                  ? "Mostly secure"
+                  : protocolSummary.httpsPct > 0
+                    ? "Mixed"
+                    : "Insecure"}
               </span>
             </div>
             {playlist.xtream_account_info && (
@@ -482,7 +523,8 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
             <div className="flex items-center justify-between">
               <span className="text-text-tertiary">Alive / Dead / Geo</span>
               <span className="text-text-primary">
-                {statusSnapshot?.alive ?? 0} / {statusSnapshot?.dead ?? 0} / {statusSnapshot?.geoblocked ?? 0}
+                {statusSnapshot?.alive ?? 0} / {statusSnapshot?.dead ?? 0} /{" "}
+                {statusSnapshot?.geoblocked ?? 0}
               </span>
             </div>
             {(statusSnapshot?.placeholder ?? 0) > 0 && (
@@ -501,13 +543,18 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
         </section>
 
         <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
-          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">Codec Distribution</p>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">
+            Codec Distribution
+          </p>
           {quality.codecEntries.length === 0 ? (
             <p className="text-[12px] text-text-tertiary">No codec data yet.</p>
           ) : (
             <div className="space-y-1 text-[12px]">
               {quality.codecEntries.slice(0, 5).map(([codec, count]) => (
-                <div key={codec} className="flex items-center justify-between rounded-md bg-input/60 px-2 py-1">
+                <div
+                  key={codec}
+                  className="flex items-center justify-between rounded-md bg-input/60 px-2 py-1"
+                >
                   <span className="text-text-secondary truncate mr-2">{codec}</span>
                   <span className="text-text-primary">{count}</span>
                 </div>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -17,16 +17,11 @@ function formatEta(seconds: number | null): string {
 export const ProgressBar = memo(function ProgressBar() {
   const progress = useAppStore((s) => s.progress);
   const scanState = useAppStore((s) => s.scanState);
-  const throughputChannelsPerSecond = useAppStore(
-    (s) => s.telemetry.throughputChannelsPerSecond,
-  );
+  const throughputChannelsPerSecond = useAppStore((s) => s.telemetry.throughputChannelsPerSecond);
   const etaSeconds = useAppStore((s) => s.telemetry.etaSeconds);
   if (!progress) return null;
 
-  const percent =
-    progress.total > 0
-      ? Math.round((progress.completed / progress.total) * 100)
-      : 0;
+  const percent = progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 0;
 
   const showTelemetry = isScanActive(scanState);
 
@@ -41,9 +36,7 @@ export const ProgressBar = memo(function ProgressBar() {
     } else {
       const chPerMin = throughputChannelsPerSecond * 60;
       const throughputDisplay =
-        chPerMin >= 10
-          ? `${Math.round(chPerMin)} ch/min`
-          : `${chPerMin.toFixed(1)} ch/min`;
+        chPerMin >= 10 ? `${Math.round(chPerMin)} ch/min` : `${chPerMin.toFixed(1)} ch/min`;
       telemetryLabel = `${throughputDisplay} · ~${formatEta(etaSeconds)} remaining`;
     }
   }
@@ -72,9 +65,7 @@ export const ProgressBar = memo(function ProgressBar() {
         )}
       </div>
       {telemetryLabel != null && (
-        <div className="mt-1 text-[11px] text-text-tertiary tabular-nums">
-          {telemetryLabel}
-        </div>
+        <div className="mt-1 text-[11px] text-text-tertiary tabular-nums">{telemetryLabel}</div>
       )}
     </div>
   );

--- a/src/components/SFSymbols.tsx
+++ b/src/components/SFSymbols.tsx
@@ -4,30 +4,30 @@
  * Each component is a thin wrapper that renders the real SF Symbol SVG path data
  * with a Lucide-compatible `ComponentProps<"svg">` interface for drop-in use.
  */
-import type { ComponentProps } from "react";
-import {
-  sfPlayFill,
-  sfPauseFill,
-  sfStopFill,
-  sfFolder,
 
-  sfLink,
-  sfGearshape,
-  sfClockArrowTriangleheadCounterclockwiseRotate90,
-  sfSquareAndArrowUp,
+import {
   sfCheckmarkCircleFill,
-  sfXmarkCircleFill,
-  sfLockFill,
-  sfShieldFill,
-  sfListNumber,
-  sfExclamationmarkTriangleFill,
-  sfDocumentOnDocumentFill,
-  sfTagFill,
   sfChevronDown,
+  sfClockArrowTriangleheadCounterclockwiseRotate90,
+  sfDocumentOnDocumentFill,
   sfDocumentViewfinder,
+  sfExclamationmarkTriangleFill,
+  sfFolder,
+  sfGearshape,
+  sfLink,
+  sfListNumber,
+  sfLockFill,
+  sfPauseFill,
   sfPhotoFill,
+  sfPlayFill,
   sfScanner,
+  sfShieldFill,
+  sfSquareAndArrowUp,
+  sfStopFill,
+  sfTagFill,
+  sfXmarkCircleFill,
 } from "@bradleyhodges/sfsymbols";
+import type { ComponentProps } from "react";
 
 type IconProps = ComponentProps<"svg">;
 
@@ -40,18 +40,9 @@ interface SFIconDef {
 function makeSFIcon(icon: SFIconDef) {
   return function SFIconComponent(props: IconProps) {
     return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox={icon.viewBox}
-        fill="currentColor"
-        {...props}
-      >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox={icon.viewBox} fill="currentColor" {...props}>
         {icon.svgPathData.map((path, i) => (
-          <path
-            key={i}
-            d={path.d}
-            fillOpacity={path.fillOpacity}
-          />
+          <path key={i} d={path.d} fillOpacity={path.fillOpacity} />
         ))}
       </svg>
     );
@@ -65,18 +56,14 @@ export const SFFolder = makeSFIcon(sfFolder);
 
 export const SFLink = makeSFIcon(sfLink);
 export const SFGearshape = makeSFIcon(sfGearshape);
-export const SFClockArrow = makeSFIcon(
-  sfClockArrowTriangleheadCounterclockwiseRotate90,
-);
+export const SFClockArrow = makeSFIcon(sfClockArrowTriangleheadCounterclockwiseRotate90);
 export const SFSquareArrowUp = makeSFIcon(sfSquareAndArrowUp);
 export const SFCheckmarkCircleFill = makeSFIcon(sfCheckmarkCircleFill);
 export const SFXmarkCircleFill = makeSFIcon(sfXmarkCircleFill);
 export const SFLockFill = makeSFIcon(sfLockFill);
 export const SFShieldFill = makeSFIcon(sfShieldFill);
 export const SFListNumber = makeSFIcon(sfListNumber);
-export const SFExclamationTriangleFill = makeSFIcon(
-  sfExclamationmarkTriangleFill,
-);
+export const SFExclamationTriangleFill = makeSFIcon(sfExclamationmarkTriangleFill);
 export const SFDocOnDocFill = makeSFIcon(sfDocumentOnDocumentFill);
 export const SFTagFill = makeSFIcon(sfTagFill);
 export const SFChevronDown = makeSFIcon(sfChevronDown);

--- a/src/components/SavedPlaylistEditorDialog.tsx
+++ b/src/components/SavedPlaylistEditorDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { FolderOpen, X } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { FolderOpen, X } from "lucide-react";
+import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useState } from "react";
 import type { SavedPlaylistDraft } from "../lib/types";
 import PasswordField from "./PasswordField";
 
@@ -44,8 +44,7 @@ function handleSelectAllShortcut(
   event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
 ): void {
   const lowerKey = event.key.toLowerCase();
-  const hasPrimaryModifier =
-    (event.metaKey && !event.ctrlKey) || (event.ctrlKey && !event.metaKey);
+  const hasPrimaryModifier = (event.metaKey && !event.ctrlKey) || (event.ctrlKey && !event.metaKey);
 
   if (!hasPrimaryModifier || event.altKey || event.shiftKey || lowerKey !== "a") {
     return;
@@ -108,9 +107,7 @@ export default function SavedPlaylistEditorDialog({
               username: form.username.trim(),
               password: form.password?.trim() ?? null,
               preferred_server:
-                preferredServer && servers.includes(preferredServer)
-                  ? preferredServer
-                  : null,
+                preferredServer && servers.includes(preferredServer) ? preferredServer : null,
               servers,
             };
           })()
@@ -164,9 +161,7 @@ export default function SavedPlaylistEditorDialog({
 
         <div className="space-y-4 p-5">
           <div className="space-y-1.5">
-            <label className="text-[12px] font-medium text-text-secondary">
-              Display Name
-            </label>
+            <label className="text-[12px] font-medium text-text-secondary">Display Name</label>
             <input
               type="text"
               value={form.display_name}
@@ -222,9 +217,7 @@ export default function SavedPlaylistEditorDialog({
             <>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-1.5">
-                  <label className="text-[12px] font-medium text-text-secondary">
-                    Username
-                  </label>
+                  <label className="text-[12px] font-medium text-text-secondary">Username</label>
                   <input
                     type="text"
                     value={form.username}
@@ -277,9 +270,7 @@ export default function SavedPlaylistEditorDialog({
                   }
                   className="w-full rounded-md border border-border-app bg-input px-3 py-2 text-[13px] text-text-primary focus:border-blue-500 focus:outline-none font-mono resize-none"
                 />
-                <p className="text-[11px] text-text-tertiary">
-                  Enter one server URL per line.
-                </p>
+                <p className="text-[11px] text-text-tertiary">Enter one server URL per line.</p>
               </div>
 
               <div className="space-y-1.5">

--- a/src/components/SavedPlaylistsDialog.tsx
+++ b/src/components/SavedPlaylistsDialog.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
 import { FolderOpen, Pencil, Server, Trash2, X } from "lucide-react";
-import type { SavedPlaylistEntry } from "../lib/types";
+import { useEffect } from "react";
 import { savedPlaylistSecondaryLabel } from "../lib/savedPlaylists";
+import type { SavedPlaylistEntry } from "../lib/types";
 
 interface SavedPlaylistsDialogProps {
   playlists: SavedPlaylistEntry[];
@@ -45,9 +45,7 @@ export default function SavedPlaylistsDialog({
             <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-1">
               Library
             </p>
-            <h2 className="text-[18px] font-semibold text-text-primary">
-              Saved Playlists
-            </h2>
+            <h2 className="text-[18px] font-semibold text-text-primary">Saved Playlists</h2>
           </div>
           <button
             type="button"

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,12 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import {
-  Gauge,
-  Layers,
-  Network,
-  SlidersHorizontal,
-  Wrench,
-} from "lucide-react";
+import { Gauge, Layers, Network, SlidersHorizontal, Wrench } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   clearScreenshotCache,
   deleteScanPreset,
@@ -14,8 +8,8 @@ import {
   getScreenshotCacheStats,
   renameScanPreset,
   saveScanPreset,
-  setDefaultScanPreset,
   setDefaultM3u8FileAssociation,
+  setDefaultScanPreset,
 } from "../lib/tauri";
 import type {
   AppSettings,
@@ -66,10 +60,7 @@ function buildScanPresetConfig(settings: AppSettings): ScanPresetConfig {
   };
 }
 
-function applyScanPresetConfig(
-  base: AppSettings,
-  config: ScanPresetConfig,
-): AppSettings {
+function applyScanPresetConfig(base: AppSettings, config: ScanPresetConfig): AppSettings {
   return {
     ...base,
     timeout: config.timeout,
@@ -120,9 +111,7 @@ function Switch({
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full border transition-colors ${
-        checked
-          ? "border-blue-500 bg-blue-500/80"
-          : "border-border-app bg-panel"
+        checked ? "border-blue-500 bg-blue-500/80" : "border-border-app bg-panel"
       }`}
     >
       <span
@@ -153,9 +142,7 @@ function SegmentedControl<T extends string>({
             type="button"
             onClick={() => onChange(option.value)}
             className={`rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors ${
-              selected
-                ? "bg-blue-600 text-white"
-                : "text-text-secondary hover:bg-btn-hover"
+              selected ? "bg-blue-600 text-white" : "text-text-secondary hover:bg-btn-hover"
             }`}
           >
             {option.label}
@@ -225,8 +212,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   }, [presetCollection, selectedPresetName]);
 
   const selectedPreset: ScanSettingsPreset | null =
-    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ??
-    null;
+    presetCollection.presets.find((preset) => preset.name === selectedPresetName) ?? null;
 
   const persist = useCallback(
     (next: AppSettings) => {
@@ -274,11 +260,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   );
 
   const updateSetting = useCallback(
-    <K extends keyof AppSettings>(
-      key: K,
-      value: AppSettings[K],
-      options?: PersistOptions,
-    ) => {
+    <K extends keyof AppSettings>(key: K, value: AppSettings[K], options?: PersistOptions) => {
       setDraft((prev) => {
         const next = { ...prev, [key]: value };
         schedulePersist(next, options);
@@ -380,11 +362,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
     setPresetError(null);
     setPresetNotice(null);
     try {
-      const next = await saveScanPreset(
-        name,
-        buildScanPresetConfig(draft),
-        presetSetAsDefault,
-      );
+      const next = await saveScanPreset(name, buildScanPresetConfig(draft), presetSetAsDefault);
       setPresetCollection(next);
       setSelectedPresetName(name);
       setPresetNameDraft(name);
@@ -411,9 +389,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       setPresetError("Select a preset to rename.");
       return;
     }
-    const nextName = window
-      .prompt("Rename preset", selectedPreset.name)
-      ?.trim();
+    const nextName = window.prompt("Rename preset", selectedPreset.name)?.trim();
     if (!nextName || nextName === selectedPreset.name) {
       return;
     }
@@ -454,9 +430,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       const next = await deleteScanPreset(selectedPreset.name);
       setPresetCollection(next);
       setPresetNameDraft("");
-      setSelectedPresetName(
-        next.default_preset ?? next.presets[0]?.name ?? "",
-      );
+      setSelectedPresetName(next.default_preset ?? next.presets[0]?.name ?? "");
       setPresetNotice(`Deleted preset "${selectedPreset.name}".`);
     } catch (error) {
       setPresetError(error instanceof Error ? error.message : String(error));
@@ -517,7 +491,10 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
       tabIndex={-1}
       className="flex flex-col h-full bg-overlay focus:outline-none"
     >
-      <div className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle" data-tauri-drag-region>
+      <div
+        className="relative flex items-center justify-center px-4 pt-4 pb-3 border-b border-border-app bg-panel-subtle"
+        data-tauri-drag-region
+      >
         <div className="flex items-center gap-1">
           {tabs.map(({ id, label, Icon }) => {
             const active = activeTab === id;
@@ -540,729 +517,716 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
         </div>
       </div>
 
-        <div className="flex-1 overflow-y-auto p-5 space-y-4">
-          {saveError && (
-            <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
-              Could not save one or more changes: {saveError}
-            </div>
-          )}
+      <div className="flex-1 overflow-y-auto p-5 space-y-4">
+        {saveError && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
+            Could not save one or more changes: {saveError}
+          </div>
+        )}
 
-          {activeTab === "general" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Theme</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Choose system, light, or dark appearance.
-                    </p>
-                  </div>
-                  <SegmentedControl
-                    value={draft.theme}
-                    options={[
-                      { value: "system", label: "System" },
-                      { value: "light", label: "Light" },
-                      { value: "dark", label: "Dark" },
-                    ]}
-                    onChange={(value) => updateSetting("theme", value, { immediate: true })}
-                  />
+        {activeTab === "general" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Theme</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Choose system, light, or dark appearance.
+                  </p>
                 </div>
+                <SegmentedControl
+                  value={draft.theme}
+                  options={[
+                    { value: "system", label: "System" },
+                    { value: "light", label: "Light" },
+                    { value: "dark", label: "Dark" },
+                  ]}
+                  onChange={(value) => updateSetting("theme", value, { immediate: true })}
+                />
+              </div>
 
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Channel logo size</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Controls logo size in the channel name column.
-                    </p>
-                  </div>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Channel logo size</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Controls logo size in the channel name column.
+                  </p>
+                </div>
+                <select
+                  value={draft.channel_logo_size}
+                  onChange={(event) =>
+                    updateSetting(
+                      "channel_logo_size",
+                      event.target.value as AppSettings["channel_logo_size"],
+                      { immediate: true },
+                    )
+                  }
+                  className={`${inputClass} w-44`}
+                >
+                  <option value="small">Small (16px)</option>
+                  <option value="medium">Medium (24px)</option>
+                  <option value="large">Large (36px)</option>
+                  <option value="huge">Huge (48px)</option>
+                </select>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Profile video bitrate</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Captures 10s of each stream for accurate video bitrate values. Much slower.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.profile_bitrate}
+                  onChange={(checked) =>
+                    updateSetting("profile_bitrate", checked, { immediate: true })
+                  }
+                  ariaLabel="Profile bitrate"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Show source filter bar</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Display the regex source filter bar above the table.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.show_prescan_filter}
+                  onChange={(checked) =>
+                    updateSetting("show_prescan_filter", checked, { immediate: true })
+                  }
+                  ariaLabel="Show source filter bar"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Hide VOD / series entries</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Remove movies and series from loaded playlists, scans, and exports until
+                    re-enabled.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.hide_vod_content}
+                  onChange={(checked) =>
+                    updateSetting("hide_vod_content", checked, { immediate: true })
+                  }
+                  ariaLabel="Hide VOD and series entries"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Auto-reveal report panel</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Slide in the playlist report near scan completion.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.report_auto_reveal}
+                  onChange={(checked) =>
+                    updateSetting("report_auto_reveal", checked, { immediate: true })
+                  }
+                  ariaLabel="Auto-reveal report panel"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Separate placeholder status</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Show placeholder streams as a distinct status. When off, they are grouped under
+                    Dead.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.separate_placeholder_status}
+                  onChange={(checked) =>
+                    updateSetting("separate_placeholder_status", checked, { immediate: true })
+                  }
+                  ariaLabel="Separate placeholder status"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Show header button text</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    {platform === "macos"
+                      ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
+                      : "Display labels beside toolbar icons in the main window header."}
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.show_header_button_text}
+                  onChange={(checked) =>
+                    updateSetting("show_header_button_text", checked, {
+                      immediate: true,
+                    })
+                  }
+                  ariaLabel="Show header button text"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Scan completion notifications</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Show native notifications when scans complete or are cancelled.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.scan_notifications}
+                  onChange={(checked) =>
+                    updateSetting("scan_notifications", checked, { immediate: true })
+                  }
+                  ariaLabel="Scan completion notifications"
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Open playlist files in IPTV Checker by default.
+                  </p>
+                </div>
+                <button
+                  onClick={handleSetDefaultM3u8Association}
+                  disabled={associationBusy}
+                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  type="button"
+                >
+                  {associationBusy ? "Applying..." : "Set as Default"}
+                </button>
+              </div>
+              {associationNotice && (
+                <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
+                  {associationNotice}
+                </p>
+              )}
+              {associationError && (
+                <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
+                  {associationError}
+                </p>
+              )}
+            </section>
+          </>
+        )}
+
+        {activeTab === "scanning" && (
+          <>
+            <section className={`${blockClass} px-4 py-3 space-y-2`}>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
+                {presetCollection.default_preset && (
+                  <span className="text-[10px] text-text-tertiary">
+                    Default: {presetCollection.default_preset}
+                  </span>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-1.5">
+                <div className="flex gap-1.5">
                   <select
-                    value={draft.channel_logo_size}
-                    onChange={(event) =>
-                      updateSetting(
-                        "channel_logo_size",
-                        event.target.value as AppSettings["channel_logo_size"],
-                        { immediate: true },
-                      )
-                    }
-                    className={`${inputClass} w-44`}
+                    value={selectedPresetName}
+                    onChange={(event) => {
+                      setSelectedPresetName(event.target.value);
+                      setPresetNameDraft(event.target.value);
+                    }}
+                    className={`${inputClass} min-w-0 flex-1`}
+                    disabled={presetBusy || presetCollection.presets.length === 0}
                   >
-                    <option value="small">Small (16px)</option>
-                    <option value="medium">Medium (24px)</option>
-                    <option value="large">Large (36px)</option>
-                    <option value="huge">Huge (48px)</option>
-                  </select>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Profile video bitrate</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Captures 10s of each stream for accurate video bitrate values. Much slower.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.profile_bitrate}
-                    onChange={(checked) =>
-                      updateSetting("profile_bitrate", checked, { immediate: true })
-                    }
-                    ariaLabel="Profile bitrate"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Show source filter bar</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Display the regex source filter bar above the table.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.show_prescan_filter}
-                    onChange={(checked) =>
-                      updateSetting("show_prescan_filter", checked, { immediate: true })
-                    }
-                    ariaLabel="Show source filter bar"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Hide VOD / series entries</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Remove movies and series from loaded playlists, scans, and exports until re-enabled.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.hide_vod_content}
-                    onChange={(checked) =>
-                      updateSetting("hide_vod_content", checked, { immediate: true })
-                    }
-                    ariaLabel="Hide VOD and series entries"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Auto-reveal report panel</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Slide in the playlist report near scan completion.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.report_auto_reveal}
-                    onChange={(checked) =>
-                      updateSetting("report_auto_reveal", checked, { immediate: true })
-                    }
-                    ariaLabel="Auto-reveal report panel"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Separate placeholder status</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Show placeholder streams as a distinct status. When off, they are grouped under Dead.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.separate_placeholder_status}
-                    onChange={(checked) =>
-                      updateSetting("separate_placeholder_status", checked, { immediate: true })
-                    }
-                    ariaLabel="Separate placeholder status"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Show header button text</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      {platform === "macos"
-                        ? "Display labels beside toolbar icons instead of the default icon-only macOS header."
-                        : "Display labels beside toolbar icons in the main window header."}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.show_header_button_text}
-                    onChange={(checked) =>
-                      updateSetting("show_header_button_text", checked, {
-                        immediate: true,
-                      })
-                    }
-                    ariaLabel="Show header button text"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Scan completion notifications</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Show native notifications when scans complete or are cancelled.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.scan_notifications}
-                    onChange={(checked) =>
-                      updateSetting("scan_notifications", checked, { immediate: true })
-                    }
-                    ariaLabel="Scan completion notifications"
-                  />
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">Default app for .m3u/.m3u8</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Open playlist files in IPTV Checker by default.
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleSetDefaultM3u8Association}
-                    disabled={associationBusy}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    type="button"
-                  >
-                    {associationBusy ? "Applying..." : "Set as Default"}
-                  </button>
-                </div>
-                {associationNotice && (
-                  <p className="px-4 py-2 text-[11px] text-emerald-400 border-t border-border-subtle">
-                    {associationNotice}
-                  </p>
-                )}
-                {associationError && (
-                  <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
-                    {associationError}
-                  </p>
-                )}
-              </section>
-            </>
-          )}
-
-          {activeTab === "scanning" && (
-            <>
-              <section className={`${blockClass} px-4 py-3 space-y-2`}>
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-[12px] font-medium text-text-primary">Scan Presets</p>
-                  {presetCollection.default_preset && (
-                    <span className="text-[10px] text-text-tertiary">
-                      Default: {presetCollection.default_preset}
-                    </span>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-2 gap-1.5">
-                  <div className="flex gap-1.5">
-                    <select
-                      value={selectedPresetName}
-                      onChange={(event) => {
-                        setSelectedPresetName(event.target.value);
-                        setPresetNameDraft(event.target.value);
-                      }}
-                      className={`${inputClass} min-w-0 flex-1`}
-                      disabled={presetBusy || presetCollection.presets.length === 0}
-                    >
-                      <option value="">
-                        {presetCollection.presets.length === 0
-                          ? "No presets"
-                          : "Select preset"}
+                    <option value="">
+                      {presetCollection.presets.length === 0 ? "No presets" : "Select preset"}
+                    </option>
+                    {presetCollection.presets.map((preset) => (
+                      <option key={preset.name} value={preset.name}>
+                        {preset.name}
+                        {presetCollection.default_preset === preset.name ? " (Default)" : ""}
                       </option>
-                      {presetCollection.presets.map((preset) => (
-                        <option key={preset.name} value={preset.name}>
-                          {preset.name}
-                          {presetCollection.default_preset === preset.name
-                            ? " (Default)"
-                            : ""}
-                        </option>
-                      ))}
-                    </select>
-                    <button
-                      type="button"
-                      onClick={handleLoadPreset}
-                      disabled={presetBusy || !selectedPreset}
-                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      Load
-                    </button>
-                  </div>
-                  <div className="flex gap-1.5">
-                    <input
-                      type="text"
-                      value={presetNameDraft}
-                      onChange={(event) =>
-                        setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
-                      }
-                      placeholder="Preset name"
-                      className={`${inputClass} min-w-0 flex-1`}
-                      disabled={presetBusy}
-                    />
-                    <button
-                      type="button"
-                      onClick={handleSavePreset}
-                      disabled={presetBusy}
-                      className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
-                    >
-                      Save
-                    </button>
-                  </div>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={handleLoadPreset}
+                    disabled={presetBusy || !selectedPreset}
+                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Load
+                  </button>
                 </div>
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    value={presetNameDraft}
+                    onChange={(event) =>
+                      setPresetNameDraft(event.target.value.slice(0, PRESET_NAME_MAX_LENGTH))
+                    }
+                    placeholder="Preset name"
+                    className={`${inputClass} min-w-0 flex-1`}
+                    disabled={presetBusy}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleSavePreset}
+                    disabled={presetBusy}
+                    className="macos-btn px-2.5 py-1 min-h-[30px] text-[12px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
 
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
-                    <input
-                      type="checkbox"
-                      checked={presetSetAsDefault}
-                      onChange={(event) => setPresetSetAsDefault(event.target.checked)}
-                      disabled={presetBusy}
-                    />
-                    Save as default
+              <div className="flex flex-wrap items-center gap-1.5">
+                <label className="inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={presetSetAsDefault}
+                    onChange={(event) => setPresetSetAsDefault(event.target.checked)}
+                    disabled={presetBusy}
+                  />
+                  Save as default
+                </label>
+                <button
+                  type="button"
+                  onClick={handleSetDefaultPreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Mark Default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClearDefaultPreset}
+                  disabled={presetBusy || !presetCollection.default_preset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Clear Default
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRenamePreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeletePreset}
+                  disabled={presetBusy || !selectedPreset}
+                  className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
+                >
+                  Delete
+                </button>
+              </div>
+
+              {presetNotice && <p className="text-[11px] text-emerald-400">{presetNotice}</p>}
+              {presetError && <p className="text-[11px] text-red-400">{presetError}</p>}
+            </section>
+
+            <section className={`${blockClass} p-4`}>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Timeout (seconds)
                   </label>
-                  <button
-                    type="button"
-                    onClick={handleSetDefaultPreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Mark Default
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleClearDefaultPreset}
-                    disabled={presetBusy || !presetCollection.default_preset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Clear Default
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleRenamePreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none"
-                  >
-                    Rename
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDeletePreset}
-                    disabled={presetBusy || !selectedPreset}
-                    className="macos-btn px-2 py-0.5 text-[11px] bg-btn hover:bg-btn-hover rounded disabled:opacity-50 disabled:pointer-events-none text-red-400"
-                  >
-                    Delete
-                  </button>
-                </div>
-
-                {presetNotice && (
-                  <p className="text-[11px] text-emerald-400">{presetNotice}</p>
-                )}
-                {presetError && (
-                  <p className="text-[11px] text-red-400">{presetError}</p>
-                )}
-              </section>
-
-              <section className={`${blockClass} p-4`}>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Timeout (seconds)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.timeout}
-                      onChange={(event) => {
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "timeout",
-                          Number.isNaN(value) ? 10 : Math.max(0.5, value),
-                        );
-                      }}
-                      step="0.5"
-                      min="0.5"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Extended Timeout (seconds)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.extended_timeout ?? ""}
-                      onChange={(event) => {
-                        if (!event.target.value) {
-                          updateSetting("extended_timeout", null);
-                          return;
-                        }
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "extended_timeout",
-                          Number.isNaN(value) ? null : Math.max(1, value),
-                        );
-                      }}
-                      placeholder="Disabled"
-                      step="1"
-                      min="1"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Concurrency
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.concurrency || ""}
-                      placeholder="Auto"
-                      onChange={(event) => {
-                        const raw = event.target.value.trim();
-                        if (raw === "") {
-                          updateSetting("concurrency", 0);
-                          return;
-                        }
-                        const value = parseInt(raw, 10);
-                        updateSetting(
-                          "concurrency",
-                          Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
-                        );
-                      }}
-                      min="0"
-                      max="20"
-                      className={inputClass}
-                    />
-                    <p className="text-[11px] text-text-quaternary mt-1">
-                      0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1
-                      for single-server)
-                    </p>
-                  </div>
-
-                </div>
-              </section>
-
-              <section className={`${blockClass} p-4`}>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Max Retries
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.retries}
-                      onChange={(event) => {
-                        const value = parseInt(event.target.value, 10);
-                        updateSetting(
-                          "retries",
-                          Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
-                        );
-                      }}
-                      min="0"
-                      max="10"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Retry Backoff
-                    </label>
-                    <SegmentedControl
-                      value={draft.retry_backoff}
-                      options={[
-                        { value: "none", label: "None" },
-                        { value: "linear", label: "Linear" },
-                        { value: "exponential", label: "Exponential" },
-                      ]}
-                      onChange={(value) =>
-                        updateSetting("retry_backoff", value, { immediate: true })
-                      }
-                    />
-                  </div>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Low FPS threshold</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Streams below this FPS are flagged as low framerate.
-                    </p>
-                  </div>
                   <input
                     type="number"
-                    value={draft.low_fps_threshold}
+                    value={draft.timeout}
+                    onChange={(event) => {
+                      const value = parseFloat(event.target.value);
+                      updateSetting("timeout", Number.isNaN(value) ? 10 : Math.max(0.5, value));
+                    }}
+                    step="0.5"
+                    min="0.5"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Extended Timeout (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.extended_timeout ?? ""}
+                    onChange={(event) => {
+                      if (!event.target.value) {
+                        updateSetting("extended_timeout", null);
+                        return;
+                      }
+                      const value = parseFloat(event.target.value);
+                      updateSetting(
+                        "extended_timeout",
+                        Number.isNaN(value) ? null : Math.max(1, value),
+                      );
+                    }}
+                    placeholder="Disabled"
+                    step="1"
+                    min="1"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Concurrency
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.concurrency || ""}
+                    placeholder="Auto"
+                    onChange={(event) => {
+                      const raw = event.target.value.trim();
+                      if (raw === "") {
+                        updateSetting("concurrency", 0);
+                        return;
+                      }
+                      const value = parseInt(raw, 10);
+                      updateSetting(
+                        "concurrency",
+                        Number.isNaN(value) ? 0 : Math.max(0, Math.min(20, value)),
+                      );
+                    }}
+                    min="0"
+                    max="20"
+                    className={inputClass}
+                  />
+                  <p className="text-[11px] text-text-quaternary mt-1">
+                    0 or empty = auto (Xtream max for Xtream playlists, 10 for multi-server, 1 for
+                    single-server)
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className={`${blockClass} p-4`}>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Max Retries
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.retries}
+                    onChange={(event) => {
+                      const value = parseInt(event.target.value, 10);
+                      updateSetting(
+                        "retries",
+                        Number.isNaN(value) ? 3 : Math.max(0, Math.min(10, value)),
+                      );
+                    }}
+                    min="0"
+                    max="10"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Retry Backoff
+                  </label>
+                  <SegmentedControl
+                    value={draft.retry_backoff}
+                    options={[
+                      { value: "none", label: "None" },
+                      { value: "linear", label: "Linear" },
+                      { value: "exponential", label: "Exponential" },
+                    ]}
+                    onChange={(value) => updateSetting("retry_backoff", value, { immediate: true })}
+                  />
+                </div>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Low FPS threshold</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Streams below this FPS are flagged as low framerate.
+                  </p>
+                </div>
+                <input
+                  type="number"
+                  value={draft.low_fps_threshold}
+                  onChange={(event) => {
+                    const value = parseFloat(event.target.value);
+                    updateSetting(
+                      "low_fps_threshold",
+                      Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
+                    );
+                  }}
+                  step="0.1"
+                  min="0"
+                  max="240"
+                  className={`${inputClass} w-24`}
+                />
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">User agent</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    HTTP user agent string sent with stream requests.
+                  </p>
+                </div>
+                <input
+                  type="text"
+                  value={draft.user_agent}
+                  onChange={(event) => updateSetting("user_agent", event.target.value)}
+                  className={`${inputClass} w-56`}
+                />
+              </div>
+            </section>
+          </>
+        )}
+
+        {activeTab === "media" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Skip screenshots</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Disable frame captures for faster checks.
+                  </p>
+                </div>
+                <Switch
+                  checked={draft.skip_screenshots}
+                  onChange={(checked) =>
+                    updateSetting("skip_screenshots", checked, { immediate: true })
+                  }
+                  ariaLabel="Skip screenshots"
+                />
+              </div>
+
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Screenshot format</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    WebP is faster and smaller. PNG is lossless.
+                  </p>
+                </div>
+                <select
+                  value={draft.screenshot_format}
+                  onChange={(event) =>
+                    updateSetting(
+                      "screenshot_format",
+                      event.target.value as AppSettings["screenshot_format"],
+                      { immediate: true },
+                    )
+                  }
+                  className={`${inputClass} w-44`}
+                  disabled={draft.skip_screenshots}
+                >
+                  <option value="webp">WebP</option>
+                  <option value="png">PNG</option>
+                </select>
+              </div>
+
+              <div className={rowClass}>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-medium">Save screenshots to</p>
+                  <p
+                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                    title={draft.screenshots_dir ?? "Not saved (preview only)"}
+                  >
+                    {draft.screenshots_dir ?? "Not saved (preview only)"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleSelectScreenshotsDir}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                    type="button"
+                  >
+                    Browse
+                  </button>
+                  {draft.screenshots_dir && (
+                    <button
+                      onClick={() => updateSetting("screenshots_dir", null, { immediate: true })}
+                      className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                      type="button"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    {cacheStats
+                      ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
+                      : "Unavailable"}
+                    {cacheStats?.disk_space && (
+                      <span className="ml-1.5 text-text-tertiary/70">
+                        · {formatBytes(cacheStats.disk_space.available_bytes)} free
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <button
+                  onClick={handleClearScreenshotCache}
+                  disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
+                  className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                  type="button"
+                >
+                  {cacheBusy ? "Clearing..." : "Clear Cache"}
+                </button>
+              </div>
+
+              {cacheStats && (
+                <p
+                  className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
+                  title={cacheStats.cache_dir}
+                >
+                  {cacheStats.cache_dir}
+                </p>
+              )}
+
+              <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Screenshot Retention
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.screenshot_retention_count}
+                    onChange={(event) => {
+                      const value = parseInt(event.target.value, 10);
+                      updateSetting(
+                        "screenshot_retention_count",
+                        Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
+                      );
+                    }}
+                    min="0"
+                    max="100"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
+                    Low Space Threshold (GB)
+                  </label>
+                  <input
+                    type="number"
+                    value={draft.low_space_threshold_gb}
                     onChange={(event) => {
                       const value = parseFloat(event.target.value);
                       updateSetting(
-                        "low_fps_threshold",
-                        Number.isNaN(value) ? 23.0 : Math.max(0, Math.min(240, value)),
+                        "low_space_threshold_gb",
+                        Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
                       );
                     }}
-                    step="0.1"
-                    min="0"
-                    max="240"
-                    className={`${inputClass} w-24`}
+                    step="0.5"
+                    min="1"
+                    max="50"
+                    className={inputClass}
                   />
                 </div>
-              </section>
+              </div>
+            </section>
+          </>
+        )}
 
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">User agent</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      HTTP user agent string sent with stream requests.
-                    </p>
-                  </div>
-                  <input
-                    type="text"
-                    value={draft.user_agent}
-                    onChange={(event) => updateSetting("user_agent", event.target.value)}
-                    className={`${inputClass} w-56`}
-                  />
-                </div>
-              </section>
-
-            </>
-          )}
-
-          {activeTab === "media" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Skip screenshots</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Disable frame captures for faster checks.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.skip_screenshots}
-                    onChange={(checked) =>
-                      updateSetting("skip_screenshots", checked, { immediate: true })
-                    }
-                    ariaLabel="Skip screenshots"
-                  />
-                </div>
-
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Screenshot format</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      WebP is faster and smaller. PNG is lossless.
-                    </p>
-                  </div>
-                  <select
-                    value={draft.screenshot_format}
-                    onChange={(event) =>
-                      updateSetting(
-                        "screenshot_format",
-                        event.target.value as AppSettings["screenshot_format"],
-                        { immediate: true },
-                      )
-                    }
-                    className={`${inputClass} w-44`}
-                    disabled={draft.skip_screenshots}
+        {activeTab === "network" && (
+          <>
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-medium">Proxy file</p>
+                  <p
+                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                    title={draft.proxy_file ?? "No proxy file selected"}
                   >
-                    <option value="webp">WebP</option>
-                    <option value="png">PNG</option>
-                  </select>
+                    {draft.proxy_file ?? "No proxy file selected"}
+                  </p>
                 </div>
-
-                <div className={rowClass}>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-medium">Save screenshots to</p>
-                    <p
-                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                      title={draft.screenshots_dir ?? "Not saved (preview only)"}
-                    >
-                      {draft.screenshots_dir ?? "Not saved (preview only)"}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={handleSelectScreenshotsDir}
-                      className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                      type="button"
-                    >
-                      Browse
-                    </button>
-                    {draft.screenshots_dir && (
-                      <button
-                        onClick={() =>
-                          updateSetting("screenshots_dir", null, { immediate: true })
-                        }
-                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                        type="button"
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </section>
-
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0">
-                    <p className="text-[13px] font-medium">Temp Screenshot Cache</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      {cacheStats
-                        ? `${formatBytes(cacheStats.total_bytes)} (${cacheStats.file_count} files)`
-                        : "Unavailable"}
-                      {cacheStats?.disk_space && (
-                        <span className="ml-1.5 text-text-tertiary/70">
-                          · {formatBytes(cacheStats.disk_space.available_bytes)} free
-                        </span>
-                      )}
-                    </p>
-                  </div>
+                <div className="flex items-center gap-2">
                   <button
-                    onClick={handleClearScreenshotCache}
-                    disabled={cacheBusy || !cacheStats || cacheStats.file_count === 0}
-                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md disabled:opacity-50 disabled:pointer-events-none"
+                    onClick={handleSelectProxy}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                     type="button"
                   >
-                    {cacheBusy ? "Clearing..." : "Clear Cache"}
+                    Browse
                   </button>
-                </div>
-
-                {cacheStats && (
-                  <p
-                    className="px-4 py-2 text-[11px] text-text-tertiary border-t border-border-subtle truncate"
-                    title={cacheStats.cache_dir}
-                  >
-                    {cacheStats.cache_dir}
-                  </p>
-                )}
-
-                <div className="grid grid-cols-1 grid-cols-2 gap-3 p-4 border-t border-border-subtle">
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Screenshot Retention
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.screenshot_retention_count}
-                      onChange={(event) => {
-                        const value = parseInt(event.target.value, 10);
-                        updateSetting(
-                          "screenshot_retention_count",
-                          Number.isNaN(value) ? 1 : Math.max(0, Math.min(100, value)),
-                        );
-                      }}
-                      min="0"
-                      max="100"
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
-                      Low Space Threshold (GB)
-                    </label>
-                    <input
-                      type="number"
-                      value={draft.low_space_threshold_gb}
-                      onChange={(event) => {
-                        const value = parseFloat(event.target.value);
-                        updateSetting(
-                          "low_space_threshold_gb",
-                          Number.isNaN(value) ? 5.0 : Math.max(1, Math.min(50, value)),
-                        );
-                      }}
-                      step="0.5"
-                      min="1"
-                      max="50"
-                      className={inputClass}
-                    />
-                  </div>
-                </div>
-              </section>
-            </>
-          )}
-
-          {activeTab === "network" && (
-            <>
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-medium">Proxy file</p>
-                    <p
-                      className="text-[11px] text-text-tertiary mt-0.5 truncate"
-                      title={draft.proxy_file ?? "No proxy file selected"}
-                    >
-                      {draft.proxy_file ?? "No proxy file selected"}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
+                  {draft.proxy_file && (
                     <button
-                      onClick={handleSelectProxy}
+                      onClick={() => updateSetting("proxy_file", null, { immediate: true })}
                       className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                       type="button"
                     >
-                      Browse
+                      Clear
                     </button>
-                    {draft.proxy_file && (
-                      <button
-                        onClick={() => updateSetting("proxy_file", null, { immediate: true })}
-                        className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
-                        type="button"
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
+                  )}
                 </div>
+              </div>
 
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Re-test geoblocked streams through your proxy list.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.test_geoblock}
-                    onChange={(checked) =>
-                      updateSetting("test_geoblock", checked, { immediate: true })
-                    }
-                    ariaLabel="Confirm geoblocks with proxies"
-                  />
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">Confirm geoblocks with proxies</p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Re-test geoblocked streams through your proxy list.
+                  </p>
                 </div>
-              </section>
+                <Switch
+                  checked={draft.test_geoblock}
+                  onChange={(checked) =>
+                    updateSetting("test_geoblock", checked, { immediate: true })
+                  }
+                  ariaLabel="Confirm geoblocks with proxies"
+                />
+              </div>
+            </section>
 
-              <section className={blockClass}>
-                <div className={rowClass}>
-                  <div>
-                    <p className="text-[13px] font-medium">Skip certificate verification (insecure)</p>
-                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Accept invalid/self-signed TLS certificates during stream checks.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={draft.accept_invalid_certs}
-                    onChange={(checked) =>
-                      updateSetting("accept_invalid_certs", checked, { immediate: true })
-                    }
-                    ariaLabel="Skip certificate verification"
-                  />
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div>
+                  <p className="text-[13px] font-medium">
+                    Skip certificate verification (insecure)
+                  </p>
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Accept invalid/self-signed TLS certificates during stream checks.
+                  </p>
                 </div>
-              </section>
-            </>
-          )}
+                <Switch
+                  checked={draft.accept_invalid_certs}
+                  onChange={(checked) =>
+                    updateSetting("accept_invalid_certs", checked, { immediate: true })
+                  }
+                  ariaLabel="Skip certificate verification"
+                />
+              </div>
+            </section>
+          </>
+        )}
 
-          {activeTab === "advanced" && (
-            <>
-              <section className={`${blockClass} p-4`}>
+        {activeTab === "advanced" && (
+          <>
+            <section className={`${blockClass} p-4`}>
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-[12px] font-medium text-text-secondary mb-1.5">
@@ -1302,7 +1266,6 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                     className={inputClass}
                   />
                 </div>
-
               </div>
             </section>
 
@@ -1352,9 +1315,9 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                 </div>
               </div>
             </section>
-            </>
-          )}
-        </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,12 +1,8 @@
-import { useMemo } from "react";
 import { FolderOpen, Loader2 } from "lucide-react";
-import type {
-  PlaylistLoadProgress,
-  RecentPlaylistEntry,
-  SavedPlaylistEntry,
-} from "../lib/types";
+import { useMemo } from "react";
 import { recentTitle, recentValueLabel } from "../lib/recentPlaylists";
 import { savedPlaylistSecondaryLabel } from "../lib/savedPlaylists";
+import type { PlaylistLoadProgress, RecentPlaylistEntry, SavedPlaylistEntry } from "../lib/types";
 
 const START_SCREEN_RECENT_LIMIT = 5;
 const START_SCREEN_SAVED_LIMIT = 8;
@@ -75,31 +71,31 @@ export function StartScreen({
             </p>
             {(playlistLoadProgress?.stage === "Connecting" ||
               playlistLoadProgress?.stage === "Saving") && (
-              <p className="text-sm mt-1 text-text-quaternary">
-                {playlistLoadProgress.detail}
-              </p>
+              <p className="text-sm mt-1 text-text-quaternary">{playlistLoadProgress.detail}</p>
             )}
             {playlistLoadProgress?.stage === "Downloading" && (
               <p className="text-sm mt-1 tabular-nums">
                 {(playlistLoadProgress.bytes_downloaded / (1024 * 1024)).toFixed(1)} MB
                 {playlistLoadProgress.elapsed_secs > 0 && (
                   <span className="ml-2 text-text-quaternary">
-                    {(playlistLoadProgress.bytes_downloaded / playlistLoadProgress.elapsed_secs / (1024 * 1024)).toFixed(1)} MB/s
+                    {(
+                      playlistLoadProgress.bytes_downloaded /
+                      playlistLoadProgress.elapsed_secs /
+                      (1024 * 1024)
+                    ).toFixed(1)}{" "}
+                    MB/s
                   </span>
                 )}
               </p>
             )}
             {playlistLoadProgress?.stage === "Parsing" && (
               <div className="text-sm mt-1 tabular-nums">
-                <p>
-                  {playlistLoadProgress.channels_found.toLocaleString()} entries found
-                </p>
+                <p>{playlistLoadProgress.channels_found.toLocaleString()} entries found</p>
                 <p className="text-text-quaternary">
                   {playlistLoadProgress.live_found.toLocaleString()} channels
                   <span className="mx-2">•</span>
                   {(
-                    playlistLoadProgress.movie_found +
-                    playlistLoadProgress.series_found
+                    playlistLoadProgress.movie_found + playlistLoadProgress.series_found
                   ).toLocaleString()}{" "}
                   VOD
                   {(playlistLoadProgress.movie_found > 0 ||
@@ -113,18 +109,14 @@ export function StartScreen({
               </div>
             )}
             {playlistLoadProgress?.stage === "Processing" && (
-              <p className="text-sm mt-1 text-text-quaternary">
-                {playlistLoadProgress.detail}
-              </p>
+              <p className="text-sm mt-1 text-text-quaternary">{playlistLoadProgress.detail}</p>
             )}
           </div>
         ) : (
           <>
             <div className="flex flex-col items-center">
               <div className="select-none pt-3">
-                <p className="text-lg font-medium mb-2">
-                  No playlist loaded
-                </p>
+                <p className="text-lg font-medium mb-2">No playlist loaded</p>
                 <p className="text-[15px] mb-4">
                   Click Open or press{" "}
                   <kbd className="px-2 py-0.5 bg-input rounded text-[13px] border border-border-app">

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,17 +1,16 @@
-import { memo, startTransition, type ReactNode } from "react";
+import { memo, type ReactNode, startTransition } from "react";
+import { useAppStore } from "../store";
 import {
   SFCheckmarkCircleFill,
-  SFXmarkCircleFill,
-  SFLockFill,
-  SFShieldFill,
-  SFListNumber,
-  SFExclamationTriangleFill,
-  SFTagFill,
   SFDocOnDocFill,
+  SFExclamationTriangleFill,
+  SFListNumber,
+  SFLockFill,
   SFPhotoFill,
+  SFShieldFill,
+  SFTagFill,
+  SFXmarkCircleFill,
 } from "./SFSymbols";
-import { useAppStore } from "../store";
-
 
 function Pill({
   icon,
@@ -80,9 +79,7 @@ const iconSize = "w-3 h-3";
 export const StatsPanel = memo(function StatsPanel() {
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
-  const totalChannels = useAppStore(
-    (s) => s.playlist?.total_channels ?? 0,
-  );
+  const totalChannels = useAppStore((s) => s.playlist?.total_channels ?? 0);
   const scanState = useAppStore((s) => s.scanState);
   const lowFpsCount = useAppStore((s) => s.uiMetrics.lowFpsCount);
   const mislabeledCount = useAppStore((s) => s.uiMetrics.mislabeledCount);

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,17 +1,8 @@
-import type { ChannelStatus } from "../lib/types";
 import { statusDotColor } from "../lib/format";
+import type { ChannelStatus } from "../lib/types";
 
-export function StatusBadge({
-  status,
-  title,
-}: {
-  status: ChannelStatus;
-  title?: string;
-}) {
+export function StatusBadge({ status, title }: { status: ChannelStatus; title?: string }) {
   return (
-    <span
-      title={title}
-      className={`inline-block w-2 h-2 rounded-full ${statusDotColor(status)}`}
-    />
+    <span title={title} className={`inline-block w-2 h-2 rounded-full ${statusDotColor(status)}`} />
   );
 }

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Cast,
@@ -11,10 +10,11 @@ import {
   Volume2,
   VolumeX,
 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { UseChromecastResult } from "../hooks/useChromecast";
 import { MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../hooks/useStreamPlayer";
-import type { CastMediaRequest } from "../lib/types";
 import { isCastSessionActive } from "../lib/cast";
+import type { CastMediaRequest } from "../lib/types";
 import { CastMenu } from "./CastMenu";
 
 interface StreamPlayerProps {
@@ -107,7 +107,10 @@ export function StreamPlayer({
       scheduleHide();
     } else {
       setControlsVisible(true);
-      if (hideTimerRef.current) { clearTimeout(hideTimerRef.current); hideTimerRef.current = null; }
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
     }
     return () => {
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
@@ -136,9 +139,7 @@ export function StreamPlayer({
       {showCastUi && isCasting && chromecast?.session && (
         <div className="absolute top-2 left-2 flex items-center gap-1.5 px-2 py-1 rounded-md bg-blue-600/85 text-white text-[11px] font-medium shadow-md backdrop-blur-sm">
           <Cast className="w-3 h-3" />
-          <span className="truncate max-w-[180px]">
-            Casting to {chromecast.session.deviceName}
-          </span>
+          <span className="truncate max-w-[180px]">Casting to {chromecast.session.deviceName}</span>
         </div>
       )}
 
@@ -151,16 +152,14 @@ export function StreamPlayer({
         >
           <LoaderCircle className="h-6 w-6 animate-spin text-white" />
           <span className="text-[12px] font-medium text-white/85">
-            {isRecovering ? recoveryMessage ?? "Reconnecting..." : "Connecting..."}
+            {isRecovering ? (recoveryMessage ?? "Reconnecting...") : "Connecting..."}
           </span>
           {isRecovering && (
             <div className="flex items-center gap-1.5 text-[11px] text-amber-100/85">
               <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
               <span>
                 Trying a clean reconnect
-                {recoveryAttempt
-                  ? ` (${recoveryAttempt}/${MAX_PLAYBACK_RECOVERY_ATTEMPTS})`
-                  : ""}
+                {recoveryAttempt ? ` (${recoveryAttempt}/${MAX_PLAYBACK_RECOVERY_ATTEMPTS})` : ""}
               </span>
             </div>
           )}

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -1,14 +1,25 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  CircleHelp,
+  ExternalLink,
+  Fullscreen,
+  ImageOff,
+  LoaderCircle,
+  Play,
+  RotateCw,
+  Shrink,
+  Square,
+  X,
+} from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { CircleHelp, ExternalLink, Fullscreen, ImageOff, LoaderCircle, Play, RotateCw, Shrink, Square, X } from "lucide-react";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ChannelResult } from "../lib/types";
+import type { UseChromecastResult } from "../hooks/useChromecast";
 import { buildCastRequest, isCastSessionActive } from "../lib/cast";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { formatAudioInfo, formatVideoInfo, statusLabel } from "../lib/format";
 import { isScanActive, type ScanState } from "../lib/scanState";
 import { getThumbnailDisplayState } from "../lib/thumbnailState";
-import type { UseChromecastResult } from "../hooks/useChromecast";
+import type { ChannelResult } from "../lib/types";
 import { CastMenu } from "./CastMenu";
 import { StatusBadge } from "./StatusBadge";
 import { StreamPlayer } from "./StreamPlayer";
@@ -94,9 +105,10 @@ export function ThumbnailPanel({
   useLayoutEffect(() => {
     if (!isPlaying || !videoElement) return;
 
-    const target = (lightboxOpen && lightboxRendered && lightboxPlayerRef.current)
-      ? lightboxPlayerRef.current
-      : sidebarPlayerRef.current;
+    const target =
+      lightboxOpen && lightboxRendered && lightboxPlayerRef.current
+        ? lightboxPlayerRef.current
+        : sidebarPlayerRef.current;
     if (!target || videoElement.parentNode === target) return;
 
     // FLIP: capture current position before move
@@ -113,16 +125,25 @@ export function ThumbnailPanel({
       const sw = firstRect.width / lastRect.width;
       const sh = firstRect.height / lastRect.height;
 
-      if (Math.abs(dx) > 2 || Math.abs(dy) > 2 || Math.abs(sw - 1) > 0.01 || Math.abs(sh - 1) > 0.01) {
+      if (
+        Math.abs(dx) > 2 ||
+        Math.abs(dy) > 2 ||
+        Math.abs(sw - 1) > 0.01 ||
+        Math.abs(sh - 1) > 0.01
+      ) {
         videoElement.style.transformOrigin = "top left";
         videoElement.style.transform = `translate(${dx}px, ${dy}px) scale(${sw}, ${sh})`;
         requestAnimationFrame(() => {
           videoElement.style.transition = "transform 300ms cubic-bezier(0.4, 0, 0.2, 1)";
           videoElement.style.transform = "";
-          videoElement.addEventListener("transitionend", () => {
-            videoElement.style.transition = "";
-            videoElement.style.transformOrigin = "";
-          }, { once: true });
+          videoElement.addEventListener(
+            "transitionend",
+            () => {
+              videoElement.style.transition = "";
+              videoElement.style.transformOrigin = "";
+            },
+            { once: true },
+          );
         });
       }
     }
@@ -206,7 +227,8 @@ export function ThumbnailPanel({
   // useEffect downstream of `castRequest` would tear down and re-fire on every
   // parent re-render even when none of its inputs actually changed.
   const castRequest = useMemo(() => buildCastRequest(result), [result]);
-  const mediaFrameClass = "relative w-full aspect-video overflow-hidden rounded-lg border border-border-app";
+  const mediaFrameClass =
+    "relative w-full aspect-video overflow-hidden rounded-lg border border-border-app";
   const lightboxPlaceholderClass =
     "w-[400px] max-w-[88vw] aspect-video rounded-xl border border-white/15 bg-black/60 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]";
 
@@ -240,7 +262,13 @@ export function ThumbnailPanel({
       {/* Hidden sidebar container keeps the ref alive for FLIP handoff from lightbox */}
       {isPlaying && lightboxOpen && <div ref={sidebarPlayerRef} className="hidden" />}
 
-      {isPlaying && !lightboxOpen && videoElement && onTogglePause && onStopPlayer && onSetVolume && onToggleMute ? (
+      {isPlaying &&
+      !lightboxOpen &&
+      videoElement &&
+      onTogglePause &&
+      onStopPlayer &&
+      onSetVolume &&
+      onToggleMute ? (
         <StreamPlayer
           containerRef={sidebarPlayerRef}
           playerState={playerState}
@@ -284,7 +312,9 @@ export function ThumbnailPanel({
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-text-secondary">
             <LoaderCircle className="h-5 w-5 animate-spin" />
             <span className="text-[11px] font-medium">
-              {thumbnailState.waitingForScanResult ? "Waiting for scan result..." : "Loading thumbnail..."}
+              {thumbnailState.waitingForScanResult
+                ? "Waiting for scan result..."
+                : "Loading thumbnail..."}
             </span>
           </div>
         </div>
@@ -309,14 +339,18 @@ export function ThumbnailPanel({
           <CircleHelp className="h-8 w-8 text-cyan-300/90" strokeWidth={1.75} />
           <p className="text-[12px] font-medium text-cyan-200">DRM-protected stream</p>
           <p className="text-[11px] text-cyan-200/80">
-            {result.drm_system ? `Detected system: ${result.drm_system}` : "Detected encrypted playback requirements."}
+            {result.drm_system
+              ? `Detected system: ${result.drm_system}`
+              : "Detected encrypted playback requirements."}
           </p>
         </div>
       ) : thumbnailState.showNoThumbnailCaptured ? (
         <div className="flex w-full aspect-video flex-col items-center justify-center gap-2 rounded-lg border border-border-subtle bg-panel-subtle px-3 text-center">
           <CircleHelp className="h-8 w-8 text-text-tertiary" strokeWidth={1.75} />
           <p className="text-[12px] font-medium text-text-secondary">No thumbnail captured</p>
-          <p className="text-[11px] text-text-tertiary">This channel scanned successfully, but no frame was saved.</p>
+          <p className="text-[11px] text-text-tertiary">
+            This channel scanned successfully, but no frame was saved.
+          </p>
         </div>
       ) : thumbnailState.showUnscannedPlaceholder ? (
         <div className="flex w-full aspect-video flex-col items-center justify-center gap-2 rounded-lg border border-border-subtle bg-panel-subtle px-3 text-center">
@@ -328,14 +362,16 @@ export function ThumbnailPanel({
         <div className="flex w-full aspect-video flex-col items-center justify-center gap-2 rounded-lg border border-border-subtle bg-panel-subtle px-3 text-center">
           <CircleHelp className="h-8 w-8 text-text-tertiary" strokeWidth={1.75} />
           <p className="text-[12px] font-medium text-text-secondary">Screenshots disabled</p>
-          <p className="text-[11px] text-text-tertiary">Enable screenshots in Settings to capture thumbnails.</p>
+          <p className="text-[11px] text-text-tertiary">
+            Enable screenshots in Settings to capture thumbnails.
+          </p>
         </div>
       ) : null}
 
       {(onPlayChannel || onScanChannel) && (
         <div className="flex items-center justify-center gap-2">
-          {onPlayChannel && (
-            isPlaying ? (
+          {onPlayChannel &&
+            (isPlaying ? (
               <button
                 type="button"
                 onClick={onStopPlayer}
@@ -355,8 +391,7 @@ export function ThumbnailPanel({
                 <Play className="w-3.5 h-3.5" />
                 Play
               </button>
-            )
-          )}
+            ))}
           {onOpenExternal && (
             <button
               type="button"
@@ -373,7 +408,13 @@ export function ThumbnailPanel({
               disabled={scanActive}
               onClick={() => onScanChannel([result.index])}
               className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium rounded-md bg-btn hover:bg-btn-hover text-text-primary border border-border-app shadow-sm transition-colors disabled:opacity-40 disabled:pointer-events-none"
-              title={scanActive ? "Scan in progress" : result.status === "pending" || result.status === "checking" ? "Scan channel" : "Rescan channel"}
+              title={
+                scanActive
+                  ? "Scan in progress"
+                  : result.status === "pending" || result.status === "checking"
+                    ? "Scan channel"
+                    : "Rescan channel"
+              }
             >
               <RotateCw className="w-3.5 h-3.5" />
               {result.status === "pending" || result.status === "checking" ? "Scan" : "Rescan"}
@@ -462,9 +503,7 @@ export function ThumbnailPanel({
 
       {result.low_framerate && (
         <div className="p-2 rounded bg-orange-500/10 border border-orange-500/20">
-          <p className="text-[11px] text-orange-400">
-            Low framerate: {result.fps} fps
-          </p>
+          <p className="text-[11px] text-orange-400">Low framerate: {result.fps} fps</p>
         </div>
       )}
 
@@ -472,9 +511,7 @@ export function ThumbnailPanel({
         <div className="p-2 rounded bg-panel-subtle border border-border-subtle">
           <p className="text-[12px] font-medium text-text-primary">Diagnostics</p>
           {retryCount > 0 && (
-            <p className="text-[11px] text-text-secondary mt-1">
-              Retries used: {retryCount}
-            </p>
+            <p className="text-[11px] text-text-secondary mt-1">Retries used: {retryCount}</p>
           )}
           {lastErrorReason && (
             <p className="text-[11px] text-text-secondary mt-1 break-words">
@@ -500,171 +537,213 @@ export function ThumbnailPanel({
         </div>
       )}
 
-      {lightboxRendered && createPortal(
-        <div
-          className={`fixed inset-0 z-[80] flex items-center justify-center transition-all duration-200 ${
-            theaterMode ? "p-0" : "px-6 py-10"
-          } ${
-            lightboxVisible ? (theaterMode ? "bg-black opacity-100" : "bg-black/70 opacity-100") : "bg-black/0 opacity-0"
-          }`}
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) {
-              closeLightbox();
-            }
-          }}
-        >
-          <button
-            type="button"
-            onClick={closeLightbox}
-            className={`absolute top-5 right-5 p-2 rounded-full bg-black/35 text-white hover:bg-black/55 transition-colors ${theaterMode ? "hidden" : ""}`}
-            aria-label="Close image preview"
-          >
-            <X className="w-5 h-5" />
-          </button>
+      {lightboxRendered &&
+        createPortal(
           <div
-            className={`flex flex-col items-center transition-all duration-200 ${
-              theaterMode ? "w-full h-full gap-0" : "max-h-full max-w-full gap-3"
+            className={`fixed inset-0 z-[80] flex items-center justify-center transition-all duration-200 ${
+              theaterMode ? "p-0" : "px-6 py-10"
             } ${
-              lightboxVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
+              lightboxVisible
+                ? theaterMode
+                  ? "bg-black opacity-100"
+                  : "bg-black/70 opacity-100"
+                : "bg-black/0 opacity-0"
             }`}
-            onMouseDown={(event) => event.stopPropagation()}
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) {
+                closeLightbox();
+              }
+            }}
           >
-            {!theaterMode && (
-              <h2 className="text-white text-[15px] font-semibold truncate max-w-[88vw] text-center drop-shadow-lg">
-                {result.name}
-              </h2>
-            )}
-            {isPlaying && videoElement && onTogglePause && onStopPlayer && onSetVolume && onToggleMute ? (
-              <div
-                className={`relative ${
-                  theaterMode
-                    ? "w-full h-full [&>div]:rounded-none [&>div]:border-0 [&>div]:shadow-none [&>div]:aspect-auto [&>div]:h-full"
-                    : "mb-14 mt-2 [&>div]:rounded-xl [&>div]:border-white/15 [&>div]:shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]"
-                }`}
-                style={theaterMode ? undefined : { width: "min(calc(84vh * 16 / 9), 88vw)" }}
-                onMouseEnter={() => setTheaterHover(true)}
-                onMouseLeave={() => setTheaterHover(false)}
-              >
-                <StreamPlayer
-                  containerRef={lightboxPlayerRef}
-                  playerState={playerState}
-                  errorMessage={playerErrorMessage ?? null}
-                  isPaused={isPaused ?? false}
-                  isRecovering={isRecovering ?? false}
-                  recoveryAttempt={recoveryAttempt ?? null}
-                  recoveryMessage={recoveryMessage ?? null}
-                  volume={volume ?? 0.75}
-                  muted={muted ?? false}
-                  onTogglePause={onTogglePause}
-                  onStop={onStopPlayer}
-                  onSetVolume={onSetVolume}
-                  onToggleMute={onToggleMute}
-                  onOpenExternal={() => onOpenExternal?.(result)}
-                  onRetry={() => onRetryPlay?.(result)}
-                  onPip={onPip ? () => { onPip(); closeLightbox(); } : undefined}
-                  castRequest={castRequest}
-                  chromecast={chromecast}
-                />
-                <button
-                  type="button"
-                  onClick={() => {
-                    const next = !theaterMode;
-                    setTheaterMode(next);
-                    void getCurrentWindow().setFullscreen(next);
-                  }}
-                  className={`absolute top-3 right-3 p-2.5 rounded-xl bg-black/50 text-white hover:bg-black/70 transition-all duration-200 ${
-                    theaterHover ? "opacity-100" : "opacity-0"
-                  }`}
-                  title={theaterMode ? "Exit fullscreen" : "Fullscreen"}
-                >
-                  {theaterMode ? <Shrink className="w-6 h-6" /> : <Fullscreen className="w-6 h-6" />}
-                </button>
-                {!theaterMode && (
-                  <button
-                    type="button"
-                    onClick={onStopPlayer}
-                    className="absolute -bottom-14 left-1/2 -translate-x-1/2 flex items-center gap-2 px-6 py-3 text-[15px] font-medium rounded-xl bg-red-600 hover:bg-red-500 text-white shadow-lg transition-colors"
-                  >
-                    <Square className="w-4 h-4" />
-                    Stop
-                  </button>
-                )}
-              </div>
-            ) : screenshotUrl ? (
-              <img
-                src={screenshotUrl}
-                alt={result.name}
-                className="block max-h-[84vh] max-w-[88vw] rounded-xl border border-white/15 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]"
-              />
-            ) : result.screenshot_path ? (
-              <div className={lightboxPlaceholderClass} />
-            ) : (
-              <div className={`flex flex-col items-center justify-center gap-2 ${lightboxPlaceholderClass}`}>
-                {result.status === "checking" ? (
-                  <LoaderCircle className="w-24 h-24 text-white/40 animate-spin" strokeWidth={1.5} />
-                ) : result.status === "pending" ? (
-                  <>
-                    <CircleHelp className="w-24 h-24 text-white/40" strokeWidth={1.5} />
-                    <span className="text-white/50 text-[14px] font-medium">Unscanned</span>
-                  </>
-                ) : (
-                  <X className="w-24 h-24 text-red-500/80" strokeWidth={2.5} />
-                )}
-              </div>
-            )}
-            {!theaterMode && !isPlaying && (onPlayChannel || onScanChannel) && (
-              <div className="flex items-center gap-2 mt-1">
-                {onPlayChannel && (
-                  <button
-                    type="button"
-                    onClick={() => onPlayChannel(result)}
-                    className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium rounded-lg bg-white/10 hover:bg-white/20 text-white backdrop-blur-sm transition-colors"
-                  >
-                    <Play className="w-4 h-4" />
-                    Play
-                  </button>
-                )}
-                {onScanChannel && (
-                  <button
-                    type="button"
-                    disabled={scanActive}
-                    onClick={() => onScanChannel([result.index])}
-                    className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium rounded-lg bg-white/10 hover:bg-white/20 text-white backdrop-blur-sm transition-colors disabled:opacity-40 disabled:pointer-events-none"
-                  >
-                    <RotateCw className="w-4 h-4" />
-                    {result.status === "pending" || result.status === "checking" ? "Scan" : "Rescan"}
-                  </button>
-                )}
-              </div>
-            )}
-            <div className={`flex items-center justify-center gap-2 mt-2 min-h-[24px] ${theaterMode ? "hidden" : ""}`}>
-              {result.status === "alive" && (
-                <>
-                  {result.resolution && result.resolution !== "Unknown" && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.width}x{result.height}</span>
-                  )}
-                  {result.fps && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.fps} fps</span>
-                  )}
-                  {result.video_bitrate && result.video_bitrate !== "Unknown" && result.video_bitrate !== "N/A" && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.video_bitrate}</span>
-                  )}
-                  {result.hdr_format && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.hdr_format}</span>
-                  )}
-                  {result.audio_bitrate && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.audio_bitrate} kbps audio</span>
-                  )}
-                  {result.audio_channel_layout && (
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">{result.audio_channel_layout} audio</span>
-                  )}
-                </>
+            <button
+              type="button"
+              onClick={closeLightbox}
+              className={`absolute top-5 right-5 p-2 rounded-full bg-black/35 text-white hover:bg-black/55 transition-colors ${theaterMode ? "hidden" : ""}`}
+              aria-label="Close image preview"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <div
+              className={`flex flex-col items-center transition-all duration-200 ${
+                theaterMode ? "w-full h-full gap-0" : "max-h-full max-w-full gap-3"
+              } ${lightboxVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}
+              onMouseDown={(event) => event.stopPropagation()}
+            >
+              {!theaterMode && (
+                <h2 className="text-white text-[15px] font-semibold truncate max-w-[88vw] text-center drop-shadow-lg">
+                  {result.name}
+                </h2>
               )}
+              {isPlaying &&
+              videoElement &&
+              onTogglePause &&
+              onStopPlayer &&
+              onSetVolume &&
+              onToggleMute ? (
+                <div
+                  className={`relative ${
+                    theaterMode
+                      ? "w-full h-full [&>div]:rounded-none [&>div]:border-0 [&>div]:shadow-none [&>div]:aspect-auto [&>div]:h-full"
+                      : "mb-14 mt-2 [&>div]:rounded-xl [&>div]:border-white/15 [&>div]:shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]"
+                  }`}
+                  style={theaterMode ? undefined : { width: "min(calc(84vh * 16 / 9), 88vw)" }}
+                  onMouseEnter={() => setTheaterHover(true)}
+                  onMouseLeave={() => setTheaterHover(false)}
+                >
+                  <StreamPlayer
+                    containerRef={lightboxPlayerRef}
+                    playerState={playerState}
+                    errorMessage={playerErrorMessage ?? null}
+                    isPaused={isPaused ?? false}
+                    isRecovering={isRecovering ?? false}
+                    recoveryAttempt={recoveryAttempt ?? null}
+                    recoveryMessage={recoveryMessage ?? null}
+                    volume={volume ?? 0.75}
+                    muted={muted ?? false}
+                    onTogglePause={onTogglePause}
+                    onStop={onStopPlayer}
+                    onSetVolume={onSetVolume}
+                    onToggleMute={onToggleMute}
+                    onOpenExternal={() => onOpenExternal?.(result)}
+                    onRetry={() => onRetryPlay?.(result)}
+                    onPip={
+                      onPip
+                        ? () => {
+                            onPip();
+                            closeLightbox();
+                          }
+                        : undefined
+                    }
+                    castRequest={castRequest}
+                    chromecast={chromecast}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = !theaterMode;
+                      setTheaterMode(next);
+                      void getCurrentWindow().setFullscreen(next);
+                    }}
+                    className={`absolute top-3 right-3 p-2.5 rounded-xl bg-black/50 text-white hover:bg-black/70 transition-all duration-200 ${
+                      theaterHover ? "opacity-100" : "opacity-0"
+                    }`}
+                    title={theaterMode ? "Exit fullscreen" : "Fullscreen"}
+                  >
+                    {theaterMode ? (
+                      <Shrink className="w-6 h-6" />
+                    ) : (
+                      <Fullscreen className="w-6 h-6" />
+                    )}
+                  </button>
+                  {!theaterMode && (
+                    <button
+                      type="button"
+                      onClick={onStopPlayer}
+                      className="absolute -bottom-14 left-1/2 -translate-x-1/2 flex items-center gap-2 px-6 py-3 text-[15px] font-medium rounded-xl bg-red-600 hover:bg-red-500 text-white shadow-lg transition-colors"
+                    >
+                      <Square className="w-4 h-4" />
+                      Stop
+                    </button>
+                  )}
+                </div>
+              ) : screenshotUrl ? (
+                <img
+                  src={screenshotUrl}
+                  alt={result.name}
+                  className="block max-h-[84vh] max-w-[88vw] rounded-xl border border-white/15 shadow-[0_35px_90px_rgba(0,0,0,0.55),0_5px_18px_rgba(0,0,0,0.28)]"
+                />
+              ) : result.screenshot_path ? (
+                <div className={lightboxPlaceholderClass} />
+              ) : (
+                <div
+                  className={`flex flex-col items-center justify-center gap-2 ${lightboxPlaceholderClass}`}
+                >
+                  {result.status === "checking" ? (
+                    <LoaderCircle
+                      className="w-24 h-24 text-white/40 animate-spin"
+                      strokeWidth={1.5}
+                    />
+                  ) : result.status === "pending" ? (
+                    <>
+                      <CircleHelp className="w-24 h-24 text-white/40" strokeWidth={1.5} />
+                      <span className="text-white/50 text-[14px] font-medium">Unscanned</span>
+                    </>
+                  ) : (
+                    <X className="w-24 h-24 text-red-500/80" strokeWidth={2.5} />
+                  )}
+                </div>
+              )}
+              {!theaterMode && !isPlaying && (onPlayChannel || onScanChannel) && (
+                <div className="flex items-center gap-2 mt-1">
+                  {onPlayChannel && (
+                    <button
+                      type="button"
+                      onClick={() => onPlayChannel(result)}
+                      className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium rounded-lg bg-white/10 hover:bg-white/20 text-white backdrop-blur-sm transition-colors"
+                    >
+                      <Play className="w-4 h-4" />
+                      Play
+                    </button>
+                  )}
+                  {onScanChannel && (
+                    <button
+                      type="button"
+                      disabled={scanActive}
+                      onClick={() => onScanChannel([result.index])}
+                      className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium rounded-lg bg-white/10 hover:bg-white/20 text-white backdrop-blur-sm transition-colors disabled:opacity-40 disabled:pointer-events-none"
+                    >
+                      <RotateCw className="w-4 h-4" />
+                      {result.status === "pending" || result.status === "checking"
+                        ? "Scan"
+                        : "Rescan"}
+                    </button>
+                  )}
+                </div>
+              )}
+              <div
+                className={`flex items-center justify-center gap-2 mt-2 min-h-[24px] ${theaterMode ? "hidden" : ""}`}
+              >
+                {result.status === "alive" && (
+                  <>
+                    {result.resolution && result.resolution !== "Unknown" && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                        {result.width}x{result.height}
+                      </span>
+                    )}
+                    {result.fps && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                        {result.fps} fps
+                      </span>
+                    )}
+                    {result.video_bitrate &&
+                      result.video_bitrate !== "Unknown" &&
+                      result.video_bitrate !== "N/A" && (
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                          {result.video_bitrate}
+                        </span>
+                      )}
+                    {result.hdr_format && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                        {result.hdr_format}
+                      </span>
+                    )}
+                    {result.audio_bitrate && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                        {result.audio_bitrate} kbps audio
+                      </span>
+                    )}
+                    {result.audio_channel_layout && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] text-white/80 bg-white/10 backdrop-blur-sm">
+                        {result.audio_channel_layout} audio
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,14 +1,3 @@
-import {
-  memo,
-  startTransition,
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   BarChart3,
@@ -20,37 +9,44 @@ import {
   KeyRound,
   Library,
   Link2,
+  Loader2,
   Pause,
   Play,
   Radar,
-  Square,
-  Settings,
   Search,
-  Loader2,
+  Settings,
+  Square,
 } from "lucide-react";
-import {
-  SFPlayFill,
-  SFPauseFill,
-  SFStopFill,
-  SFChevronDown,
-  SFDocumentViewfinder,
-  SFFolder,
-  SFLink,
-  SFGearshape,
-  SFClockArrow,
-} from "./SFSymbols";
 import type { PointerEvent, RefObject } from "react";
-import type { ChannelResult } from "../lib/types";
-import type { ExportScope } from "../lib/exportScope";
 import {
-  countStatusOptions,
-  filterResultsShared,
-  sharedSearchTextCache,
-} from "../lib/filters";
+  memo,
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ExportScope } from "../lib/exportScope";
+import { countStatusOptions, filterResultsShared, sharedSearchTextCache } from "../lib/filters";
 import { measureUiPerf } from "../lib/perf";
 import { validateSourceFilterPattern } from "../lib/sourceFilter";
-import { ExportMenu } from "./ExportMenu";
+import type { ChannelResult } from "../lib/types";
 import { useAppStore } from "../store";
+import { ExportMenu } from "./ExportMenu";
+import {
+  SFChevronDown,
+  SFClockArrow,
+  SFDocumentViewfinder,
+  SFFolder,
+  SFGearshape,
+  SFLink,
+  SFPauseFill,
+  SFPlayFill,
+  SFStopFill,
+} from "./SFSymbols";
 
 interface ToolbarProps {
   onOpen: () => void;
@@ -108,15 +104,12 @@ function measureGroupSelectWidth(
   }, 0);
 
   const horizontalPadding =
-    Number.parseFloat(computedStyle.paddingLeft) +
-    Number.parseFloat(computedStyle.paddingRight);
+    Number.parseFloat(computedStyle.paddingLeft) + Number.parseFloat(computedStyle.paddingRight);
   const horizontalBorder =
     Number.parseFloat(computedStyle.borderLeftWidth) +
     Number.parseFloat(computedStyle.borderRightWidth);
 
-  return Math.ceil(
-    widestLabel + horizontalPadding + horizontalBorder + GROUP_SELECT_CHROME_WIDTH,
-  );
+  return Math.ceil(widestLabel + horizontalPadding + horizontalBorder + GROUP_SELECT_CHROME_WIDTH);
 }
 
 export const Toolbar = memo(function Toolbar({
@@ -145,21 +138,15 @@ export const Toolbar = memo(function Toolbar({
   const completedResults = useAppStore((s) => s.flatResults);
   const duplicateIndices = useAppStore((s) => s.duplicateIndices);
   const menuExportRequest = useAppStore((s) => s.menuExportRequest);
-  const showReport = useAppStore(
-    (s) => s.playlist !== null && s.showReportPanel,
-  );
+  const showReport = useAppStore((s) => s.playlist !== null && s.showReportPanel);
   const hasPlaylist = useAppStore((s) => s.playlist !== null);
   const currentSourceDescriptor = useAppStore((s) => s.currentSourceDescriptor);
   const playlistName = useAppStore((s) => s.playlist?.file_name ?? "");
   const playlistPath = useAppStore((s) => s.playlist?.file_path ?? "");
   const groups = useAppStore((s) => s.playlist?.groups ?? EMPTY_GROUPS);
   const selectedIndices = useAppStore((s) => s.selectedChannelIndices);
-  const separatePlaceholder = useAppStore(
-    (s) => s.settings.separate_placeholder_status,
-  );
-  const showHeaderButtonText = useAppStore(
-    (s) => s.settings.show_header_button_text,
-  );
+  const separatePlaceholder = useAppStore((s) => s.settings.separate_placeholder_status);
+  const showHeaderButtonText = useAppStore((s) => s.settings.show_header_button_text);
   const openMenuRef = useRef<HTMLDivElement | null>(null);
   const groupSelectRef = useRef<HTMLSelectElement | null>(null);
   const [openMenuVisible, setOpenMenuVisible] = useState(false);
@@ -205,13 +192,7 @@ export const Toolbar = memo(function Toolbar({
         sharedSearchTextCache,
         separatePlaceholder,
       ),
-    [
-      completedResults,
-      deferredSearch,
-      groupFilter,
-      duplicateIndices,
-      separatePlaceholder,
-    ],
+    [completedResults, deferredSearch, groupFilter, duplicateIndices, separatePlaceholder],
   );
 
   const exportContextRef = useRef({
@@ -230,10 +211,7 @@ export const Toolbar = memo(function Toolbar({
 
   useEffect(() => {
     const handlePointerDownOutside = (event: MouseEvent) => {
-      if (
-        openMenuRef.current &&
-        !openMenuRef.current.contains(event.target as Node)
-      ) {
+      if (openMenuRef.current && !openMenuRef.current.contains(event.target as Node)) {
         setOpenMenuVisible(false);
       }
     };
@@ -252,23 +230,20 @@ export const Toolbar = memo(function Toolbar({
     };
   }, []);
 
-  const resolveExportScopeResults = useCallback(
-    (scope: ExportScope): ChannelResult[] => {
-      const context = exportContextRef.current;
-      if (scope === "all") {
-        return context.all;
-      }
-      if (scope === "filtered") {
-        return context.filtered;
-      }
-      if (context.selectedIndices.length === 0) {
-        return [];
-      }
-      const selectedSet = new Set(context.selectedIndices);
-      return context.all.filter((result) => selectedSet.has(result.index));
-    },
-    [],
-  );
+  const resolveExportScopeResults = useCallback((scope: ExportScope): ChannelResult[] => {
+    const context = exportContextRef.current;
+    if (scope === "all") {
+      return context.all;
+    }
+    if (scope === "filtered") {
+      return context.filtered;
+    }
+    if (context.selectedIndices.length === 0) {
+      return [];
+    }
+    const selectedSet = new Set(context.selectedIndices);
+    return context.all.filter((result) => selectedSet.has(result.index));
+  }, []);
 
   const exportScopeCounts = useMemo(
     () => ({
@@ -294,16 +269,10 @@ export const Toolbar = memo(function Toolbar({
   const inScanSession = scanning || paused || cancelling;
   const hasResults = exportScopeCounts.all > 0;
   const scanLabel =
-    selectedIndices.length > 0
-      ? `Scan Selected (${selectedIndices.length})`
-      : "Scan";
-  const scanDisabledReason = !hasPlaylist
-    ? "Open a playlist first"
-    : scanBlockedReason;
+    selectedIndices.length > 0 ? `Scan Selected (${selectedIndices.length})` : "Scan";
+  const scanDisabledReason = !hasPlaylist ? "Open a playlist first" : scanBlockedReason;
   const canSavePlaylist =
-    hasPlaylist &&
-    currentSourceDescriptor !== null &&
-    currentSourceDescriptor.kind !== "stalker";
+    hasPlaylist && currentSourceDescriptor !== null && currentSourceDescriptor.kind !== "stalker";
   const filtersDisabled = !hasPlaylist;
   const statusLabel = (value: string, label: string) =>
     hasPlaylist ? `${label} (${statusOptionCounts[value] ?? 0})` : label;
@@ -417,8 +386,7 @@ export const Toolbar = memo(function Toolbar({
     : isMac
       ? toolbarBtnMac
       : `${toolbarBtn} justify-center px-2.5`;
-  const btnWithOptionalText = (extraClasses = "") =>
-    `${btn} ${extraClasses}`.trim();
+  const btnWithOptionalText = (extraClasses = "") => `${btn} ${extraClasses}`.trim();
   const toolbarPadding = hasPlaylist
     ? "pt-[var(--toolbar-pt)] pb-2"
     : isMac
@@ -434,8 +402,7 @@ export const Toolbar = memo(function Toolbar({
   const rightControlsClass =
     "ml-auto flex flex-1 min-w-0 items-center justify-end gap-[clamp(0.45rem,0.9vw,1rem)]";
   const filtersClass = `flex min-w-0 flex-1 items-center justify-end gap-[clamp(0.5rem,0.95vw,1rem)] ${filtersDisabled ? "opacity-50" : ""}`;
-  const selectedGroupTitle =
-    groupFilter === "all" ? GROUP_FILTER_LABEL : groupFilter;
+  const selectedGroupTitle = groupFilter === "all" ? GROUP_FILTER_LABEL : groupFilter;
   const groupSelectStyle =
     groupSelectWidth === null
       ? {
@@ -454,7 +421,13 @@ export const Toolbar = memo(function Toolbar({
       className={`relative flex items-center px-3 ${toolbarSurface} ${toolbarPadding} ${toolbarHorizontalPadding} ${isMac ? "gap-3" : "gap-1.5"}`}
     >
       {/* Scan group: Scan / Pause+Stop — under traffic lights on macOS */}
-      <div className={isMac ? "toolbar-group toolbar-group-prominent -ml-[calc(var(--toolbar-pl)-0.75rem)] mr-2" : "flex items-center gap-1.5"}>
+      <div
+        className={
+          isMac
+            ? "toolbar-group toolbar-group-prominent -ml-[calc(var(--toolbar-pl)-0.75rem)] mr-2"
+            : "flex items-center gap-1.5"
+        }
+      >
         {inScanSession ? (
           <>
             {cancelling ? (
@@ -616,34 +589,21 @@ export const Toolbar = memo(function Toolbar({
 
       {/* macOS: playlist name centered in title bar area */}
       {playlistName && isMac && (
-        <span
-          data-tauri-drag-region
-          className={inlinePlaylistNameClass}
-          title={playlistName}
-        >
+        <span data-tauri-drag-region className={inlinePlaylistNameClass} title={playlistName}>
           {playlistName}
         </span>
       )}
 
       {/* Non-macOS: playlist name inline */}
       {playlistName && !isMac && (
-        <span
-          className={inlinePlaylistNameClass}
-          title={playlistName}
-        >
+        <span className={inlinePlaylistNameClass} title={playlistName}>
           {playlistName}
         </span>
       )}
 
-      <div
-        data-tauri-drag-region={dragRegionAttr}
-        className={rightControlsClass}
-      >
+      <div data-tauri-drag-region={dragRegionAttr} className={rightControlsClass}>
         {/* Filters: Group, Status, Search */}
-        <div
-          className={filtersClass}
-          data-no-window-drag
-        >
+        <div className={filtersClass} data-no-window-drag>
           <div className="flex min-w-0 items-center gap-[clamp(0.5rem,0.95vw,1rem)]">
             <div className="min-w-0 shrink" style={groupSelectStyle}>
               <select

--- a/src/hooks/useChromecast.ts
+++ b/src/hooks/useChromecast.ts
@@ -1,16 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import {
-  castToDevice,
-  discoverChromecasts,
-  getCastStatus,
-  stopCast,
-} from "../lib/tauri";
-import type {
-  CastMediaRequest,
-  CastSession,
-  ChromecastDevice,
-} from "../lib/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { castToDevice, discoverChromecasts, getCastStatus, stopCast } from "../lib/tauri";
+import type { CastMediaRequest, CastSession, ChromecastDevice } from "../lib/types";
 
 export interface UseChromecastResult {
   devices: ChromecastDevice[];
@@ -42,22 +33,19 @@ export function useChromecast(): UseChromecastResult {
     }
   }, []);
 
-  const cast = useCallback(
-    async (device: ChromecastDevice, request: CastMediaRequest) => {
-      setError(null);
-      try {
-        const next = await castToDevice(device, request);
-        if (!cancelledRef.current) setSession(next);
-      } catch (err) {
-        if (!cancelledRef.current) {
-          setError(String(err));
-          setSession(null);
-        }
-        throw err;
+  const cast = useCallback(async (device: ChromecastDevice, request: CastMediaRequest) => {
+    setError(null);
+    try {
+      const next = await castToDevice(device, request);
+      if (!cancelledRef.current) setSession(next);
+    } catch (err) {
+      if (!cancelledRef.current) {
+        setError(String(err));
+        setSession(null);
       }
-    },
-    [],
-  );
+      throw err;
+    }
+  }, []);
 
   const stop = useCallback(async () => {
     try {

--- a/src/hooks/useMenuEventBridge.ts
+++ b/src/hooks/useMenuEventBridge.ts
@@ -1,11 +1,7 @@
-import { useEffect, useRef } from "react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type {
-  AppSettings,
-  PlaylistLoadProgress,
-  RecentPlaylistEntry,
-} from "../lib/types";
+import { useEffect, useRef } from "react";
+import type { AppSettings, PlaylistLoadProgress, RecentPlaylistEntry } from "../lib/types";
 import { useAppStore } from "../store";
 
 // Non-reactive store access for writes inside callbacks/effects.
@@ -109,12 +105,9 @@ export function useMenuEventBridge(handlers: MenuEventHandlers): void {
         listen("menu://open-log", () => void handlersRef.current.handleOpenLog()),
         listen("menu://check-updates", () => void handlersRef.current.checkForUpdates(true)),
         listen("menu://keyboard-shortcuts", () => getStore().setShowKeyboardShortcuts(true)),
-        listen<PlaylistLoadProgress>(
-          "playlist://load-progress",
-          (event) => {
-            getStore().setPlaylistLoadProgress(event.payload);
-          },
-        ),
+        listen<PlaylistLoadProgress>("playlist://load-progress", (event) => {
+          getStore().setPlaylistLoadProgress(event.payload);
+        }),
       ]);
       if (cancelled) {
         for (const off of listeners) off();

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -1,5 +1,39 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  errorToString,
+  formatPlaylistOpenError,
+  formatSourceReloadError,
+  redactUrlCredentials,
+} from "../lib/errors";
+import { logger } from "../lib/logger";
+import { parseXtreamRecent, serializeXtreamRecent } from "../lib/recentPlaylists";
+import {
+  buildSavedPlaylistDraftFromSource,
+  findSavedPlaylistForCurrentSource,
+  savedEntryToSourceDescriptor,
+} from "../lib/savedPlaylists";
+import {
+  applyContentVisibilityToPreview,
+  applySourceFilterToPreview,
+  hasDirtySourceFilter,
+  normalizeSourceFilter,
+  resolvePreservedGroupFilter,
+  validateSourceFilterPattern,
+} from "../lib/sourceFilter";
+import {
+  addRecentPlaylist,
+  clearRecentPlaylists,
+  deleteSavedPlaylist,
+  getRecentPlaylists,
+  getSavedPlaylists,
+  openPlaylist,
+  openPlaylistStalker,
+  openPlaylistUrl,
+  openPlaylistXtream,
+  openSavedPlaylist,
+  upsertSavedPlaylist,
+} from "../lib/tauri";
 import type {
   Channel,
   CurrentSourceDescriptor,
@@ -10,44 +44,7 @@ import type {
   StalkerOpenRequest,
   XtreamOpenRequest,
 } from "../lib/types";
-import {
-  addRecentPlaylist,
-  clearRecentPlaylists,
-  deleteSavedPlaylist,
-  getRecentPlaylists,
-  getSavedPlaylists,
-  openPlaylist,
-  openSavedPlaylist,
-  openPlaylistStalker,
-  openPlaylistXtream,
-  openPlaylistUrl,
-  upsertSavedPlaylist,
-} from "../lib/tauri";
 import { useAppStore } from "../store";
-import { logger } from "../lib/logger";
-import {
-  errorToString,
-  formatPlaylistOpenError,
-  formatSourceReloadError,
-  redactUrlCredentials,
-} from "../lib/errors";
-import {
-  parseXtreamRecent,
-  serializeXtreamRecent,
-} from "../lib/recentPlaylists";
-import {
-  applyContentVisibilityToPreview,
-  applySourceFilterToPreview,
-  hasDirtySourceFilter,
-  normalizeSourceFilter,
-  resolvePreservedGroupFilter,
-  validateSourceFilterPattern,
-} from "../lib/sourceFilter";
-import {
-  buildSavedPlaylistDraftFromSource,
-  findSavedPlaylistForCurrentSource,
-  savedEntryToSourceDescriptor,
-} from "../lib/savedPlaylists";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -71,9 +68,7 @@ function applyDisplayNameToPreview(
   savedPlaylistId?: string | null,
 ): PlaylistPreview {
   const uniquePlaylistLabels = new Set(
-    preview.channels
-      .map((channel) => channel.playlist.trim())
-      .filter((value) => value.length > 0),
+    preview.channels.map((channel) => channel.playlist.trim()).filter((value) => value.length > 0),
   );
   const shouldRewriteChannelPlaylists = uniquePlaylistLabels.size <= 1;
 
@@ -132,10 +127,7 @@ function savedEntryToDraft(entry: SavedPlaylistEntry): SavedPlaylistDraft {
 
 export interface UsePlaylistSourcesParams {
   /** From useScan: rebuilds the scan cache when a source is (re)loaded. */
-  initFromPlaylist: (
-    channels: Channel[],
-    shouldApply?: () => boolean,
-  ) => Promise<boolean>;
+  initFromPlaylist: (channels: Channel[], shouldApply?: () => boolean) => Promise<boolean>;
   /** From useScan: re-syncs the scan cache, optionally preserving results. */
   syncFromPlaylist: (
     channels: Channel[],
@@ -157,8 +149,7 @@ export function usePlaylistSources({
   const [savedPlaylistsDialogOpen, setSavedPlaylistsDialogOpen] = useState(false);
   const [savedPlaylistEditorDraft, setSavedPlaylistEditorDraft] =
     useState<SavedPlaylistDraft | null>(null);
-  const [savedXtreamTestEntry, setSavedXtreamTestEntry] =
-    useState<SavedPlaylistEntry | null>(null);
+  const [savedXtreamTestEntry, setSavedXtreamTestEntry] = useState<SavedPlaylistEntry | null>(null);
   const sourceLoadGenerationRef = useRef(0);
 
   const refreshRecentPlaylists = useCallback(async () => {
@@ -207,19 +198,12 @@ export function usePlaylistSources({
       shouldApply: () => boolean,
     ): Promise<boolean> => {
       const initStartedAt = performance.now();
-      logger.info(
-        `[App] Preparing scan cache for ${preview.channels.length} visible channels`,
-      );
-      const initialized = await initFromPlaylist(
-        preview.channels,
-        shouldApply,
-      );
+      logger.info(`[App] Preparing scan cache for ${preview.channels.length} visible channels`);
+      const initialized = await initFromPlaylist(preview.channels, shouldApply);
       if (!initialized || !shouldApply()) {
         return false;
       }
-      logger.info(
-        `[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`,
-      );
+      logger.info(`[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`);
 
       const state = getStore();
       state.setPlaylist(preview);
@@ -234,9 +218,7 @@ export function usePlaylistSources({
         state.setStatusFilter("all");
         state.setShowHistory(false);
       } else {
-        state.setGroupFilter(
-          resolvePreservedGroupFilter(state.groupFilter, preview.groups),
-        );
+        state.setGroupFilter(resolvePreservedGroupFilter(state.groupFilter, preview.groups));
       }
 
       state.setSelectedChannel(null);
@@ -294,8 +276,7 @@ export function usePlaylistSources({
     ): Promise<LoadAndCommitSourceResult> => {
       const loadGeneration = sourceLoadGenerationRef.current + 1;
       sourceLoadGenerationRef.current = loadGeneration;
-      const isCurrentLoad = () =>
-        sourceLoadGenerationRef.current === loadGeneration;
+      const isCurrentLoad = () => sourceLoadGenerationRef.current === loadGeneration;
       const supersededResult = (): LoadAndCommitSourceResult => ({
         ok: false,
         error: "",
@@ -303,9 +284,7 @@ export function usePlaylistSources({
       });
 
       const normalizedSourceFilter = normalizeSourceFilter(channelSearch);
-      const currentSourceFilterError = validateSourceFilterPattern(
-        normalizedSourceFilter,
-      );
+      const currentSourceFilterError = validateSourceFilterPattern(normalizedSourceFilter);
       if (currentSourceFilterError) {
         const error =
           mode === "reapplySourceFilter"
@@ -332,9 +311,7 @@ export function usePlaylistSources({
         }
       })();
       const loadingAction =
-        mode === "reapplySourceFilter"
-          ? "Reloading source with source filter"
-          : "Opening source";
+        mode === "reapplySourceFilter" ? "Reloading source with source filter" : "Opening source";
 
       getStore().setPlaylistOpenError(null);
       getStore().setPlaylistLoadProgress(null);
@@ -356,17 +333,13 @@ export function usePlaylistSources({
         const latestState = getStore();
         const savedEntry =
           descriptor.kind === "saved"
-            ? latestState.savedPlaylists.find(
-                (entry) => entry.id === descriptor.id,
-              )
+            ? latestState.savedPlaylists.find((entry) => entry.id === descriptor.id)
             : undefined;
         const xtreamUsername = (() => {
           if (descriptor.kind === "xtream") {
             return descriptor.username;
           }
-          return savedEntry?.kind === "xtream"
-            ? savedEntry.username
-            : undefined;
+          return savedEntry?.kind === "xtream" ? savedEntry.username : undefined;
         })();
         const safeFileName = xtreamUsername
           ? cachedPreview.file_name.replaceAll(xtreamUsername, "***")
@@ -465,9 +438,7 @@ export function usePlaylistSources({
       state.cachedSourcePreview,
       state.lastAppliedSourceFilter,
     );
-    const visibleIndices = new Set(
-      nextPreview.channels.map((channel) => channel.index),
-    );
+    const visibleIndices = new Set(nextPreview.channels.map((channel) => channel.index));
     const selectedIndex = state.selectedChannel?.index ?? null;
     const pendingPlaybackIndex = state.pendingPlaybackChannel?.index ?? null;
     const nextSelectedIndices = state.selectedChannelIndices.filter((index) =>
@@ -475,9 +446,7 @@ export function usePlaylistSources({
     );
 
     state.setPlaylist(nextPreview);
-    state.setGroupFilter(
-      resolvePreservedGroupFilter(state.groupFilter, nextPreview.groups),
-    );
+    state.setGroupFilter(resolvePreservedGroupFilter(state.groupFilter, nextPreview.groups));
     state.setSelectedChannelIndices(nextSelectedIndices);
 
     if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
@@ -497,28 +466,17 @@ export function usePlaylistSources({
         getStore().setSelectedChannel(refreshed);
       }
     });
-  }, [
-    buildVisiblePreview,
-    hideVodContent,
-    settingsHydrated,
-    syncFromPlaylist,
-  ]);
+  }, [buildVisiblePreview, hideVodContent, settingsHydrated, syncFromPlaylist]);
 
   const patchCurrentPlaylistMetadata = useCallback(
     (displayName: string, savedPlaylistId?: string | null) => {
       const state = getStore();
       if (state.playlist) {
-        state.setPlaylist(
-          applyDisplayNameToPreview(state.playlist, displayName, savedPlaylistId),
-        );
+        state.setPlaylist(applyDisplayNameToPreview(state.playlist, displayName, savedPlaylistId));
       }
       if (state.cachedSourcePreview) {
         state.setCachedSourcePreview(
-          applyDisplayNameToPreview(
-            state.cachedSourcePreview,
-            displayName,
-            savedPlaylistId,
-          ),
+          applyDisplayNameToPreview(state.cachedSourcePreview, displayName, savedPlaylistId),
         );
       }
     },
@@ -560,8 +518,7 @@ export function usePlaylistSources({
               : {
                   kind: "xtream" as const,
                   value: serializeXtreamRecent({
-                    server:
-                      savedEntry.preferred_server ?? savedEntry.servers[0] ?? "",
+                    server: savedEntry.preferred_server ?? savedEntry.servers[0] ?? "",
                     username: savedEntry.username,
                     password: savedEntry.password ?? undefined,
                   }),
@@ -583,32 +540,33 @@ export function usePlaylistSources({
     [loadAndCommitSource, refreshRecentPlaylists, refreshSavedPlaylists],
   );
 
-  const openPlaylistPath = useCallback(async (selectedPath: string) => {
-    const result = await loadAndCommitSource(
-      {
-        kind: "path",
-        path: selectedPath,
-      },
-      "freshOpen",
-    );
-    if (!result.ok) {
-      return;
-    }
+  const openPlaylistPath = useCallback(
+    async (selectedPath: string) => {
+      const result = await loadAndCommitSource(
+        {
+          kind: "path",
+          path: selectedPath,
+        },
+        "freshOpen",
+      );
+      if (!result.ok) {
+        return;
+      }
 
-    try {
-      const entries = await addRecentPlaylist("file", selectedPath, null, null);
-      getStore().setRecentPlaylists(entries);
-    } catch {
-      // Ignore recent-list update failures.
-    }
-  }, [loadAndCommitSource]);
+      try {
+        const entries = await addRecentPlaylist("file", selectedPath, null, null);
+        getStore().setRecentPlaylists(entries);
+      } catch {
+        // Ignore recent-list update failures.
+      }
+    },
+    [loadAndCommitSource],
+  );
 
   const handleOpen = useCallback(async () => {
     const path = await open({
       multiple: false,
-      filters: [
-        { name: "M3U Playlists", extensions: ["m3u", "m3u8"] },
-      ],
+      filters: [{ name: "M3U Playlists", extensions: ["m3u", "m3u8"] }],
       directory: false,
     });
     if (!path) return;
@@ -632,27 +590,30 @@ export function usePlaylistSources({
     await openPlaylistPath(selectedPath);
   }, [openPlaylistPath]);
 
-  const openPlaylistUrlValue = useCallback(async (url: string): Promise<string | true> => {
-    const result = await loadAndCommitSource(
-      {
-        kind: "url",
-        url,
-      },
-      "freshOpen",
-    );
-    if (!result.ok) {
-      return result.superseded ? true : result.error;
-    }
+  const openPlaylistUrlValue = useCallback(
+    async (url: string): Promise<string | true> => {
+      const result = await loadAndCommitSource(
+        {
+          kind: "url",
+          url,
+        },
+        "freshOpen",
+      );
+      if (!result.ok) {
+        return result.superseded ? true : result.error;
+      }
 
-    try {
-      const entries = await addRecentPlaylist("url", url, null, null);
-      getStore().setRecentPlaylists(entries);
-    } catch {
-      // Ignore recent-list update failures.
-    }
+      try {
+        const entries = await addRecentPlaylist("url", url, null, null);
+        getStore().setRecentPlaylists(entries);
+      } catch {
+        // Ignore recent-list update failures.
+      }
 
-    return true;
-  }, [loadAndCommitSource]);
+      return true;
+    },
+    [loadAndCommitSource],
+  );
 
   const openPlaylistXtreamValue = useCallback(
     async (source: XtreamOpenRequest, savePassword?: boolean): Promise<string | true> => {
@@ -719,9 +680,12 @@ export function usePlaylistSources({
     [loadAndCommitSource],
   );
 
-  const handleOpenSaved = useCallback((id: string) => {
-    void openSavedPlaylistById(id);
-  }, [openSavedPlaylistById]);
+  const handleOpenSaved = useCallback(
+    (id: string) => {
+      void openSavedPlaylistById(id);
+    },
+    [openSavedPlaylistById],
+  );
 
   const handleManageSavedPlaylists = useCallback(() => {
     setSavedPlaylistsDialogOpen(true);
@@ -790,11 +754,8 @@ export function usePlaylistSources({
 
       try {
         const currentState = getStore();
-        const deletedEntry =
-          currentState.savedPlaylists.find((entry) => entry.id === id) ?? null;
-        const fallbackDescriptor = deletedEntry
-          ? savedEntryToSourceDescriptor(deletedEntry)
-          : null;
+        const deletedEntry = currentState.savedPlaylists.find((entry) => entry.id === id) ?? null;
+        const fallbackDescriptor = deletedEntry ? savedEntryToSourceDescriptor(deletedEntry) : null;
         const entries = await deleteSavedPlaylist(id);
         getStore().setSavedPlaylists(entries);
         void refreshRecentPlaylists();
@@ -856,10 +817,7 @@ export function usePlaylistSources({
       return { ok: true, reapplied: false };
     }
 
-    const result = await loadAndCommitSource(
-      state.currentSourceDescriptor,
-      "reapplySourceFilter",
-    );
+    const result = await loadAndCommitSource(state.currentSourceDescriptor, "reapplySourceFilter");
     return { ok: result.ok, reapplied: result.ok };
   }, [loadAndCommitSource]);
 

--- a/src/hooks/useScan.helpers.ts
+++ b/src/hooks/useScan.helpers.ts
@@ -52,8 +52,7 @@ export function applyResultUpdates(
       metricsChanged = true;
     }
 
-    const previousMislabeled =
-      (previousResult?.label_mismatches.length ?? 0) > 0;
+    const previousMislabeled = (previousResult?.label_mismatches.length ?? 0) > 0;
     const nextMislabeled = result.label_mismatches.length > 0;
     if (previousMislabeled !== nextMislabeled) {
       mislabeledCount += nextMislabeled ? 1 : -1;

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -1,5 +1,14 @@
-import { useCallback, useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  getChannelIdFromUrl,
+  resetChannelResultForRescan,
+  toPendingChannelResult,
+} from "../lib/channelResults";
+import { findDuplicateChannelIndicesChunked } from "../lib/duplicates";
+import { logger } from "../lib/logger";
+import { pendingScanErrorMessageForRun, runScopedScanErrorMessage } from "../lib/scanErrorEvents";
+import { cancelScan, pauseScan, resetScan, resumeScan, startScan } from "../lib/tauri";
 import type {
   Channel,
   ChannelResult,
@@ -10,26 +19,14 @@ import type {
   ScanResultBatchPayload,
   ScanSummary,
 } from "../lib/types";
-import { cancelScan, pauseScan, resetScan, resumeScan, startScan } from "../lib/tauri";
-import { logger } from "../lib/logger";
-import {
-  getChannelIdFromUrl,
-  resetChannelResultForRescan,
-  toPendingChannelResult,
-} from "../lib/channelResults";
-import { findDuplicateChannelIndicesChunked } from "../lib/duplicates";
-import {
-  pendingScanErrorMessageForRun,
-  runScopedScanErrorMessage,
-} from "../lib/scanErrorEvents";
+import { useAppStore } from "../store";
+import { EMPTY_TELEMETRY } from "../store/slices/scanSlice";
+import type { ScanResultLookup } from "../store/types";
 import {
   applyResultUpdates,
   isRunScopedEventForActiveRun,
   type ScanUiMetrics,
 } from "./useScan.helpers";
-import { useAppStore } from "../store";
-import { EMPTY_TELEMETRY } from "../store/slices/scanSlice";
-import type { ScanResultLookup } from "../store/types";
 
 export type { ScanState } from "../lib/scanState";
 
@@ -53,9 +50,7 @@ interface RunClockState {
   accumulatedPausedMs: number;
 }
 
-function buildFlatResultsAndMetrics(
-  source: ChannelResult[],
-): {
+function buildFlatResultsAndMetrics(source: ChannelResult[]): {
   resultsByIndex: ScanResultLookup;
   flatResults: ChannelResult[];
   indexToFlatPos: Map<number, number>;
@@ -91,10 +86,7 @@ function buildFlatResultsAndMetrics(
   };
 }
 
-function mergeChannelIntoResult(
-  channel: Channel,
-  existing: ChannelResult,
-): ChannelResult {
+function mergeChannelIntoResult(channel: Channel, existing: ChannelResult): ChannelResult {
   return {
     ...existing,
     ...channel,
@@ -204,13 +196,8 @@ export function useScan() {
     if (count <= 0) return;
     const clock = runClock.current;
     if (!clock) return;
-    const pauseMs =
-      clock.pausedAtMs != null ? performance.now() - clock.pausedAtMs : 0;
-    const activeMs =
-      performance.now() -
-      clock.startedAtMs -
-      clock.accumulatedPausedMs -
-      pauseMs;
+    const pauseMs = clock.pausedAtMs != null ? performance.now() - clock.pausedAtMs : 0;
+    const activeMs = performance.now() - clock.startedAtMs - clock.accumulatedPausedMs - pauseMs;
     for (let i = 0; i < count; i += 1) {
       completionActiveMs.current.push(activeMs);
     }
@@ -295,32 +282,23 @@ export function useScan() {
       logger.debug("[useScan] Setting up event listeners");
 
       const registered = await Promise.all([
-        listen<ScanEvent<ScanResultBatchPayload>>(
-          "scan://channel-results-batch",
-          (event) => {
-            if (
-              cancelling.current ||
-              !isRunScopedEventForActiveRun(
-                activeRunId.current,
-                event.payload.run_id,
-              )
-            ) {
-              return;
-            }
+        listen<ScanEvent<ScanResultBatchPayload>>("scan://channel-results-batch", (event) => {
+          if (
+            cancelling.current ||
+            !isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)
+          ) {
+            return;
+          }
 
-            const payload = event.payload.payload;
-            queueResults(payload.items);
-            recordCompletions(payload.items.length);
-            handleProgressUpdate(payload.progress);
-          },
-        ),
+          const payload = event.payload.payload;
+          queueResults(payload.items);
+          recordCompletions(payload.items.length);
+          handleProgressUpdate(payload.progress);
+        }),
         listen<ScanEvent<ChannelResult>>("scan://channel-result", (event) => {
           if (
             cancelling.current ||
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
+            !isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)
           ) {
             return;
           }
@@ -330,22 +308,14 @@ export function useScan() {
         listen<ScanEvent<ScanProgress>>("scan://progress", (event) => {
           if (
             cancelling.current ||
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
+            !isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)
           ) {
             return;
           }
           handleProgressUpdate(event.payload.payload);
         }),
         listen<ScanEvent<ScanSummary>>("scan://complete", (event) => {
-          if (
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
-          ) {
+          if (!isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)) {
             return;
           }
           logger.debug("[useScan] scan://complete received", event.payload);
@@ -359,12 +329,7 @@ export function useScan() {
           runClock.current = null;
         }),
         listen<ScanEvent<ScanSummary>>("scan://cancelled", (event) => {
-          if (
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
-          ) {
+          if (!isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)) {
             return;
           }
           logger.debug("[useScan] scan://cancelled received", event.payload);
@@ -379,12 +344,7 @@ export function useScan() {
           runClock.current = null;
         }),
         listen<ScanEvent<null>>("scan://paused", (event) => {
-          if (
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
-          ) {
+          if (!isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)) {
             return;
           }
           const activeRun = runClock.current;
@@ -394,12 +354,7 @@ export function useScan() {
           getStore().applyScanRuntime({ scanState: "paused" });
         }),
         listen<ScanEvent<null>>("scan://resumed", (event) => {
-          if (
-            !isRunScopedEventForActiveRun(
-              activeRunId.current,
-              event.payload.run_id,
-            )
-          ) {
+          if (!isRunScopedEventForActiveRun(activeRunId.current, event.payload.run_id)) {
             return;
           }
           const now = performance.now();
@@ -417,10 +372,7 @@ export function useScan() {
         listen<ScanEvent<ScanErrorPayload>>("scan://error", (event) => {
           logger.debug("[useScan] scan://error received", event.payload);
 
-          const message = runScopedScanErrorMessage(
-            activeRunId.current,
-            event.payload,
-          );
+          const message = runScopedScanErrorMessage(activeRunId.current, event.payload);
           if (message) {
             pendingScanError.current = null;
             applyScanError(message);
@@ -473,25 +425,13 @@ export function useScan() {
         cancelAnimationFrame(rafId.current);
       }
     };
-  }, [
-    queueResult,
-    queueResults,
-    applyScanError,
-    recordCompletions,
-    handleProgressUpdate,
-  ]);
+  }, [queueResult, queueResults, applyScanError, recordCompletions, handleProgressUpdate]);
 
   const start = useCallback(
-    async (
-      config: ScanConfig,
-      totalChannels: number,
-      selectedIndices: number[] = [],
-    ) => {
+    async (config: ScanConfig, totalChannels: number, selectedIndices: number[] = []) => {
       logger.debug(`[useScan] start: totalChannels=${totalChannels}`, config);
-      const selectedSet =
-        selectedIndices.length > 0 ? new Set(selectedIndices) : null;
-      const initialTotal =
-        selectedIndices.length > 0 ? selectedIndices.length : totalChannels;
+      const selectedSet = selectedIndices.length > 0 ? new Set(selectedIndices) : null;
+      const initialTotal = selectedIndices.length > 0 ? selectedIndices.length : totalChannels;
 
       // Reset existing results back to pending status for channels being scanned.
       const updated = flatResultsRef.current.map((existing) =>
@@ -542,10 +482,7 @@ export function useScan() {
           accumulatedPausedMs: 0,
         };
         logger.debug(`[useScan] startScan IPC returned run_id=${runId}`);
-        const pendingMessage = pendingScanErrorMessageForRun(
-          pendingScanError.current,
-          runId,
-        );
+        const pendingMessage = pendingScanErrorMessageForRun(pendingScanError.current, runId);
         if (pendingMessage) {
           pendingScanError.current = null;
           applyScanError(pendingMessage);
@@ -664,10 +601,7 @@ export function useScan() {
         batchSize: 2000,
         shouldCancel: () => duplicateComputeVersion.current !== duplicateVersion,
       }).then((duplicates) => {
-        if (
-          duplicates == null ||
-          duplicateComputeVersion.current !== duplicateVersion
-        ) {
+        if (duplicates == null || duplicateComputeVersion.current !== duplicateVersion) {
           return;
         }
 
@@ -692,19 +626,22 @@ export function useScan() {
     [syncFromPlaylist],
   );
 
-  const updateResult = useCallback((result: ChannelResult) => {
-    const next = applyResultUpdates(
-      {
-        resultsByIndex: resultsRef.current,
-        flatResults: flatResultsRef.current,
-        indexToFlatPos: indexToFlatPosRef.current,
-        metrics: uiMetricsRef.current,
-      },
-      [result],
-    );
+  const updateResult = useCallback(
+    (result: ChannelResult) => {
+      const next = applyResultUpdates(
+        {
+          resultsByIndex: resultsRef.current,
+          flatResults: flatResultsRef.current,
+          indexToFlatPos: indexToFlatPosRef.current,
+          metrics: uiMetricsRef.current,
+        },
+        [result],
+      );
 
-    commitCollections(next);
-  }, [commitCollections]);
+      commitCollections(next);
+    },
+    [commitCollections],
+  );
 
   return {
     start,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -1,29 +1,29 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ChannelResult } from "../lib/types";
 import { normalizeCodecName, resolveResolutionLabel } from "../lib/format";
 import { logger } from "../lib/logger";
-import { toProxyUrl } from "../lib/proxyUrl";
-import { getStreamingProxyPort } from "../lib/tauri";
 import {
   areStreamMetadataEqual,
   classifyStream,
   decidePlaybackRecovery,
   formatPlaybackRecoveryMessage,
   getMpegtsPlaybackRoutes,
+  type HlsErrorPayload,
   MAX_PLAYBACK_RECOVERY_ATTEMPTS,
+  type PlaybackRecoveryIssue,
+  type PlaybackStartMode,
+  type PlayerState,
   readMediaErrorMessage,
   recordPlaybackRecoveryAttempt,
+  type StreamMetadata,
   shouldResetPlaybackRecoveryAttempts,
   shouldTryXtreamHlsBeforeMpegts,
   supportsNativeHlsPlayback,
   tryConvertToXtreamHls,
-  type HlsErrorPayload,
-  type PlaybackRecoveryIssue,
-  type PlaybackStartMode,
-  type PlayerState,
-  type StreamMetadata,
 } from "../lib/playback";
+import { toProxyUrl } from "../lib/proxyUrl";
 import { createRuntimeMonitor, type MpegtsPlayer } from "../lib/runtimeMonitor";
+import { getStreamingProxyPort } from "../lib/tauri";
+import type { ChannelResult } from "../lib/types";
 import { canUseBlobWorkers } from "../lib/workerSupport";
 
 // Re-exported for components (e.g. StreamPlayer) that read the recovery cap
@@ -202,7 +202,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
     const hls = hlsInstanceRef.current;
     if (hls) {
-      const levelIdx = hls.currentLevel >= 0 ? hls.currentLevel : (hls.levels?.length ? 0 : -1);
+      const levelIdx = hls.currentLevel >= 0 ? hls.currentLevel : hls.levels?.length ? 0 : -1;
       const level = levelIdx >= 0 ? hls.levels?.[levelIdx] : undefined;
       if (level) {
         if (level.width && level.height) {
@@ -232,7 +232,8 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         meta.resolution = resolveResolutionLabel(info.width, info.height);
       }
       if (!meta.codec && info.videoCodec) meta.codec = normalizeCodecName(info.videoCodec);
-      if (!meta.audioCodec && info.audioCodec) meta.audioCodec = normalizeCodecName(info.audioCodec);
+      if (!meta.audioCodec && info.audioCodec)
+        meta.audioCodec = normalizeCodecName(info.audioCodec);
       if (!meta.fps && info.fps) meta.fps = Math.round(info.fps);
       if (!meta.videoBitrate && info.videoDataRate) {
         meta.videoBitrate = formatBitrateKbps(Math.round(info.videoDataRate));
@@ -250,9 +251,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     }
 
     if (meta.width || meta.codec || meta.audioCodec) {
-      setStreamMetadata((previous) =>
-        areStreamMetadataEqual(previous, meta) ? previous : meta,
-      );
+      setStreamMetadata((previous) => (areStreamMetadataEqual(previous, meta) ? previous : meta));
     }
   }, [videoElement]);
 
@@ -371,12 +370,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   );
 
   const attemptRecoveryOrFail = useCallback(
-    (
-      result: ChannelResult,
-      sessionId: number,
-      issue: PlaybackRecoveryIssue,
-      reason: string,
-    ) => {
+    (result: ChannelResult, sessionId: number, issue: PlaybackRecoveryIssue, reason: string) => {
       const now = Date.now();
       const decision = decidePlaybackRecovery({
         issue,
@@ -445,8 +439,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         playerStateRef,
         playbackSessionIdRef,
         hasStartedPlayingRef,
-        onRuntimeIssue: (issue, reason) =>
-          attemptRecoveryOrFail(result, sessionId, issue, reason),
+        onRuntimeIssue: (issue, reason) => attemptRecoveryOrFail(result, sessionId, issue, reason),
       });
     },
     [attemptRecoveryOrFail, cleanupRuntimeMonitor, videoElement],
@@ -656,15 +649,10 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
           const onError = () => {
             fail(readMediaErrorMessage(videoElement.error) ?? "MPEG-TS media error");
           };
-          const onPlayerError = (
-            errorType?: unknown,
-            errorDetail?: unknown,
-            info?: unknown,
-          ) => {
-            const segments = [errorType, errorDetail, info]
-              .filter((value): value is string =>
-                typeof value === "string" && value.length > 0
-              );
+          const onPlayerError = (errorType?: unknown, errorDetail?: unknown, info?: unknown) => {
+            const segments = [errorType, errorDetail, info].filter(
+              (value): value is string => typeof value === "string" && value.length > 0,
+            );
             fail(segments.join(": ") || "mpegts.js error");
           };
           const onAbort = () => {
@@ -706,11 +694,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       cleanup();
       currentChannelRef.current = result;
       hasStartedPlayingRef.current = false;
-      if (shouldResetPlaybackRecoveryAttempts(
-        startMode,
-        previousChannelIndex,
-        result.index,
-      )) {
+      if (shouldResetPlaybackRecoveryAttempts(startMode, previousChannelIndex, result.index)) {
         recoveryTimestampsRef.current = [];
       }
 
@@ -804,7 +788,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         if (!isCurrentPlayback()) {
           return;
         }
-        if (nativeOk && await handleSuccessfulStart()) {
+        if (nativeOk && (await handleSuccessfulStart())) {
           return;
         }
       }
@@ -824,7 +808,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         }
       }
 
-      if (preferXtreamHls && await tryXtreamHlsRoute()) {
+      if (preferXtreamHls && (await tryXtreamHlsRoute())) {
         return;
       }
       if (!isCurrentPlayback()) {
@@ -855,21 +839,17 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
             result.name,
           );
           lastErrorRef.current = null;
-          const mpegtsOk = await tryMpegtsPlayback(
-            route.url,
-            abortController.signal,
-            isLive,
-          );
+          const mpegtsOk = await tryMpegtsPlayback(route.url, abortController.signal, isLive);
           if (!isCurrentPlayback()) {
             return;
           }
-          if (mpegtsOk && await handleSuccessfulStart()) {
+          if (mpegtsOk && (await handleSuccessfulStart())) {
             return;
           }
         }
       }
 
-      if (!preferXtreamHls && await tryXtreamHlsRoute()) {
+      if (!preferXtreamHls && (await tryXtreamHlsRoute())) {
         return;
       }
       if (!isCurrentPlayback()) {
@@ -886,7 +866,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         if (!isCurrentPlayback()) {
           return;
         }
-        if (nativeOk && await handleSuccessfulStart()) {
+        if (nativeOk && (await handleSuccessfulStart())) {
           return;
         }
       }
@@ -918,17 +898,20 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     };
   }, [cleanup, clearRecoveryTimer]);
 
-  const play = useCallback((result: ChannelResult) => {
-    playbackSessionIdRef.current += 1;
-    isPausedRef.current = false;
-    const sessionId = playbackSessionIdRef.current;
-    clearRecoveryTimer();
-    currentChannelRef.current = result;
-    recoveryTimestampsRef.current = [];
-    hasStartedPlayingRef.current = false;
-    resetRecoveryUi();
-    void startPlaybackAttempt(result, sessionId, "manual", 0);
-  }, [clearRecoveryTimer, resetRecoveryUi, startPlaybackAttempt]);
+  const play = useCallback(
+    (result: ChannelResult) => {
+      playbackSessionIdRef.current += 1;
+      isPausedRef.current = false;
+      const sessionId = playbackSessionIdRef.current;
+      clearRecoveryTimer();
+      currentChannelRef.current = result;
+      recoveryTimestampsRef.current = [];
+      hasStartedPlayingRef.current = false;
+      resetRecoveryUi();
+      void startPlaybackAttempt(result, sessionId, "manual", 0);
+    },
+    [clearRecoveryTimer, resetRecoveryUi, startPlaybackAttempt],
+  );
 
   const stop = useCallback(() => {
     playbackSessionIdRef.current += 1;

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useRef } from "react";
 import { getVersion } from "@tauri-apps/api/app";
+import { useCallback, useEffect, useRef } from "react";
+import { errorToString } from "../lib/errors";
 import { useAppStore } from "../store";
 import type { UpdateNotice } from "../store/types";
-import { errorToString } from "../lib/errors";
 
 const UPDATE_CHECK_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const UPDATE_CHECK_TIMEOUT_MS = 15_000;
@@ -10,8 +10,7 @@ const UPDATE_LAST_CHECK_KEY = "updates:last-check-epoch-ms";
 const UPDATE_CACHE_KEY = "updates:last-available-release";
 const GITHUB_LATEST_RELEASE_API =
   "https://api.github.com/repos/kristofferR/IPTVChecker/releases/latest";
-const GITHUB_RELEASES_PAGE =
-  "https://github.com/kristofferR/IPTVChecker/releases";
+const GITHUB_RELEASES_PAGE = "https://github.com/kristofferR/IPTVChecker/releases";
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
@@ -64,14 +63,8 @@ function shouldSkipUpdateCheck(
   now: number,
   lastCheckedRaw: string | null,
 ): boolean {
-  const lastChecked = lastCheckedRaw
-    ? Number.parseInt(lastCheckedRaw, 10)
-    : Number.NaN;
-  return (
-    !force &&
-    Number.isFinite(lastChecked) &&
-    now - lastChecked < UPDATE_CHECK_COOLDOWN_MS
-  );
+  const lastChecked = lastCheckedRaw ? Number.parseInt(lastCheckedRaw, 10) : Number.NaN;
+  return !force && Number.isFinite(lastChecked) && now - lastChecked < UPDATE_CHECK_COOLDOWN_MS;
 }
 
 /** Clears the update banner and its cached release info (used by the banner's
@@ -89,90 +82,80 @@ export function useUpdateCheck(): {
   const requestIdRef = useRef(0);
   const activeControllerRef = useRef<AbortController | null>(null);
 
-  const checkForUpdates = useCallback(
-    async (force: boolean, knownCurrentVersion?: string) => {
-      const now = Date.now();
-      const lastCheckedRaw = localStorage.getItem(UPDATE_LAST_CHECK_KEY);
-      if (shouldSkipUpdateCheck(force, now, lastCheckedRaw)) {
+  const checkForUpdates = useCallback(async (force: boolean, knownCurrentVersion?: string) => {
+    const now = Date.now();
+    const lastCheckedRaw = localStorage.getItem(UPDATE_LAST_CHECK_KEY);
+    if (shouldSkipUpdateCheck(force, now, lastCheckedRaw)) {
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+    const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS);
+    const isCurrentRequest = () => requestIdRef.current === requestId;
+
+    try {
+      const currentVersion = normalizeVersion(knownCurrentVersion ?? (await getVersion()));
+      if (!isCurrentRequest() || controller.signal.aborted) return;
+      getStore().setAppVersion(currentVersion);
+
+      const response = await fetch(GITHUB_LATEST_RELEASE_API, {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+        signal: controller.signal,
+      });
+
+      if (!isCurrentRequest() || controller.signal.aborted) return;
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const release = (await response.json()) as {
+        tag_name?: string;
+        html_url?: string;
+      };
+
+      if (!isCurrentRequest() || controller.signal.aborted) return;
+      const latestVersion = normalizeVersion(release.tag_name ?? "");
+      if (!latestVersion) {
+        throw new Error("Latest release version is missing");
+      }
+
+      localStorage.setItem(UPDATE_LAST_CHECK_KEY, String(now));
+
+      if (compareVersions(latestVersion, currentVersion) > 0) {
+        const notice: UpdateNotice = {
+          latest_version: latestVersion,
+          release_url: release.html_url || GITHUB_RELEASES_PAGE,
+          checked_at_epoch_ms: now,
+        };
+        getStore().setUpdateNotice(notice);
+        localStorage.setItem(UPDATE_CACHE_KEY, JSON.stringify(notice));
         return;
       }
 
-      const requestId = requestIdRef.current + 1;
-      requestIdRef.current = requestId;
-      activeControllerRef.current?.abort();
-      const controller = new AbortController();
-      activeControllerRef.current = controller;
-      const timeout = setTimeout(
-        () => controller.abort(),
-        UPDATE_CHECK_TIMEOUT_MS,
-      );
-      const isCurrentRequest = () => requestIdRef.current === requestId;
-
-      try {
-        const currentVersion = normalizeVersion(
-          knownCurrentVersion ?? (await getVersion()),
-        );
-        if (!isCurrentRequest() || controller.signal.aborted) return;
-        getStore().setAppVersion(currentVersion);
-
-        const response = await fetch(GITHUB_LATEST_RELEASE_API, {
-          headers: {
-            Accept: "application/vnd.github+json",
-          },
-          signal: controller.signal,
-        });
-
-        if (!isCurrentRequest() || controller.signal.aborted) return;
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        const release = (await response.json()) as {
-          tag_name?: string;
-          html_url?: string;
-        };
-
-        if (!isCurrentRequest() || controller.signal.aborted) return;
-        const latestVersion = normalizeVersion(release.tag_name ?? "");
-        if (!latestVersion) {
-          throw new Error("Latest release version is missing");
-        }
-
-        localStorage.setItem(UPDATE_LAST_CHECK_KEY, String(now));
-
-        if (compareVersions(latestVersion, currentVersion) > 0) {
-          const notice: UpdateNotice = {
-            latest_version: latestVersion,
-            release_url: release.html_url || GITHUB_RELEASES_PAGE,
-            checked_at_epoch_ms: now,
-          };
-          getStore().setUpdateNotice(notice);
-          localStorage.setItem(UPDATE_CACHE_KEY, JSON.stringify(notice));
-          return;
-        }
-
-        getStore().setUpdateNotice(null);
-        localStorage.removeItem(UPDATE_CACHE_KEY);
-        if (force) {
-          getStore().setMenuInfo(`You're up to date (v${currentVersion}).`);
-        }
-      } catch (err) {
-        if (!isCurrentRequest()) return;
-        if (force) {
-          const detail = controller.signal.aborted
-            ? "Request timed out."
-            : errorToString(err);
-          getStore().setMenuInfo(`Update check failed: ${detail}`);
-        }
-      } finally {
-        clearTimeout(timeout);
-        if (activeControllerRef.current === controller) {
-          activeControllerRef.current = null;
-        }
+      getStore().setUpdateNotice(null);
+      localStorage.removeItem(UPDATE_CACHE_KEY);
+      if (force) {
+        getStore().setMenuInfo(`You're up to date (v${currentVersion}).`);
       }
-    },
-    [],
-  );
+    } catch (err) {
+      if (!isCurrentRequest()) return;
+      if (force) {
+        const detail = controller.signal.aborted ? "Request timed out." : errorToString(err);
+        getStore().setMenuInfo(`Update check failed: ${detail}`);
+      }
+    } finally {
+      clearTimeout(timeout);
+      if (activeControllerRef.current === controller) {
+        activeControllerRef.current = null;
+      }
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,9 @@
 
 /* Shared base (opaque dark — used by Windows/Linux) */
 :root {
-  --text-primary: rgb(244 244 245);     /* zinc-100 */
-  --text-secondary: rgb(161 161 170);   /* zinc-400 */
-  --text-tertiary: rgb(113 113 122);    /* zinc-500 */
+  --text-primary: rgb(244 244 245); /* zinc-100 */
+  --text-secondary: rgb(161 161 170); /* zinc-400 */
+  --text-tertiary: rgb(113 113 122); /* zinc-500 */
   --panel-bg: rgb(39 39 42);
   --panel-bg-subtle: rgb(39 39 42 / 0.5);
   --panel-bg-muted: rgb(39 39 42 / 0.3);
@@ -157,7 +157,9 @@
   --color-text-tertiary: var(--text-tertiary);
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   background: var(--surface-bg);
 }
@@ -170,8 +172,8 @@ body {
   margin: 0;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   color: var(--text-primary);
 }
 
@@ -276,7 +278,7 @@ body {
 
 /* Button separators — vertical line between adjacent buttons */
 [data-platform="macos"] .toolbar-group .toolbar-btn:not(:first-child)::before {
-  content: '';
+  content: "";
   position: absolute;
   left: -0.5px;
   top: 16%;
@@ -323,29 +325,20 @@ body {
 /* macOS controls */
 [data-platform="macos"] .macos-btn {
   border: 0.5px solid rgb(0 0 0 / 0.12);
-  background: linear-gradient(
-    180deg,
-    rgb(255 255 255 / 0.9) 0%,
-    rgb(255 255 255 / 0.7) 100%
-  );
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.9) 0%, rgb(255 255 255 / 0.7) 100%);
   box-shadow: 0 0.5px 1px rgb(0 0 0 / 0.08);
-  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 [data-platform="macos"] .macos-btn:hover {
-  background: linear-gradient(
-    180deg,
-    rgb(255 255 255 / 0.96) 0%,
-    rgb(255 255 255 / 0.78) 100%
-  );
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.96) 0%, rgb(255 255 255 / 0.78) 100%);
 }
 
 [data-platform="macos"] .macos-btn:active {
-  background: linear-gradient(
-    180deg,
-    rgb(255 255 255 / 0.7) 0%,
-    rgb(255 255 255 / 0.86) 100%
-  );
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.7) 0%, rgb(255 255 255 / 0.86) 100%);
 }
 
 [data-platform="macos"] .macos-btn-primary {
@@ -377,7 +370,9 @@ body {
 
 [data-platform="macos"] .native-field:focus {
   border-color: rgb(10 132 255 / 0.7);
-  box-shadow: 0 0 0 3px var(--focus-ring), inset 0 0.5px 1px rgb(0 0 0 / 0.04);
+  box-shadow:
+    0 0 0 3px var(--focus-ring),
+    inset 0 0.5px 1px rgb(0 0 0 / 0.04);
 }
 
 .toolbar-select {
@@ -407,7 +402,7 @@ body {
   }
 
   [data-platform="macos"] .toolbar-group-prominent {
-    background: linear-gradient(to bottom, rgb(10 132 255 / 0.10), rgb(10 132 255 / 0.07));
+    background: linear-gradient(to bottom, rgb(10 132 255 / 0.1), rgb(10 132 255 / 0.07));
     box-shadow:
       0 6px 20px rgb(0 0 0 / 0.15),
       inset 1px 2px 1px -1px rgb(255 255 255 / 0.06),
@@ -441,28 +436,16 @@ body {
 
   [data-platform="macos"] .macos-btn {
     border-color: rgb(255 255 255 / 0.13);
-    background: linear-gradient(
-      180deg,
-      rgb(69 69 74 / 0.82) 0%,
-      rgb(52 52 56 / 0.82) 100%
-    );
+    background: linear-gradient(180deg, rgb(69 69 74 / 0.82) 0%, rgb(52 52 56 / 0.82) 100%);
     box-shadow: 0 0.5px 1px rgb(0 0 0 / 0.32);
   }
 
   [data-platform="macos"] .macos-btn:hover {
-    background: linear-gradient(
-      180deg,
-      rgb(80 80 86 / 0.84) 0%,
-      rgb(58 58 64 / 0.84) 100%
-    );
+    background: linear-gradient(180deg, rgb(80 80 86 / 0.84) 0%, rgb(58 58 64 / 0.84) 100%);
   }
 
   [data-platform="macos"] .macos-btn:active {
-    background: linear-gradient(
-      180deg,
-      rgb(50 50 54 / 0.84) 0%,
-      rgb(72 72 78 / 0.84) 100%
-    );
+    background: linear-gradient(180deg, rgb(50 50 54 / 0.84) 0%, rgb(72 72 78 / 0.84) 100%);
   }
 
   [data-platform="macos"] .macos-btn-primary {
@@ -483,7 +466,9 @@ body {
 
   [data-platform="macos"] .native-field:focus {
     border-color: rgb(89 180 255 / 0.78);
-    box-shadow: 0 0 0 3px rgb(10 132 255 / 0.34), inset 0 0.5px 1px rgb(0 0 0 / 0.2);
+    box-shadow:
+      0 0 0 3px rgb(10 132 255 / 0.34),
+      inset 0 0.5px 1px rgb(0 0 0 / 0.2);
   }
 
   [data-platform="macos"] .channel-row:hover {
@@ -516,7 +501,9 @@ body {
   background: rgb(255 255 255 / 0.97);
   -webkit-backdrop-filter: blur(30px) saturate(180%);
   backdrop-filter: blur(30px) saturate(180%);
-  box-shadow: 0 4px 24px rgb(0 0 0 / 0.12), 0 0 0 0.5px rgb(0 0 0 / 0.06);
+  box-shadow:
+    0 4px 24px rgb(0 0 0 / 0.12),
+    0 0 0 0.5px rgb(0 0 0 / 0.06);
   border-color: transparent;
   border-radius: 8px;
 }
@@ -524,7 +511,9 @@ body {
 @media (prefers-color-scheme: dark) {
   [data-platform="macos"] .macos-popover {
     background: rgb(38 38 40 / 0.93);
-    box-shadow: 0 4px 24px rgb(0 0 0 / 0.4), 0 0 0 0.5px rgb(255 255 255 / 0.08);
+    box-shadow:
+      0 4px 24px rgb(0 0 0 / 0.4),
+      0 0 0 0.5px rgb(255 255 255 / 0.08);
   }
 }
 

--- a/src/lib/cast.ts
+++ b/src/lib/cast.ts
@@ -1,9 +1,4 @@
-import type {
-  CastMediaRequest,
-  CastSession,
-  CastStreamKind,
-  ChannelResult,
-} from "./types";
+import type { CastMediaRequest, CastSession, CastStreamKind, ChannelResult } from "./types";
 
 export function detectStreamKind(url: string): CastStreamKind {
   // Strip query/fragment from a path-like string before checking the extension,
@@ -33,8 +28,6 @@ export function buildCastRequest(channel: ChannelResult): CastMediaRequest {
   };
 }
 
-export function isCastSessionActive(
-  session: CastSession | null,
-): session is CastSession {
+export function isCastSessionActive(session: CastSession | null): session is CastSession {
   return !!session && session.state !== "stopped" && session.state !== "error";
 }

--- a/src/lib/channelResults.ts
+++ b/src/lib/channelResults.ts
@@ -41,9 +41,7 @@ export function getChannelIdFromUrl(url: string): string {
   return segment.replace(".ts", "");
 }
 
-export function getChannelErrorReason(
-  result: Pick<ChannelResult, "error_reason">,
-): string | null {
+export function getChannelErrorReason(result: Pick<ChannelResult, "error_reason">): string | null {
   return result.error_reason?.trim() || null;
 }
 
@@ -68,9 +66,7 @@ export function toPendingChannelResult(channel: Channel): ChannelResult {
   };
 }
 
-export function resetChannelResultForRescan(
-  result: ChannelResult,
-): ChannelResult {
+export function resetChannelResultForRescan(result: ChannelResult): ChannelResult {
   return {
     ...result,
     ...pendingScanFields(),

--- a/src/lib/duplicates.ts
+++ b/src/lib/duplicates.ts
@@ -17,8 +17,7 @@ function decodeUnreservedPercentEncoding(value: string): string {
 }
 
 function normalizePathname(pathname: string): string {
-  const withoutTrailingSlash =
-    pathname.length > 1 ? pathname.replace(/\/+$/u, "") : pathname;
+  const withoutTrailingSlash = pathname.length > 1 ? pathname.replace(/\/+$/u, "") : pathname;
   return decodeUnreservedPercentEncoding(withoutTrailingSlash);
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -19,19 +19,13 @@ export function errorToString(err: unknown): string {
 }
 
 function redactSensitiveQueryParameters(message: string): string {
-  return message.replace(
-    /([?&](?:username|password)=)[^&#)\]]*/gi,
-    "$1***",
-  );
+  return message.replace(/([?&](?:username|password)=)[^&#)\]]*/gi, "$1***");
 }
 
 /** Redact URL userinfo and Xtream-style credential query parameters in either
  *  a standalone URL or a larger error/log message. */
 export function redactUrlCredentials(value: string): string {
-  const redactedUserInfo = value.replace(
-    /\b(https?:\/\/)[^/\s?#()[\]]+@/gi,
-    "$1***@",
-  );
+  const redactedUserInfo = value.replace(/\b(https?:\/\/)[^/\s?#()[\]]+@/gi, "$1***@");
   return redactSensitiveQueryParameters(redactedUserInfo);
 }
 
@@ -48,16 +42,12 @@ function formatUserFacingError(
   const raw = redactUrlCredentials(errorToString(err))
     .replace(/^error:\s*/i, "")
     .trim();
-  const normalized = normalizedPrefix
-    ? raw.replace(normalizedPrefix, "").trim()
-    : raw;
+  const normalized = normalizedPrefix ? raw.replace(normalizedPrefix, "").trim() : raw;
 
   if (!normalized || normalized === "[object Object]") {
     return fallback;
   }
-  return existingPrefix.test(normalized)
-    ? normalized
-    : `${prefix}: ${normalized}`;
+  return existingPrefix.test(normalized) ? normalized : `${prefix}: ${normalized}`;
 }
 
 export function formatPlaylistOpenError(err: unknown): string {

--- a/src/lib/extinf.ts
+++ b/src/lib/extinf.ts
@@ -33,26 +33,21 @@ function findUnquotedComma(text: string): number {
   return -1;
 }
 
-export function getExtinfAttribute(
-  extinfLine: string,
-  attribute: string,
-): string | null {
+export function getExtinfAttribute(extinfLine: string, attribute: string): string | null {
   if (!extinfLine.startsWith("#EXTINF")) return null;
 
   const headerEnd = findUnquotedComma(extinfLine);
   const header = headerEnd >= 0 ? extinfLine.slice(0, headerEnd) : extinfLine;
   const escapedAttribute = attribute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(
-    `\\b${escapedAttribute}=(?:\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'|([^\\s]+))`,
+    `\\b${escapedAttribute}=(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'|([^\\s]+))`,
     "i",
   );
 
   const match = pattern.exec(header);
   if (!match) return null;
 
-  const value = (match[1] ?? match[2] ?? match[3] ?? "")
-    .replace(/\\(["'])/g, "$1")
-    .trim();
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").replace(/\\(["'])/g, "$1").trim();
   return value.length > 0 ? value : null;
 }
 

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -1,5 +1,5 @@
-import type { ChannelResult, ChannelStatus } from "./types";
 import { getChannelErrorReason } from "./channelResults";
+import type { ChannelResult, ChannelStatus } from "./types";
 
 export type SortField =
   | "index"
@@ -115,10 +115,7 @@ function compareOptionalText(
   return compared;
 }
 
-function getSearchHaystack(
-  result: ChannelResult,
-  searchTextCache?: SearchTextCache,
-): string {
+function getSearchHaystack(result: ChannelResult, searchTextCache?: SearchTextCache): string {
   let haystack = searchTextCache?.get(result);
   if (!haystack) {
     haystack = `${result.name}\n${result.playlist}\n${result.group}`.toLowerCase();
@@ -226,13 +223,7 @@ export function sortResults(
       case "codec":
         return (a.codec ?? "").localeCompare(b.codec ?? "") * dir;
       case "hdr":
-        return compareOptionalText(
-          a.hdr_format,
-          b.hdr_format,
-          dir,
-          a.index,
-          b.index,
-        );
+        return compareOptionalText(a.hdr_format, b.hdr_format, dir, a.index, b.index);
       case "fps":
         return ((a.fps ?? 0) - (b.fps ?? 0)) * dir;
       case "latency": {
@@ -321,7 +312,10 @@ export function filterResults(
     ) {
       return false;
     }
-    if (hasStatusFilter && !matchesStatusFilter(r, statusFilter, duplicateIndices, separatePlaceholder)) {
+    if (
+      hasStatusFilter &&
+      !matchesStatusFilter(r, statusFilter, duplicateIndices, separatePlaceholder)
+    ) {
       return false;
     }
     return true;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -94,9 +94,7 @@ export function statusIcon(status: ChannelStatus): string {
 export function formatVideoInfo(result: ChannelResult): string {
   const parts: string[] = [];
   if (result.resolution && result.resolution !== "Unknown") {
-    const res = result.fps
-      ? `${result.resolution}${result.fps}`
-      : result.resolution;
+    const res = result.fps ? `${result.resolution}${result.fps}` : result.resolution;
     parts.push(res);
   }
   if (result.codec && result.codec !== "Unknown") {

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,7 +1,7 @@
 import {
   HapticFeedbackPattern,
-  PerformanceTime,
   isSupported,
+  PerformanceTime,
   perform,
 } from "tauri-plugin-macos-haptics-api";
 

--- a/src/lib/languageDistribution.ts
+++ b/src/lib/languageDistribution.ts
@@ -27,9 +27,7 @@ export function summarizeLanguageDistribution(
   items: LanguageDistributionInput[],
   topN = 5,
 ): LanguageDistributionSummary {
-  const normalizedTopN = Number.isFinite(topN)
-    ? Math.max(1, Math.floor(topN))
-    : 5;
+  const normalizedTopN = Number.isFinite(topN) ? Math.max(1, Math.floor(topN)) : 5;
   const counts = new Map<string, number>();
   let unknownCount = 0;
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,9 +1,9 @@
 import {
   attachConsole,
   debug as tauriDebug,
+  error as tauriError,
   info as tauriInfo,
   warn as tauriWarn,
-  error as tauriError,
 } from "@tauri-apps/plugin-log";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
@@ -62,10 +62,7 @@ function formatArgs(args: unknown[]): string {
   return args.map(formatArg).join(" ");
 }
 
-function forwardToTauri(
-  method: (message: string) => Promise<void>,
-  message: string,
-): void {
+function forwardToTauri(method: (message: string) => Promise<void>, message: string): void {
   if (!hasTauriWindow()) {
     return;
   }

--- a/src/lib/logoCache.ts
+++ b/src/lib/logoCache.ts
@@ -110,8 +110,7 @@ function getLogoStatus(url: string | null): LogoCacheStatus {
 
 export function useLogoCacheStatus(url: string | null): LogoCacheStatus {
   const subscribe = useCallback(
-    (onStoreChange: () => void) =>
-      url ? subscribeToLogo(url, onStoreChange) : () => {},
+    (onStoreChange: () => void) => (url ? subscribeToLogo(url, onStoreChange) : () => {}),
     [url],
   );
   const getSnapshot = useCallback(() => getLogoStatus(url), [url]);

--- a/src/lib/perf.ts
+++ b/src/lib/perf.ts
@@ -84,10 +84,7 @@ export function summarizeUiPerf(metric: string): {
 
   const values = samples.map((sample) => sample.valueMs).sort((a, b) => a - b);
   const total = values.reduce((sum, value) => sum + value, 0);
-  const p95Index = Math.min(
-    values.length - 1,
-    Math.max(0, Math.floor(values.length * 0.95) - 1),
-  );
+  const p95Index = Math.min(values.length - 1, Math.max(0, Math.floor(values.length * 0.95) - 1));
 
   return {
     count: values.length,

--- a/src/lib/playback.ts
+++ b/src/lib/playback.ts
@@ -173,25 +173,20 @@ export function getMpegtsPlaybackRoutes(
   return preferRemux ? [remux, direct] : [direct, remux];
 }
 
-export function shouldTryXtreamHlsBeforeMpegts(
-  startMode: PlaybackStartMode,
-): boolean {
+export function shouldTryXtreamHlsBeforeMpegts(startMode: PlaybackStartMode): boolean {
   return startMode === "recovery";
 }
 
-export function shouldSuspendPlaybackWatchdog(
-  visibilityState: DocumentVisibilityState,
-): boolean {
+export function shouldSuspendPlaybackWatchdog(visibilityState: DocumentVisibilityState): boolean {
   return visibilityState === "hidden";
 }
 
 export function supportsNativeHlsPlayback(
   mediaElement: Pick<HTMLMediaElement, "canPlayType">,
 ): boolean {
-  return [
-    "application/vnd.apple.mpegurl",
-    "application/x-mpegurl",
-  ].some((mimeType) => mediaElement.canPlayType(mimeType) !== "");
+  return ["application/vnd.apple.mpegurl", "application/x-mpegurl"].some(
+    (mimeType) => mediaElement.canPlayType(mimeType) !== "",
+  );
 }
 
 export function readMediaErrorMessage(mediaErr: MediaError | null): string | null {
@@ -224,33 +219,21 @@ export interface BufferedTimeRange {
   end: number;
 }
 
-export function chooseLiveBufferPlaybackRate(
-  currentRate: number,
-  bufferedAhead: number,
-): number {
+export function chooseLiveBufferPlaybackRate(currentRate: number, bufferedAhead: number): number {
   if (!Number.isFinite(bufferedAhead)) return 1;
   if (currentRate < 1) {
-    return bufferedAhead < LIVE_BUFFER_RECOVERED_THRESHOLD_SECS
-      ? LIVE_BUFFER_RECOVERY_RATE
-      : 1;
+    return bufferedAhead < LIVE_BUFFER_RECOVERED_THRESHOLD_SECS ? LIVE_BUFFER_RECOVERY_RATE : 1;
   }
   if (currentRate > 1) {
-    return bufferedAhead > LIVE_BUFFER_RECOVERED_THRESHOLD_SECS
-      ? LIVE_BUFFER_CATCHUP_RATE
-      : 1;
+    return bufferedAhead > LIVE_BUFFER_RECOVERED_THRESHOLD_SECS ? LIVE_BUFFER_CATCHUP_RATE : 1;
   }
   if (bufferedAhead > LIVE_BUFFER_CATCHUP_THRESHOLD_SECS) {
     return LIVE_BUFFER_CATCHUP_RATE;
   }
-  return bufferedAhead < LIVE_BUFFER_SLOWDOWN_THRESHOLD_SECS
-    ? LIVE_BUFFER_RECOVERY_RATE
-    : 1;
+  return bufferedAhead < LIVE_BUFFER_SLOWDOWN_THRESHOLD_SECS ? LIVE_BUFFER_RECOVERY_RATE : 1;
 }
 
-export function bufferedSecondsAhead(
-  currentTime: number,
-  ranges: BufferedTimeRange[],
-): number {
+export function bufferedSecondsAhead(currentTime: number, ranges: BufferedTimeRange[]): number {
   const currentRange = ranges.find(
     (range) => currentTime >= range.start && currentTime < range.end,
   );
@@ -331,8 +314,7 @@ export function getNextPlaybackRecoveryAttempt(
   maxAttempts = MAX_PLAYBACK_RECOVERY_ATTEMPTS,
   windowMs = PLAYBACK_RECOVERY_WINDOW_MS,
 ): number | null {
-  const nextAttempt =
-    prunePlaybackRecoveryHistory(recoveryTimestamps, now, windowMs).length + 1;
+  const nextAttempt = prunePlaybackRecoveryHistory(recoveryTimestamps, now, windowMs).length + 1;
   return nextAttempt <= maxAttempts ? nextAttempt : null;
 }
 

--- a/src/lib/playlistReportVisibility.ts
+++ b/src/lib/playlistReportVisibility.ts
@@ -18,16 +18,11 @@ export function hasScanStarted(scanState: ReportScanState): boolean {
   return scanState !== "idle";
 }
 
-export function shouldShowContentCounts(
-  movieCount: number,
-  seriesCount: number,
-): boolean {
+export function shouldShowContentCounts(movieCount: number, seriesCount: number): boolean {
   return movieCount > 0 || seriesCount > 0;
 }
 
-export function languageCoverage(
-  channels: Array<{ language: string | null }>,
-): number {
+export function languageCoverage(channels: Array<{ language: string | null }>): number {
   if (channels.length === 0) {
     return 0;
   }

--- a/src/lib/recentPlaylists.ts
+++ b/src/lib/recentPlaylists.ts
@@ -18,15 +18,12 @@ export function parseXtreamRecent(value: string): XtreamRecentSource | null {
   try {
     const parsed = JSON.parse(value) as Partial<XtreamRecentSource>;
     const server = typeof parsed.server === "string" ? parsed.server.trim() : "";
-    const username =
-      typeof parsed.username === "string" ? parsed.username.trim() : "";
+    const username = typeof parsed.username === "string" ? parsed.username.trim() : "";
     if (!server || !username) {
       return null;
     }
     const password =
-      typeof parsed.password === "string" && parsed.password
-        ? parsed.password
-        : undefined;
+      typeof parsed.password === "string" && parsed.password ? parsed.password : undefined;
     return { server, username, password };
   } catch {
     return null;

--- a/src/lib/runtimeMonitor.ts
+++ b/src/lib/runtimeMonitor.ts
@@ -2,24 +2,25 @@
 // factory over (video element, hls/mpegts instances, mutable refs, callbacks)
 // that wires stall detection, live-buffer resync, latency trimming, and the
 // watchdog interval, and returns a cleanup function that tears all of it down.
-import type { ChannelResult } from "./types";
+
 import { logger } from "./logger";
 import {
+  type BufferedTimeRange,
   bufferedSecondsAhead,
   chooseLiveBufferPlaybackRate,
   findLiveBufferResyncTarget,
   findLiveLatencyCatchUpTarget,
   getHlsFatalRecoveryAction,
   getNextPlaybackRecoveryAttempt,
+  type HlsErrorPayload,
   MIN_PROGRESS_DELTA_SECS,
+  type PlaybackRecoveryIssue,
+  type PlayerState,
   readMediaErrorMessage,
   recordPlaybackRecoveryAttempt,
   shouldSuspendPlaybackWatchdog,
-  type BufferedTimeRange,
-  type HlsErrorPayload,
-  type PlaybackRecoveryIssue,
-  type PlayerState,
 } from "./playback";
+import type { ChannelResult } from "./types";
 
 const PLAYBACK_STALL_GRACE_MS = 15_000;
 const PLAYBACK_NO_PROGRESS_STALL_MS = 20_000;
@@ -149,9 +150,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     monitor.lastCurrentTime = target;
     monitor.lastProgressAt = monitor.lastResyncAt;
     monitor.stallStartedAt = null;
-    logger.warn(
-      `[Player] Skipping ${(target - from).toFixed(2)}s buffered timestamp gap`,
-    );
+    logger.warn(`[Player] Skipping ${(target - from).toFixed(2)}s buffered timestamp gap`);
     videoElement.currentTime = target;
     void videoElement.play().catch(() => {});
     return true;
@@ -175,7 +174,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
         ? `[Player] Slowing live playback to ${nextRate.toFixed(2)}x to rebuild buffer`
         : nextRate > 1
           ? `[Player] Increasing live playback to ${nextRate.toFixed(2)}x to reduce latency`
-        : "[Player] Restored live playback to 1.00x",
+          : "[Player] Restored live playback to 1.00x",
     );
   };
 
@@ -197,9 +196,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     monitor.lastCurrentTime = target;
     monitor.lastProgressAt = now;
     monitor.stallStartedAt = null;
-    logger.warn(
-      `[Player] Trimming ${(target - from).toFixed(1)}s accumulated live latency`,
-    );
+    logger.warn(`[Player] Trimming ${(target - from).toFixed(1)}s accumulated live latency`);
     videoElement.currentTime = target;
     void videoElement.play().catch(() => {});
     return true;
@@ -220,10 +217,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     }, LIVE_RESYNC_WAIT_CONFIRM_MS);
   };
 
-  const triggerRuntimeIssue = (
-    issue: PlaybackRecoveryIssue,
-    reason: string,
-  ) => {
+  const triggerRuntimeIssue = (issue: PlaybackRecoveryIssue, reason: string) => {
     if (closed || playbackSessionIdRef.current !== sessionId || !hasStartedPlayingRef.current) {
       return;
     }
@@ -257,12 +251,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     if (closed || isPausedRef.current || videoElement.ended) return;
     logger.warn("[Player] Resuming an unexpected media pause");
     window.setTimeout(() => {
-      if (
-        !closed &&
-        !isPausedRef.current &&
-        videoElement.paused &&
-        !videoElement.ended
-      ) {
+      if (!closed && !isPausedRef.current && videoElement.paused && !videoElement.ended) {
         void videoElement.play().catch(() => {});
       }
     }, 100);
@@ -351,13 +340,10 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
 
   const mpegtsPlayer = mpegtsPlayerRef.current;
   if (mpegtsPlayer?.on && mpegtsPlayer.off) {
-    const onMpegtsError = (
-      errorType?: unknown,
-      errorDetail?: unknown,
-      info?: unknown,
-    ) => {
-      const segments = [errorType, errorDetail, info]
-        .filter((value): value is string => typeof value === "string" && value.length > 0);
+    const onMpegtsError = (errorType?: unknown, errorDetail?: unknown, info?: unknown) => {
+      const segments = [errorType, errorDetail, info].filter(
+        (value): value is string => typeof value === "string" && value.length > 0,
+      );
       const detail = segments.join(": ") || "mpegts.js runtime error";
       triggerRuntimeIssue("library_error", detail);
     };
@@ -381,12 +367,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     if (playerStateRef.current !== "playing") {
       return;
     }
-    if (
-      isPausedRef.current ||
-      videoElement.paused ||
-      videoElement.seeking ||
-      videoElement.ended
-    ) {
+    if (isPausedRef.current || videoElement.paused || videoElement.seeking || videoElement.ended) {
       return;
     }
 
@@ -404,10 +385,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     }
 
     if (monitor.stallStartedAt !== null) {
-      if (
-        now - monitor.stallStartedAt >= LIVE_RESYNC_WAIT_CONFIRM_MS &&
-        tryLiveBufferResync()
-      ) {
+      if (now - monitor.stallStartedAt >= LIVE_RESYNC_WAIT_CONFIRM_MS && tryLiveBufferResync()) {
         return;
       }
       if (now - monitor.stallStartedAt >= PLAYBACK_STALL_GRACE_MS) {
@@ -417,10 +395,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     }
 
     const noProgressDuration = now - monitor.lastProgressAt;
-    if (
-      noProgressDuration >= LIVE_RESYNC_SILENT_STALL_MS &&
-      tryLiveBufferResync()
-    ) {
+    if (noProgressDuration >= LIVE_RESYNC_SILENT_STALL_MS && tryLiveBufferResync()) {
       return;
     }
 

--- a/src/lib/savedPlaylists.ts
+++ b/src/lib/savedPlaylists.ts
@@ -74,9 +74,7 @@ export function findSavedPlaylistForCurrentSource(
   currentSavedPlaylistId?: string | null,
 ): SavedPlaylistEntry | null {
   if (currentSavedPlaylistId) {
-    return (
-      savedPlaylists.find((entry) => entry.id === currentSavedPlaylistId) ?? null
-    );
+    return savedPlaylists.find((entry) => entry.id === currentSavedPlaylistId) ?? null;
   }
   if (!descriptor) {
     return null;

--- a/src/lib/scanState.ts
+++ b/src/lib/scanState.ts
@@ -1,10 +1,4 @@
-export type ScanState =
-  | "idle"
-  | "scanning"
-  | "paused"
-  | "cancelling"
-  | "complete"
-  | "cancelled";
+export type ScanState = "idle" | "scanning" | "paused" | "cancelling" | "complete" | "cancelled";
 
 export function isScanActive(scanState: ScanState | null | undefined): boolean {
   return scanState === "scanning" || scanState === "paused" || scanState === "cancelling";

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -31,16 +31,11 @@ export function isInputLikeTarget(target: EventTarget | null): boolean {
 
   return (
     element.isContentEditable ||
-    element.closest(
-      "input, textarea, select, [contenteditable='true'], [role='textbox']",
-    ) !== null
+    element.closest("input, textarea, select, [contenteditable='true'], [role='textbox']") !== null
   );
 }
 
-export function isPrimaryModifierPressed(
-  state: ShortcutModifierState,
-  isMac: boolean,
-): boolean {
+export function isPrimaryModifierPressed(state: ShortcutModifierState, isMac: boolean): boolean {
   if (isMac) {
     return state.metaKey && !state.ctrlKey;
   }

--- a/src/lib/sourceFilter.ts
+++ b/src/lib/sourceFilter.ts
@@ -1,8 +1,4 @@
-import type {
-  Channel,
-  CurrentSourceDescriptor,
-  PlaylistPreview,
-} from "./types";
+import type { Channel, CurrentSourceDescriptor, PlaylistPreview } from "./types";
 
 const LEADING_CASE_INSENSITIVE_PREFIX = /^(?:\(\?i\))+/i;
 
@@ -50,9 +46,7 @@ export function normalizeSourceFilter(value: string | null | undefined): string 
   return value?.trim() ?? "";
 }
 
-export function compileSourceFilterRegex(
-  value: string | null | undefined,
-): RegExp | null {
+export function compileSourceFilterRegex(value: string | null | undefined): RegExp | null {
   const normalized = normalizeSourceFilter(value);
   if (!normalized) {
     return null;
@@ -61,9 +55,7 @@ export function compileSourceFilterRegex(
   return new RegExp(stripLeadingCaseInsensitivePrefix(normalized), "i");
 }
 
-export function validateSourceFilterPattern(
-  value: string | null | undefined,
-): string | null {
+export function validateSourceFilterPattern(value: string | null | undefined): string | null {
   try {
     compileSourceFilterRegex(value);
     return null;
@@ -127,16 +119,10 @@ export function hasDirtySourceFilter(
     return false;
   }
 
-  return (
-    normalizeSourceFilter(channelSearch) !==
-    normalizeSourceFilter(lastAppliedSourceFilter)
-  );
+  return normalizeSourceFilter(channelSearch) !== normalizeSourceFilter(lastAppliedSourceFilter);
 }
 
-export function resolvePreservedGroupFilter(
-  currentGroupFilter: string,
-  groups: string[],
-): string {
+export function resolvePreservedGroupFilter(currentGroupFilter: string, groups: string[]): string {
   if (currentGroupFilter === "all") {
     return "all";
   }

--- a/src/lib/tableColumns.ts
+++ b/src/lib/tableColumns.ts
@@ -37,35 +37,27 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
   },
 ];
 
-export const COLUMN_DEFINITION_MAP: Record<ColumnKey, ColumnDefinition> =
-  COLUMN_DEFINITIONS.reduce(
-    (acc, column) => {
-      acc[column.key] = column;
-      return acc;
-    },
-    {} as Record<ColumnKey, ColumnDefinition>,
-  );
-
-export const DEFAULT_COLUMN_ORDER: ColumnKey[] = COLUMN_DEFINITIONS.map(
-  (column) => column.key,
+export const COLUMN_DEFINITION_MAP: Record<ColumnKey, ColumnDefinition> = COLUMN_DEFINITIONS.reduce(
+  (acc, column) => {
+    acc[column.key] = column;
+    return acc;
+  },
+  {} as Record<ColumnKey, ColumnDefinition>,
 );
+
+export const DEFAULT_COLUMN_ORDER: ColumnKey[] = COLUMN_DEFINITIONS.map((column) => column.key);
 
 export const DEFAULT_VISIBLE_COLUMN_ORDER: ColumnKey[] = DEFAULT_COLUMN_ORDER.filter(
-  (key) =>
-    key !== "url" &&
-    key !== "error" &&
-    key !== "playlist" &&
-    key !== "audio_layout",
+  (key) => key !== "url" && key !== "error" && key !== "playlist" && key !== "audio_layout",
 );
 
-export const DEFAULT_COLUMN_WIDTHS: Record<ColumnKey, number> =
-  COLUMN_DEFINITIONS.reduce(
-    (acc, column) => {
-      acc[column.key] = column.defaultWidth;
-      return acc;
-    },
-    {} as Record<ColumnKey, number>,
-  );
+export const DEFAULT_COLUMN_WIDTHS: Record<ColumnKey, number> = COLUMN_DEFINITIONS.reduce(
+  (acc, column) => {
+    acc[column.key] = column.defaultWidth;
+    return acc;
+  },
+  {} as Record<ColumnKey, number>,
+);
 
 export function parseStoredColumnOrder(
   raw: string | null,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { toCommandChannelResult } from "./channelResults";
 import type {
   AppSettings,
   CastMediaRequest,
@@ -6,22 +7,21 @@ import type {
   ChannelResult,
   ChromecastDevice,
   PlaylistPreview,
-  ScanPresetCollection,
-  ScanPresetConfig,
-  ScanConfig,
-  ScanHistoryItem,
   RecentPlaylistEntry,
   RecentPlaylistKind,
   RenamePlaylistSourceInput,
   SavedPlaylistDraft,
   SavedPlaylistEntry,
   SavedPlaylistUpsertResult,
+  ScanConfig,
+  ScanHistoryItem,
+  ScanPresetCollection,
+  ScanPresetConfig,
   ScreenshotCacheStats,
   StalkerOpenRequest,
   XtreamOpenRequest,
   XtreamServerTestReport,
 } from "./types";
-import { toCommandChannelResult } from "./channelResults";
 
 function toCommandChannelResults(results: ChannelResult[]) {
   return results.map(toCommandChannelResult);
@@ -113,30 +113,21 @@ export async function exportCsv(
   });
 }
 
-export async function exportSplit(
-  results: ChannelResult[],
-  basePath: string,
-): Promise<void> {
+export async function exportSplit(results: ChannelResult[], basePath: string): Promise<void> {
   return invoke("export_split", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportRenamed(
-  results: ChannelResult[],
-  basePath: string,
-): Promise<void> {
+export async function exportRenamed(results: ChannelResult[], basePath: string): Promise<void> {
   return invoke("export_renamed", {
     results: toCommandChannelResults(results),
     basePath,
   });
 }
 
-export async function exportM3u(
-  results: ChannelResult[],
-  path: string,
-): Promise<void> {
+export async function exportM3u(results: ChannelResult[], path: string): Promise<void> {
   return invoke("export_m3u", {
     results: toCommandChannelResults(results),
     path,
@@ -181,9 +172,7 @@ export async function deleteScanPreset(name: string): Promise<ScanPresetCollecti
   return invoke("delete_scan_preset", { name });
 }
 
-export async function setDefaultScanPreset(
-  name: string | null,
-): Promise<ScanPresetCollection> {
+export async function setDefaultScanPreset(name: string | null): Promise<ScanPresetCollection> {
   return invoke("set_default_scan_preset", { name });
 }
 
@@ -277,9 +266,7 @@ export async function openSavedPlaylist(
   });
 }
 
-export async function renamePlaylistSource(
-  input: RenamePlaylistSourceInput,
-): Promise<void> {
+export async function renamePlaylistSource(input: RenamePlaylistSourceInput): Promise<void> {
   return invoke("rename_playlist_source", { input });
 }
 

--- a/src/lib/thumbnailState.ts
+++ b/src/lib/thumbnailState.ts
@@ -29,9 +29,7 @@ export interface ThumbnailDisplayState {
   screenshotErrorReason: string | null;
 }
 
-export function getThumbnailDisplayState(
-  input: ThumbnailDisplayStateInput,
-): ThumbnailDisplayState {
+export function getThumbnailDisplayState(input: ThumbnailDisplayStateInput): ThumbnailDisplayState {
   const {
     result,
     screenshotUrl,
@@ -80,9 +78,7 @@ export function getThumbnailDisplayState(
     result.status === "alive" &&
     !result.screenshot_path;
   const showScreenshotsDisabled =
-    !screenshotsEnabled &&
-    result.status === "alive" &&
-    !screenshotUrl;
+    !screenshotsEnabled && result.status === "alive" && !screenshotUrl;
 
   return {
     waitingForScanResult,

--- a/src/lib/workerSupport.ts
+++ b/src/lib/workerSupport.ts
@@ -20,9 +20,7 @@ interface BlobWorkerProbeOptions {
  * CSP violations are reported asynchronously, which otherwise leaves mpegts.js
  * waiting on a worker that will never start or request the stream.
  */
-export function probeBlobWorkerSupport(
-  options: BlobWorkerProbeOptions = {},
-): Promise<boolean> {
+export function probeBlobWorkerSupport(options: BlobWorkerProbeOptions = {}): Promise<boolean> {
   const {
     createWorker = (url) => new Worker(url),
     createObjectUrl = (blob) => URL.createObjectURL(blob),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { LogWindow } from "./LogWindow";
 import { SettingsWindow } from "./SettingsWindow";
-import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./index.css";
 
 // Initialize MCP plugin listeners for AI agent debugging (dev builds only)
 if (import.meta.env.DEV) {
-  import("tauri-plugin-mcp").then(({ setupPluginListeners }) =>
-    setupPluginListeners(),
-  );
+  import("tauri-plugin-mcp").then(({ setupPluginListeners }) => setupPluginListeners());
 }
 
 const platformHint = navigator.platform.toUpperCase().includes("MAC")
@@ -33,13 +31,7 @@ document.documentElement.dataset.window = isLogWindow
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
-      {isLogWindow ? (
-        <LogWindow />
-      ) : isSettingsWindow ? (
-        <SettingsWindow />
-      ) : (
-        <App />
-      )}
+      {isLogWindow ? <LogWindow /> : isSettingsWindow ? <SettingsWindow /> : <App />}
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -1,11 +1,10 @@
 import type { StateCreator } from "zustand";
-import type { AppStore, SettingsSlice } from "../types";
-import type { AppSettings, ScanPresetConfig } from "../../lib/types";
-import { getScanPresets, getSettings, updateSettings } from "../../lib/tauri";
 import { inferPlatformFromNavigator } from "../../lib/platform";
+import { getScanPresets, getSettings, updateSettings } from "../../lib/tauri";
+import type { AppSettings, ScanPresetConfig } from "../../lib/types";
+import type { AppStore, SettingsSlice } from "../types";
 
-const defaultShowHeaderButtonText =
-  inferPlatformFromNavigator() !== "macos";
+const defaultShowHeaderButtonText = inferPlatformFromNavigator() !== "macos";
 
 export const DEFAULT_SETTINGS: AppSettings = {
   timeout: 8.0,
@@ -38,10 +37,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   show_header_button_text: defaultShowHeaderButtonText,
 };
 
-function applyPresetConfig(
-  base: AppSettings,
-  config: ScanPresetConfig,
-): AppSettings {
+function applyPresetConfig(base: AppSettings, config: ScanPresetConfig): AppSettings {
   return {
     ...base,
     timeout: config.timeout,
@@ -63,11 +59,9 @@ function applyPresetConfig(
   };
 }
 
-function sameScanConfig(
-  value: AppSettings,
-  config: ScanPresetConfig,
-): boolean {
-  return value.timeout === config.timeout &&
+function sameScanConfig(value: AppSettings, config: ScanPresetConfig): boolean {
+  return (
+    value.timeout === config.timeout &&
     value.extended_timeout === config.extended_timeout &&
     value.concurrency === config.concurrency &&
     value.retries === config.retries &&
@@ -82,7 +76,8 @@ function sameScanConfig(
     value.test_geoblock === config.test_geoblock &&
     value.screenshots_dir === config.screenshots_dir &&
     value.low_fps_threshold === config.low_fps_threshold &&
-    value.screenshot_format === config.screenshot_format;
+    value.screenshot_format === config.screenshot_format
+  );
 }
 
 export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> = (set, get) => ({

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from "zustand";
-import type { AppStore, UiSlice } from "../types";
 import { inferPlatformFromNavigator } from "../../lib/platform";
 import { isScanActive } from "../../lib/scanState";
+import type { AppStore, UiSlice } from "../types";
 
 const initialPlatform = inferPlatformFromNavigator();
 
@@ -71,9 +71,7 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
       reportAutoRevealDone: false,
       reportWasAutoShown: false,
       showReportPanel:
-        state.reportWasAutoShown && state.showReportPanel
-          ? false
-          : state.showReportPanel,
+        state.reportWasAutoShown && state.showReportPanel ? false : state.showReportPanel,
     })),
   autoRevealReportPanel: () =>
     set({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,13 +1,13 @@
 import { create } from "zustand";
-import type { AppStore } from "./types";
+import { createFilterSlice } from "./slices/filterSlice";
+import { createHistorySlice } from "./slices/historySlice";
+import { createPlayerSlice } from "./slices/playerSlice";
 import { createPlaylistSlice } from "./slices/playlistSlice";
 import { createScanSlice } from "./slices/scanSlice";
-import { createFilterSlice } from "./slices/filterSlice";
 import { createSelectionSlice } from "./slices/selectionSlice";
-import { createUiSlice } from "./slices/uiSlice";
-import { createPlayerSlice } from "./slices/playerSlice";
-import { createHistorySlice } from "./slices/historySlice";
 import { createSettingsSlice } from "./slices/settingsSlice";
+import { createUiSlice } from "./slices/uiSlice";
+import type { AppStore } from "./types";
 
 export const useAppStore = create<AppStore>()((...a) => ({
   ...createPlaylistSlice(...a),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,3 +1,6 @@
+import type { ScanUiMetrics } from "../hooks/useScan.helpers";
+import type { Platform } from "../lib/platform";
+import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
@@ -12,9 +15,6 @@ import type {
   StalkerOpenRequest,
   XtreamRecentSource,
 } from "../lib/types";
-import type { Platform } from "../lib/platform";
-import type { ScanState } from "../lib/scanState";
-import type { ScanUiMetrics } from "../hooks/useScan.helpers";
 
 // ---------------------------------------------------------------------------
 // Playlist

--- a/tests/channelResults.test.ts
+++ b/tests/channelResults.test.ts
@@ -64,9 +64,7 @@ describe("channelResults helpers", () => {
   });
 
   it("creates pending channel results with backend-aligned IDs", () => {
-    const pending = toPendingChannelResult(
-      makeChannel("https://example.com/live/channel-42.ts"),
-    );
+    const pending = toPendingChannelResult(makeChannel("https://example.com/live/channel-42.ts"));
 
     expect(pending.channel_id).toBe("channel-42");
     expect(pending.status).toBe("pending");

--- a/tests/duplicates.test.ts
+++ b/tests/duplicates.test.ts
@@ -54,10 +54,7 @@ describe("findDuplicateChannelIndices", () => {
       makeResult(2, "https://example.com/live/stream.m3u8?a=1&b=2"),
     ];
 
-    expect(Array.from(findDuplicateChannelIndices(results)).sort((a, b) => a - b)).toEqual([
-      0,
-      1,
-    ]);
+    expect(Array.from(findDuplicateChannelIndices(results)).sort((a, b) => a - b)).toEqual([0, 1]);
   });
 
   it("normalizes unreserved percent encoding in path and query", () => {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -23,9 +23,7 @@ describe("user-facing source errors", () => {
       redactUrlCredentials(
         "https://first%20last:p%20ass@example.com/get.php?username=user name&password=secret phrase&type=m3u_plus",
       ),
-    ).toBe(
-      "https://***@example.com/get.php?username=***&password=***&type=m3u_plus",
-    );
+    ).toBe("https://***@example.com/get.php?username=***&password=***&type=m3u_plus");
   });
 
   test("redacts embedded URL userinfo in formatted errors", () => {
@@ -39,9 +37,9 @@ describe("user-facing source errors", () => {
   });
 
   test("reload errors normalize an existing playlist prefix", () => {
-    expect(
-      formatSourceReloadError("Failed to open playlist: connection refused"),
-    ).toBe("Failed to reload source: connection refused");
+    expect(formatSourceReloadError("Failed to open playlist: connection refused")).toBe(
+      "Failed to reload source: connection refused",
+    );
     expect(
       formatSourceReloadError(
         "Failed to open playlist: Failed to reload source: connection refused",

--- a/tests/exportScope.test.ts
+++ b/tests/exportScope.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
+  type ExportScope,
   exportScopeFileSuffix,
   exportScopeLabel,
   resolveExportScopeResults,
-  type ExportScope,
 } from "../src/lib/exportScope";
 import type { ChannelResult } from "../src/lib/types";
 
@@ -62,9 +62,7 @@ describe("export scope resolution", () => {
     };
 
     for (const scope of cases) {
-      expect(resolveExportScopeResults(scope, all, filtered, selected)).toEqual(
-        byScope[scope],
-      );
+      expect(resolveExportScopeResults(scope, all, filtered, selected)).toEqual(byScope[scope]);
     }
   });
 

--- a/tests/filters.logic.test.ts
+++ b/tests/filters.logic.test.ts
@@ -76,23 +76,15 @@ describe("filterResults", () => {
   ];
 
   it("filters by search across name, playlist, and group", () => {
-    expect(filterResults(results, "sports", "all", "all").map((r) => r.index)).toEqual(
-      [0, 2],
-    );
-    expect(filterResults(results, "movies", "all", "all").map((r) => r.index)).toEqual(
-      [1],
-    );
-    expect(
-      filterResults(results, "entertainment", "all", "all").map((r) => r.index),
-    ).toEqual([1]);
+    expect(filterResults(results, "sports", "all", "all").map((r) => r.index)).toEqual([0, 2]);
+    expect(filterResults(results, "movies", "all", "all").map((r) => r.index)).toEqual([1]);
+    expect(filterResults(results, "entertainment", "all", "all").map((r) => r.index)).toEqual([1]);
   });
 
   it("filters by group and status including geoblocked umbrella", () => {
     expect(filterResults(results, "", "Sports", "all").map((r) => r.index)).toEqual([0, 2]);
     expect(filterResults(results, "", "all", "dead").map((r) => r.index)).toEqual([1]);
-    expect(filterResults(results, "", "all", "geoblocked").map((r) => r.index)).toEqual(
-      [2],
-    );
+    expect(filterResults(results, "", "all", "geoblocked").map((r) => r.index)).toEqual([2]);
   });
 
   it("supports duplicates status filter using duplicateIndices set", () => {
@@ -103,9 +95,7 @@ describe("filterResults", () => {
   });
 
   it("supports audio-only status filter", () => {
-    expect(filterResults(results, "", "all", "audio_only").map((r) => r.index)).toEqual(
-      [2],
-    );
+    expect(filterResults(results, "", "all", "audio_only").map((r) => r.index)).toEqual([2]);
   });
 
   it("supports mislabeled status filter", () => {
@@ -139,12 +129,7 @@ describe("filterResults", () => {
     const duplicateSet = new Set<number>([2, 3]);
 
     expect(
-      countStatusOptions(
-        resultsWithPendingAndMislabeled,
-        "sports",
-        "Sports",
-        duplicateSet,
-      ),
+      countStatusOptions(resultsWithPendingAndMislabeled, "sports", "Sports", duplicateSet),
     ).toEqual({
       all: 3,
       alive: 1,

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -9,9 +9,7 @@ import {
 } from "../src/lib/format";
 import type { ChannelResult } from "../src/lib/types";
 
-function makeResult(
-  overrides: Partial<ChannelResult> = {},
-): ChannelResult {
+function makeResult(overrides: Partial<ChannelResult> = {}): ChannelResult {
   return {
     index: 0,
     playlist: "fixture.m3u8",

--- a/tests/playlistReportVisibility.test.ts
+++ b/tests/playlistReportVisibility.test.ts
@@ -20,18 +20,8 @@ describe("playlist report visibility rules", () => {
   });
 
   test("language distribution requires majority metadata coverage", () => {
-    const sparse = [
-      { language: "en" },
-      { language: null },
-      { language: null },
-      { language: " " },
-    ];
-    const rich = [
-      { language: "en" },
-      { language: "fr" },
-      { language: "de" },
-      { language: null },
-    ];
+    const sparse = [{ language: "en" }, { language: null }, { language: null }, { language: " " }];
+    const rich = [{ language: "en" }, { language: "fr" }, { language: "de" }, { language: null }];
 
     expect(languageCoverage(sparse)).toBe(0.25);
     expect(shouldShowLanguageDistribution(sparse)).toBe(false);

--- a/tests/savedPlaylists.test.ts
+++ b/tests/savedPlaylists.test.ts
@@ -6,8 +6,8 @@ import {
   findSavedPlaylistForCurrentSource,
   normalizeUrlIdentity,
   normalizeXtreamServer,
-  savedPlaylistSecondaryLabel,
   savedEntryToSourceDescriptor,
+  savedPlaylistSecondaryLabel,
 } from "../src/lib/savedPlaylists";
 import type { CurrentSourceDescriptor, SavedPlaylistEntry } from "../src/lib/types";
 
@@ -101,10 +101,7 @@ describe("saved playlist helpers", () => {
 
   it("builds save drafts from supported current sources", () => {
     expect(
-      buildSavedPlaylistDraftFromSource(
-        { kind: "path", path: "/tmp/demo.m3u" },
-        "My Local File",
-      ),
+      buildSavedPlaylistDraftFromSource({ kind: "path", path: "/tmp/demo.m3u" }, "My Local File"),
     ).toEqual({
       kind: "file",
       display_name: "My Local File",

--- a/tests/scanErrorEvents.test.ts
+++ b/tests/scanErrorEvents.test.ts
@@ -14,9 +14,7 @@ function event(runId: string, message: string): ScanEvent<ScanErrorPayload> {
 
 describe("scan error event run scoping", () => {
   it("accepts only errors from the active scan run", () => {
-    expect(runScopedScanErrorMessage("scan-run-2", event("scan-run-2", "boom"))).toBe(
-      "boom",
-    );
+    expect(runScopedScanErrorMessage("scan-run-2", event("scan-run-2", "boom"))).toBe("boom");
     expect(runScopedScanErrorMessage("scan-run-2", event("scan-run-1", "stale"))).toBeNull();
   });
 

--- a/tests/sourceFilter.test.ts
+++ b/tests/sourceFilter.test.ts
@@ -8,10 +8,7 @@ import {
   resolvePreservedGroupFilter,
   validateSourceFilterPattern,
 } from "../src/lib/sourceFilter";
-import type {
-  CurrentSourceDescriptor,
-  PlaylistPreview,
-} from "../src/lib/types";
+import type { CurrentSourceDescriptor, PlaylistPreview } from "../src/lib/types";
 
 const fileSource: CurrentSourceDescriptor = {
   kind: "path",
@@ -44,7 +41,7 @@ const preview: PlaylistPreview = {
       tvg_chno: null,
       url: "http://example.com/disney.m3u8",
       content_type: "live",
-      extinf_line: "#EXTINF:-1 group-title=\"Kids\",SE: Disney Junior [Multi-Audio]",
+      extinf_line: '#EXTINF:-1 group-title="Kids",SE: Disney Junior [Multi-Audio]',
       metadata_lines: [],
     },
     {
@@ -59,7 +56,7 @@ const preview: PlaylistPreview = {
       tvg_chno: null,
       url: "http://example.com/event.m3u8",
       content_type: "live",
-      extinf_line: "#EXTINF:-1 group-title=\"Sports\",Friday Event",
+      extinf_line: '#EXTINF:-1 group-title="Sports",Friday Event',
       metadata_lines: [],
     },
     {
@@ -74,7 +71,7 @@ const preview: PlaylistPreview = {
       tvg_chno: null,
       url: "http://example.com/movie.mp4",
       content_type: "movie",
-      extinf_line: "#EXTINF:-1 group-title=\"Movies\",Cinema One",
+      extinf_line: '#EXTINF:-1 group-title="Movies",Cinema One',
       metadata_lines: [],
     },
   ],
@@ -95,12 +92,8 @@ describe("sourceFilter helpers", () => {
 
   it("preserves the group filter only when it still exists", () => {
     expect(resolvePreservedGroupFilter("all", ["Sports", "News"])).toBe("all");
-    expect(resolvePreservedGroupFilter("sports", ["Sports", "News"])).toBe(
-      "sports",
-    );
-    expect(resolvePreservedGroupFilter("Movies", ["Sports", "News"])).toBe(
-      "all",
-    );
+    expect(resolvePreservedGroupFilter("sports", ["Sports", "News"])).toBe("sports");
+    expect(resolvePreservedGroupFilter("Movies", ["Sports", "News"])).toBe("all");
   });
 
   it("validates source filters with the same case-insensitive prefix handling as apply", () => {
@@ -114,10 +107,7 @@ describe("sourceFilter helpers", () => {
   });
 
   it("reapplies source filters to a cached preview while preserving source groups", () => {
-    const filtered = applySourceFilterToPreview(
-      preview,
-      "^(?!.*(event|ppv)).*",
-    );
+    const filtered = applySourceFilterToPreview(preview, "^(?!.*(event|ppv)).*");
 
     expect(filtered.channels.map((channel) => channel.name)).toEqual([
       "SE: Disney Junior [Multi-Audio]",
@@ -137,30 +127,33 @@ describe("sourceFilter helpers", () => {
   });
 
   it("can hide VOD and series entries from the visible preview", () => {
-    const filtered = applyContentVisibilityToPreview({
-      ...preview,
-      total_channels: 4,
-      series_count: 1,
-      groups: ["Kids", "Sports", "Movies", "Series"],
-      channels: [
-        ...preview.channels,
-        {
-          index: 200,
-          playlist: "sample.m3u8",
-          name: "Series One",
-          group: "Series",
-          language: null,
-          tvg_id: null,
-          tvg_name: null,
-          tvg_logo: null,
-          tvg_chno: null,
-          url: "http://example.com/series/one.mkv",
-          content_type: "series",
-          extinf_line: "#EXTINF:-1 group-title=\"Series\",Series One",
-          metadata_lines: [],
-        },
-      ],
-    }, true);
+    const filtered = applyContentVisibilityToPreview(
+      {
+        ...preview,
+        total_channels: 4,
+        series_count: 1,
+        groups: ["Kids", "Sports", "Movies", "Series"],
+        channels: [
+          ...preview.channels,
+          {
+            index: 200,
+            playlist: "sample.m3u8",
+            name: "Series One",
+            group: "Series",
+            language: null,
+            tvg_id: null,
+            tvg_name: null,
+            tvg_logo: null,
+            tvg_chno: null,
+            url: "http://example.com/series/one.mkv",
+            content_type: "series",
+            extinf_line: '#EXTINF:-1 group-title="Series",Series One',
+            metadata_lines: [],
+          },
+        ],
+      },
+      true,
+    );
 
     expect(filtered.channels.map((channel) => channel.name)).toEqual([
       "SE: Disney Junior [Multi-Audio]",

--- a/tests/tableColumns.test.ts
+++ b/tests/tableColumns.test.ts
@@ -7,10 +7,11 @@ import {
 
 describe("tableColumns helpers", () => {
   it("keeps only known columns, dedupes them, and appends fallback columns", () => {
-    const parsed = parseStoredColumnOrder(
-      JSON.stringify(["name", "status", "name", "bad-key"]),
-      ["status", "name", "group"],
-    );
+    const parsed = parseStoredColumnOrder(JSON.stringify(["name", "status", "name", "bad-key"]), [
+      "status",
+      "name",
+      "group",
+    ]);
 
     expect(parsed).toEqual(["name", "status", "group"]);
   });

--- a/tests/useScan.helpers.test.ts
+++ b/tests/useScan.helpers.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import {
-  applyResultUpdates,
-  type ScanResultCollections,
-} from "../src/hooks/useScan.helpers";
+import { applyResultUpdates, type ScanResultCollections } from "../src/hooks/useScan.helpers";
 import type { ChannelResult } from "../src/lib/types";
 
-function buildResult(
-  index: number,
-  overrides: Partial<ChannelResult> = {},
-): ChannelResult {
+function buildResult(index: number, overrides: Partial<ChannelResult> = {}): ChannelResult {
   return {
     index,
     playlist: "sample",

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   areStreamMetadataEqual,
-  classifyStream,
   chooseLiveBufferPlaybackRate,
+  classifyStream,
   decidePlaybackRecovery,
   findLiveBufferResyncTarget,
   findLiveLatencyCatchUpTarget,
@@ -13,13 +13,13 @@ import {
   PLAYBACK_RECOVERY_WINDOW_MS,
   prunePlaybackRecoveryHistory,
   recordPlaybackRecoveryAttempt,
+  type StreamMetadata,
+  type StreamType,
   shouldResetPlaybackRecoveryAttempts,
   shouldSuspendPlaybackWatchdog,
   shouldTryXtreamHlsBeforeMpegts,
   supportsNativeHlsPlayback,
   tryConvertToXtreamHls,
-  type StreamMetadata,
-  type StreamType,
 } from "../src/lib/playback";
 
 function canPlayTypes(
@@ -65,12 +65,7 @@ describe("useStreamPlayer helpers", () => {
   });
 
   it("uses the compatible direct route before remux for initial live playback", () => {
-    const routes = getMpegtsPlaybackRoutes(
-      "https://example.com/live.ts",
-      3210,
-      true,
-      false,
-    );
+    const routes = getMpegtsPlaybackRoutes("https://example.com/live.ts", 3210, true, false);
 
     expect(routes).toHaveLength(2);
     expect(routes[0]?.kind).toBe("direct");
@@ -81,12 +76,7 @@ describe("useStreamPlayer helpers", () => {
   });
 
   it("prefers timestamp-normalizing remux when recovering live playback", () => {
-    const routes = getMpegtsPlaybackRoutes(
-      "https://example.com/live.ts",
-      3210,
-      true,
-      true,
-    );
+    const routes = getMpegtsPlaybackRoutes("https://example.com/live.ts", 3210, true, true);
 
     expect(routes.map((route) => route.kind)).toEqual(["remux", "direct"]);
   });
@@ -97,12 +87,7 @@ describe("useStreamPlayer helpers", () => {
   });
 
   it("uses one non-remux URL for VOD and direct playback without a proxy", () => {
-    const vodRoutes = getMpegtsPlaybackRoutes(
-      "https://example.com/movie.ts",
-      3210,
-      false,
-      false,
-    );
+    const vodRoutes = getMpegtsPlaybackRoutes("https://example.com/movie.ts", 3210, false, false);
 
     expect(vodRoutes).toHaveLength(1);
     expect(vodRoutes[0]?.url).not.toContain("remux=1");
@@ -117,24 +102,20 @@ describe("useStreamPlayer helpers", () => {
   });
 
   it("converts common Xtream MPEG-TS URL forms to HLS", () => {
-    expect(
-      tryConvertToXtreamHls("http://provider.example/live/user/pass/12345.ts"),
-    ).toBe("http://provider.example/live/user/pass/12345.m3u8");
-    expect(
-      tryConvertToXtreamHls("https://provider.example/user/pass/12345?token=abc"),
-    ).toBe("https://provider.example/live/user/pass/12345.m3u8?token=abc");
-    expect(
-      tryConvertToXtreamHls("http://provider.example/live/user/pass/channel.ts"),
-    ).toBeNull();
+    expect(tryConvertToXtreamHls("http://provider.example/live/user/pass/12345.ts")).toBe(
+      "http://provider.example/live/user/pass/12345.m3u8",
+    );
+    expect(tryConvertToXtreamHls("https://provider.example/user/pass/12345?token=abc")).toBe(
+      "https://provider.example/live/user/pass/12345.m3u8?token=abc",
+    );
+    expect(tryConvertToXtreamHls("http://provider.example/live/user/pass/channel.ts")).toBeNull();
   });
 
   it("caps automatic clean reconnect attempts within a rolling window", () => {
     const now = 1_000_000;
     expect(getNextPlaybackRecoveryAttempt([], now)).toBe(1);
     expect(getNextPlaybackRecoveryAttempt([now - 5_000], now)).toBe(2);
-    expect(
-      getNextPlaybackRecoveryAttempt([now - 5_000, now - 10_000], now),
-    ).toBe(3);
+    expect(getNextPlaybackRecoveryAttempt([now - 5_000, now - 10_000], now)).toBe(3);
     expect(
       getNextPlaybackRecoveryAttempt(
         [now - 5_000, now - 10_000, now - 15_000, now - 20_000, now - 25_000],
@@ -194,12 +175,8 @@ describe("useStreamPlayer helpers", () => {
   });
 
   it("formats reconnect status messaging for the player UI", () => {
-    expect(formatPlaybackRecoveryMessage(1)).toBe(
-      "Stream interrupted. Reconnecting (1/5)...",
-    );
-    expect(formatPlaybackRecoveryMessage(5)).toBe(
-      "Stream interrupted. Reconnecting (5/5)...",
-    );
+    expect(formatPlaybackRecoveryMessage(1)).toBe("Stream interrupted. Reconnecting (1/5)...");
+    expect(formatPlaybackRecoveryMessage(5)).toBe("Stream interrupted. Reconnecting (5/5)...");
   });
 
   it("uses hls.js recovery before rebuilding the whole player", () => {
@@ -259,9 +236,7 @@ describe("useStreamPlayer helpers", () => {
     };
 
     expect(areStreamMetadataEqual(metadata, { ...metadata })).toBe(true);
-    expect(
-      areStreamMetadataEqual(metadata, { ...metadata, videoBitrate: "8.1 Mbps" }),
-    ).toBe(false);
+    expect(areStreamMetadataEqual(metadata, { ...metadata, videoBitrate: "8.1 Mbps" })).toBe(false);
     expect(areStreamMetadataEqual(metadata, null)).toBe(false);
   });
 });


### PR DESCRIPTION
Mechanical prep, split out of #214 so that PR's real diff is reviewable.

The project had no frontend linter or formatter, so style had drifted file by
file. This adds Biome with the config used across my other repos, and runs it
once over the existing sources.

**Everything here is mechanical**: line rewrapping to the 100-column width, and
import sorting. No behaviour changes.

### Why separate

A formatting pass touches almost every file, which buries a real diff. It also
pushed #214 to 121 files — past CodeRabbit's 100-file limit, so it declined to
review that PR at all:

> Review skipped — Too many files! This PR contains 119 files, which is 19 over
> the limit of 100.

Landing the formatting on its own drops #214 to roughly 30 files, so the
substantive changes there can actually be reviewed.

### Validation

`bun run typecheck`, `bun run test:frontend` (90 pass), and `bun run build` all
pass unchanged. The lint/format scripts are added here; CI enforcement of them
lands with #214, together with the clippy and rustfmt gates.

Review with whitespace hidden — GitHub's `?w=1`, or `git diff -w`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-wide linting and formatting commands.
* **Refactor**
  * Standardized code formatting, imports, and styling across the application.
  * Removed advanced ffmpeg/ffprobe timeout settings from the Settings panel.
* **Tests**
  * Updated test formatting to align with the new project style.
* **Chores**
  * Added automated code-quality configuration, including CSS and accessibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->