### PR TITLE
Fix broken release download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@
 <table align="center">
   <tr>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.0/IPTV.Checker_1.8.0_mac_arm.dmg">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_mac_arm.dmg">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for macOS</strong><br>
         <sub>Apple Silicon &middot; .dmg</sub>
       </a>
     </td>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.0/IPTV.Checker_1.8.0_win_x64_setup.exe">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_win_x64_setup.exe">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for Windows</strong><br>
         <sub>64-bit installer &middot; .exe</sub>
       </a>
     </td>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.0/IPTV.Checker_1.8.0_lin_x64.AppImage">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_lin_x64.AppImage">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for Linux</strong><br>
         <sub>AppImage &middot; x64</sub>

--- a/src-tauri/tauri.conf.release.json
+++ b/src-tauri/tauri.conf.release.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
+    "targets": ["app", "dmg", "nsis", "appimage", "deb", "rpm"],
     "createUpdaterArtifacts": true
   }
 }


### PR DESCRIPTION
The v1.8.0 release workflow uploaded its installers but failed before publishing, leaving the README links pointed at a private draft.

This restores the download buttons to the latest published v1.7.0 assets and adds the macOS app bundle target required to generate the updater artifact before the release manifest is patched.

Validation:
- all three README download URLs return HTTP 200
- TypeScript typecheck
- 106 frontend tests
- Biome check
- actionlint
- clean local CodeRabbit preflight

Ref #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected macOS, Windows, and Linux download links to reference the intended release version.

* **New Features**
  * Expanded release packaging to provide installers in app, DMG, NSIS, AppImage, DEB, and RPM formats, improving availability across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->