### PR TITLE
Gate Windows releases on Defender scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,25 @@ jobs:
           Compress-Archive -Path "$staging/*" -DestinationPath $zipName
           echo "PORTABLE_ZIP=$zipName" >> $env:GITHUB_ENV
 
+      - name: Scan Windows release artifacts with Microsoft Defender
+        if: startsWith(matrix.target, 'x86_64-pc-windows') || startsWith(matrix.target, 'aarch64-pc-windows')
+        shell: pwsh
+        run: |
+          $targetRoot = "src-tauri/target/${{ matrix.target }}/release"
+          $installers = @(Get-ChildItem "$targetRoot/bundle/nsis" -Filter "*.exe" -File)
+          if ($installers.Count -ne 1) {
+            throw "Expected one NSIS installer, found $($installers.Count)"
+          }
+
+          $scanPaths = @(
+            $installers[0].FullName
+            (Resolve-Path $env:PORTABLE_ZIP).Path
+            (Resolve-Path "$targetRoot/iptv-checker.exe").Path
+            (Resolve-Path "src-tauri/binaries/ffmpeg-${{ matrix.target }}.exe").Path
+            (Resolve-Path "src-tauri/binaries/ffprobe-${{ matrix.target }}.exe").Path
+          )
+          & scripts/scan-windows-defender.ps1 -Paths $scanPaths
+
       - name: Upload Windows portable zip
         if: startsWith(matrix.target, 'x86_64-pc-windows') || startsWith(matrix.target, 'aarch64-pc-windows')
         env:

--- a/scripts/scan-windows-defender.ps1
+++ b/scripts/scan-windows-defender.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string[]] $Paths
+)
+
+$ErrorActionPreference = "Stop"
+
+$scanPaths = @(
+    $Paths |
+        ForEach-Object { (Resolve-Path -LiteralPath $_).Path } |
+        Sort-Object -Unique
+)
+if ($scanPaths.Count -eq 0) {
+    throw "At least one scan path is required"
+}
+
+$preferences = Get-MpPreference
+foreach ($excludedPath in @($preferences.ExclusionPath)) {
+    if ($excludedPath) {
+        Remove-MpPreference -ExclusionPath $excludedPath
+    }
+}
+
+Set-MpPreference `
+    -DisableArchiveScanning $false `
+    -DisableBehaviorMonitoring $false `
+    -DisableBlockAtFirstSeen $false `
+    -DisableIOAVProtection $false `
+    -DisableRealtimeMonitoring $false `
+    -DisableScriptScanning $false `
+    -MAPSReporting Advanced `
+    -PUAProtection Enabled `
+    -SubmitSamplesConsent SendSafeSamples
+Update-MpSignature
+
+$status = Get-MpComputerStatus
+$status | Select-Object `
+    AMRunningMode, AntivirusEnabled, BehaviorMonitorEnabled, `
+    IoavProtectionEnabled, OnAccessProtectionEnabled, `
+    RealTimeProtectionEnabled, AntivirusSignatureVersion, `
+    AntivirusSignatureLastUpdated
+if (-not $status.AntivirusEnabled -or -not $status.RealTimeProtectionEnabled) {
+    throw "Microsoft Defender could not be enabled"
+}
+
+$platformRoot = Join-Path $env:ProgramData "Microsoft\Windows Defender\Platform"
+$mpCmdRun = Get-ChildItem -Path $platformRoot -Filter MpCmdRun.exe -Recurse -File |
+    Where-Object { $_.FullName -notmatch "\\X86\\" } |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+if (-not $mpCmdRun) {
+    throw "MpCmdRun.exe was not found"
+}
+
+$failures = @()
+foreach ($scanPath in $scanPaths) {
+    Write-Host "::group::Microsoft Defender scan: $scanPath"
+    $scanOutput = & $mpCmdRun `
+        -Scan -ScanType 3 -File $scanPath -DisableRemediation -ReturnHR
+    $exitCode = $LASTEXITCODE
+    $scanOutput | ForEach-Object { Write-Host $_ }
+    Write-Host "MpCmdRun exit code: $exitCode"
+    Write-Host "::endgroup::"
+
+    if ($exitCode -ne 0) {
+        $failures += [pscustomobject]@{
+            Path = $scanPath
+            ExitCode = $exitCode
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Get-MpThreatDetection | Format-List | Out-String | Write-Host
+    Get-MpThreat | Format-List | Out-String | Write-Host
+    $summary = $failures | ConvertTo-Json -Compress
+    throw "Microsoft Defender rejected one or more release artifacts: $summary"
+}


### PR DESCRIPTION
The reported `Trojan:Win32/Bearfoos.A!ml` verdict no longer reproduces. With current Defender intelligence, both ordinary and cloud/real-time scans pass the v1.7.0 installer, portable archive, app executable, ffmpeg, ffprobe, and extracted installer payload.

Add the same current-signature Defender scan as a release gate for both Windows architectures. A non-zero verdict keeps the release in draft and prints Defender detection details.

Ref #217