### PR TITLE
Bump version to 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@
 <table align="center">
   <tr>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_mac_arm.dmg">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.1/IPTV.Checker_1.8.1_mac_arm.dmg">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for macOS</strong><br>
         <sub>Apple Silicon &middot; .dmg</sub>
       </a>
     </td>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_win_x64_setup.exe">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.1/IPTV.Checker_1.8.1_win_x64_setup.exe">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for Windows</strong><br>
         <sub>64-bit installer &middot; .exe</sub>
       </a>
     </td>
     <td align="center" width="220">
-      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.7.0/IPTV.Checker_1.7.0_lin_x64.AppImage">
+      <a href="https://github.com/kristofferR/IPTVChecker/releases/download/v1.8.1/IPTV.Checker_1.8.1_lin_x64.AppImage">
         <img src="docs/icons/download.svg" width="56" height="56" alt=""><br>
         <strong>Download for Linux</strong><br>
         <sub>AppImage &middot; x64</sub>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iptv-checker-gui",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "iptv-checker"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "base64 0.22.1",
  "cast-sender",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iptv-checker"
-version = "1.8.0"
+version = "1.8.1"
 description = "Cross-platform IPTV Stream Checker"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "IPTV Checker",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.iptvchecker.gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Prepare the repaired release as v1.8.1 across the Rust package, Tauri config, frontend package, lockfile, and README download links.

Validated with Cargo check, frozen Bun install, TypeScript typechecking, and workflow lint.

Ref #217