### PR TITLE
Wait for Defender readiness before scanning

### DIFF
--- a/scripts/scan-windows-defender.ps1
+++ b/scripts/scan-windows-defender.ps1
@@ -35,13 +35,27 @@ Set-MpPreference `
 Update-MpSignature
 
 $status = Get-MpComputerStatus
+$readinessDeadline = [DateTime]::UtcNow.AddSeconds(60)
+while (
+    $status.AntivirusEnabled -and
+    -not $status.RealTimeProtectionEnabled -and
+    [DateTime]::UtcNow -lt $readinessDeadline
+) {
+    Start-Sleep -Seconds 5
+    $status = Get-MpComputerStatus
+}
+
 $status | Select-Object `
     AMRunningMode, AntivirusEnabled, BehaviorMonitorEnabled, `
     IoavProtectionEnabled, OnAccessProtectionEnabled, `
     RealTimeProtectionEnabled, AntivirusSignatureVersion, `
     AntivirusSignatureLastUpdated
-if (-not $status.AntivirusEnabled -or -not $status.RealTimeProtectionEnabled) {
-    throw "Microsoft Defender could not be enabled"
+if (-not $status.AntivirusEnabled) {
+    throw "Microsoft Defender Antivirus is unavailable"
+}
+if (-not $status.RealTimeProtectionEnabled) {
+    Write-Warning "Real-time protection did not start; continuing with explicit custom scans" `
+        -WarningAction Continue
 }
 
 $platformRoot = Join-Path $env:ProgramData "Microsoft\Windows Defender\Platform"


### PR DESCRIPTION
The first v1.8.1 release run exposed an asynchronous Windows runner state: Defender accepted the enable request but real-time protection was still starting when the gate checked it.

Wait up to 60 seconds for readiness. If real-time protection remains unavailable, continue with the explicit current-signature MpCmdRun custom scans, which work independently and still fail the release on any non-zero scan verdict.

Ref #217