### PR TITLE
Hide the title bar on tiling window managers (Linux)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -754,7 +754,36 @@ pub async fn update_settings(app: tauri::AppHandle, settings: AppSettings) -> Re
         log::warn!("Failed to apply theme preference: {}", error);
     }
 
+    // Title-bar visibility follows the setting live, on every window — the
+    // Settings and Log windows carry the same redundant header bar on tiling
+    // window managers.
+    #[cfg(target_os = "linux")]
+    {
+        let show_title_bar = crate::linux::show_title_bar(&settings);
+        for window in app.webview_windows().values() {
+            let _ = window.set_decorations(show_title_bar);
+        }
+    }
+
     Ok(())
+}
+
+/// Whether newly created windows should keep their native title bar. Always
+/// true off Linux (macOS/Windows use the overlay title bar instead); on Linux
+/// it follows the title-bar setting and tiling-WM detection.
+#[tauri::command]
+pub async fn get_title_bar_visibility(app: tauri::AppHandle) -> Result<bool, AppError> {
+    #[cfg(target_os = "linux")]
+    {
+        let state = app.state::<Arc<AppState>>();
+        let settings = state.settings.lock().await;
+        Ok(crate::linux::show_title_bar(&settings))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = app;
+        Ok(true)
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod commands;
 pub mod engine;
 pub mod error;
+#[cfg(target_os = "linux")]
+pub mod linux;
 pub mod models;
 pub mod state;
 pub mod urlnorm;
@@ -190,9 +192,24 @@ fn create_window_from_main_config(app: &tauri::AppHandle, label: String) {
         .and_then(|builder| builder.build())
     {
         // The built window is only consumed by the macOS-only vibrancy setup
-        // below; elsewhere the theme is applied through the app handle.
-        #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+        // and the Linux title-bar pass below; elsewhere the theme is applied
+        // through the app handle.
+        #[cfg_attr(
+            not(any(target_os = "macos", target_os = "linux")),
+            allow(unused_variables)
+        )]
         Ok(window) => {
+            // Linux: new windows follow the title-bar setting (hidden on
+            // tiling window managers by default).
+            #[cfg(target_os = "linux")]
+            {
+                let show_title_bar = {
+                    let state = app.state::<Arc<AppState>>();
+                    let settings = state.settings.blocking_lock();
+                    linux::show_title_bar(&settings)
+                };
+                let _ = window.set_decorations(show_title_bar);
+            }
             let theme_preference = {
                 let state = app.state::<Arc<AppState>>();
                 let theme = state.settings.blocking_lock().theme;
@@ -992,12 +1009,18 @@ pub fn run() {
                 }
             }
 
-            // On Linux, ensure native window decorations are visible and the
-            // window title is set (overlay titlebar is macOS/Windows only).
+            // On Linux, apply native window decorations per the title-bar
+            // setting — hidden on tiling window managers by default — and set
+            // the window title (overlay titlebar is macOS/Windows only).
             #[cfg(target_os = "linux")]
             {
+                let show_title_bar = {
+                    let state = app.state::<Arc<AppState>>();
+                    let settings = state.settings.blocking_lock();
+                    linux::show_title_bar(&settings)
+                };
                 if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.set_decorations(true);
+                    let _ = window.set_decorations(show_title_bar);
                     let _ = window.set_title("IPTV Checker");
                 }
             }
@@ -1036,6 +1059,7 @@ pub fn run() {
             commands::settings::delete_scan_preset,
             commands::settings::set_default_scan_preset,
             commands::settings::update_settings,
+            commands::settings::get_title_bar_visibility,
             commands::settings::check_ffmpeg_available,
             commands::settings::set_default_m3u8_file_association,
             commands::settings::read_screenshot,

--- a/src-tauri/src/linux.rs
+++ b/src-tauri/src/linux.rs
@@ -1,0 +1,97 @@
+use crate::models::settings::{AppSettings, TitleBarPreference};
+
+/// Whether the main window keeps its title bar. `Show`/`Hide` are explicit;
+/// `Auto` hides it under a tiling window manager (where the compositor
+/// moves/closes windows and the GTK header bar is dead weight) and keeps it
+/// on floating desktops, where it is also how you drag and close the window.
+pub fn show_title_bar(settings: &AppSettings) -> bool {
+    match settings.title_bar {
+        TitleBarPreference::Show => true,
+        TitleBarPreference::Hide => false,
+        TitleBarPreference::Auto => !is_tiling_wm(),
+    }
+}
+
+/// Best-effort "is this session a tiling window manager?". Nothing in X11 or
+/// Wayland lets a client ask, so match the session's advertised desktop
+/// identifiers against the well-known tilers. Drives the `Auto` title-bar
+/// default; Settings → Title bar overrides it either way.
+pub fn is_tiling_wm() -> bool {
+    static TILING: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *TILING.get_or_init(|| {
+        [
+            "XDG_CURRENT_DESKTOP",
+            "XDG_SESSION_DESKTOP",
+            "DESKTOP_SESSION",
+        ]
+        .iter()
+        .filter_map(|var| std::env::var(var).ok())
+        .any(|value| is_tiling_desktop(&value))
+    })
+}
+
+/// True when a desktop identifier (possibly colon-separated, as in
+/// XDG_CURRENT_DESKTOP) names a window manager that tiles by default.
+fn is_tiling_desktop(value: &str) -> bool {
+    const TILERS: &[&str] = &[
+        "hyprland",
+        "sway",
+        "swayfx",
+        "i3",
+        "i3wm",
+        "river",
+        "niri",
+        "bspwm",
+        "dwm",
+        "dwl",
+        "qtile",
+        "awesome",
+        "xmonad",
+        "herbstluftwm",
+        "leftwm",
+        "spectrwm",
+        "wmii",
+        "ratpoison",
+        "stumpwm",
+    ];
+    value
+        .split(':')
+        .map(|segment| segment.trim().to_ascii_lowercase())
+        .any(|segment| TILERS.contains(&segment.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiling_desktops_are_recognized_per_segment_case_insensitively() {
+        assert!(is_tiling_desktop("Hyprland"));
+        assert!(is_tiling_desktop("sway"));
+        assert!(is_tiling_desktop("niri"));
+        assert!(is_tiling_desktop("i3"));
+        assert!(is_tiling_desktop("wlroots:Sway"));
+        assert!(!is_tiling_desktop("GNOME"));
+        assert!(!is_tiling_desktop("KDE"));
+        assert!(!is_tiling_desktop("ubuntu:GNOME"));
+        assert!(!is_tiling_desktop("XFCE"));
+        assert!(!is_tiling_desktop(""));
+        // Substrings must not match — only whole identifiers.
+        assert!(!is_tiling_desktop("swayed"));
+    }
+
+    #[test]
+    fn explicit_preference_overrides_detection() {
+        let show = AppSettings {
+            title_bar: TitleBarPreference::Show,
+            ..AppSettings::default()
+        };
+        assert!(show_title_bar(&show));
+
+        let hide = AppSettings {
+            title_bar: TitleBarPreference::Hide,
+            ..AppSettings::default()
+        };
+        assert!(!show_title_bar(&hide));
+    }
+}

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -15,6 +15,20 @@ pub enum ThemePreference {
     Dark,
 }
 
+/// Linux: window title bar visibility. `Auto` hides it on tiling window
+/// managers (where the compositor moves/closes windows and the GTK header
+/// bar is dead weight) and keeps it on floating desktops, where it is also
+/// how you drag and close the window.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum TitleBarPreference {
+    #[default]
+    Auto,
+    Show,
+    Hide,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
@@ -65,6 +79,8 @@ pub struct AppSettings {
     pub scan_notifications: bool,
     pub low_fps_threshold: f64,
     pub theme: ThemePreference,
+    /// Linux only: title bar visibility (auto / show / hide).
+    pub title_bar: TitleBarPreference,
     pub log_level: String,
     pub show_prescan_filter: bool,
     pub hide_vod_content: bool,
@@ -188,6 +204,7 @@ impl Default for AppSettings {
             scan_notifications: true,
             low_fps_threshold: 23.0,
             theme: ThemePreference::System,
+            title_bar: TitleBarPreference::Auto,
             log_level: "error".to_string(),
             show_prescan_filter: false,
             hide_vod_content: false,
@@ -266,6 +283,8 @@ mod tests {
         assert_eq!(settings.low_fps_threshold, 23.0);
         assert_eq!(settings.channel_logo_size, super::ChannelLogoSize::Small);
         assert_eq!(settings.show_header_button_text, !cfg!(target_os = "macos"));
+        // Pre-existing installs have no `title_bar` key in settings.json.
+        assert_eq!(settings.title_bar, super::TitleBarPreference::Auto);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import {
   checkFfmpegAvailable,
   clearScanHistory,
   getScanHistory,
+  getTitleBarVisibility,
   openChannelInPlayer,
   quickCheckChannel,
   readScreenshot,
@@ -1035,6 +1036,7 @@ export default function App() {
     new WebviewWindow("settings", {
       url: `${baseUrl}?window=settings`,
       ...(platform === "windows" ? { dataDirectory: "settings-webview" } : {}),
+      ...(platform === "linux" ? { decorations: await getTitleBarVisibility() } : {}),
       title: "Settings",
       width: 620,
       height: 680,
@@ -1060,6 +1062,7 @@ export default function App() {
     new WebviewWindow("log", {
       url: `${baseUrl}?window=log`,
       ...(platform === "windows" ? { dataDirectory: "log-webview" } : {}),
+      ...(platform === "linux" ? { decorations: await getTitleBarVisibility() } : {}),
       title: "Log",
       width: 900,
       height: 600,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -575,8 +575,8 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                   <div>
                     <p className="text-[13px] font-medium">Title bar</p>
                     <p className="text-[11px] text-text-tertiary mt-0.5">
-                      Automatic hides the title bar on tiling window managers (Hyprland, Sway,
-                      i3…) and keeps it on regular desktops.
+                      Automatic hides the title bar on tiling window managers (Hyprland, Sway, i3…)
+                      and keeps it on regular desktops.
                     </p>
                   </div>
                   <select

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -569,6 +569,31 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                   <option value="huge">Huge (48px)</option>
                 </select>
               </div>
+
+              {platform === "linux" && (
+                <div className={rowClass}>
+                  <div>
+                    <p className="text-[13px] font-medium">Title bar</p>
+                    <p className="text-[11px] text-text-tertiary mt-0.5">
+                      Automatic hides the title bar on tiling window managers (Hyprland, Sway,
+                      i3…) and keeps it on regular desktops.
+                    </p>
+                  </div>
+                  <select
+                    value={draft.title_bar}
+                    onChange={(event) =>
+                      updateSetting("title_bar", event.target.value as AppSettings["title_bar"], {
+                        immediate: true,
+                      })
+                    }
+                    className={`${inputClass} w-44`}
+                  >
+                    <option value="auto">Automatic</option>
+                    <option value="show">Shown</option>
+                    <option value="hide">Hidden</option>
+                  </select>
+                </div>
+              )}
             </section>
 
             <section className={blockClass}>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -144,6 +144,11 @@ export async function getSettings(): Promise<AppSettings> {
   return invoke("get_settings");
 }
 
+/** Linux: whether new windows should keep their native title bar. */
+export async function getTitleBarVisibility(): Promise<boolean> {
+  return invoke("get_title_bar_visibility");
+}
+
 export async function updateSettings(settings: AppSettings): Promise<void> {
   return invoke("update_settings", { settings });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -311,6 +311,7 @@ export interface AppSettings {
   scan_notifications: boolean;
   low_fps_threshold: number;
   theme: ThemePreference;
+  title_bar: TitleBarPreference;
   log_level: string;
   show_prescan_filter: boolean;
   hide_vod_content: boolean;
@@ -424,6 +425,9 @@ export interface XtreamServerTestReport {
 
 export type RetryBackoff = "none" | "linear" | "exponential";
 export type ThemePreference = "system" | "light" | "dark";
+
+/** Linux only: "auto" hides the title bar on tiling window managers. */
+export type TitleBarPreference = "auto" | "show" | "hide";
 
 export interface ChromecastDevice {
   id: string;

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -25,6 +25,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   scan_notifications: true,
   low_fps_threshold: 23.0,
   theme: "system",
+  title_bar: "auto",
   log_level: "error",
   show_prescan_filter: false,
   hide_vod_content: false,


### PR DESCRIPTION
Tiling WMs (Hyprland, sway, i3, …) manage windows themselves, leaving the GTK header bar as dead weight on every window. Nothing in X11 or Wayland lets a client ask "am I tiled?", so this matches the session's desktop identifiers (`XDG_CURRENT_DESKTOP`, `XDG_SESSION_DESKTOP`, `DESKTOP_SESSION`) against the well-known tilers and drops the window decorations there by default.

- Applied to the main window at startup, live to every open window when settings change, and to the Settings/Log windows via a new `get_title_bar_visibility` command when the frontend creates them.
- New Linux-only **Title bar** select (Automatic / Shown / Hidden) in Settings → General overrides the detection either way, since on floating desktops the title bar is also how you drag and close the window.
- Existing installs default to Automatic; unknown values fail back to the enum default via serde.

Ported from Carrier's kristofferR/Carrier#240. Verified live on Hyprland: main and Settings windows come up without the header bar.
