### PR TITLE
Improve application logging

### DIFF
--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -903,6 +903,22 @@ fn now_epoch_ms() -> u64 {
         .as_millis() as u64
 }
 
+fn log_scan_summary(outcome: &str, run_id: &str, started_at_epoch_ms: u64, summary: &ScanSummary) {
+    let elapsed_secs = now_epoch_ms().saturating_sub(started_at_epoch_ms) as f64 / 1000.0;
+    log::info!(
+        "Scan {} {} in {:.1}s: total={}, alive={}, dead={}, placeholder={}, geoblocked={}, drm={}",
+        run_id,
+        outcome,
+        elapsed_secs,
+        summary.total,
+        summary.alive,
+        summary.dead,
+        summary.placeholder,
+        summary.geoblocked,
+        summary.drm,
+    );
+}
+
 async fn record_backend_perf(
     app: &AppHandle,
     state: &Arc<AppState>,
@@ -2033,6 +2049,8 @@ async fn finish_empty_scan(
         playlist_score: None,
     };
 
+    log_scan_summary("completed", run_id, scan_started_at_epoch_ms, &summary);
+
     let _ = app.emit(
         "scan://complete",
         ScanEvent {
@@ -2389,7 +2407,7 @@ async fn execute_scan_run(
             }
 
             log::info!(
-                "[Scan] #{} {} → {} (bitrate: {}, latency: {})",
+                "[Scan] #{} {} → {} (bitrate: {}, latency: {}, url: {})",
                 channel.index,
                 channel.name,
                 shared.status,
@@ -2398,6 +2416,7 @@ async fn execute_scan_run(
                     .latency_ms
                     .map(|ms| format!("{ms} ms"))
                     .unwrap_or_else(|| "—".to_string()),
+                channel.url,
             );
 
             shared.channel_log.channel_index = channel.index;
@@ -2462,6 +2481,7 @@ async fn execute_scan_run(
         summary.total,
     );
     if cancel_token.is_cancelled() {
+        log_scan_summary("cancelled", &run_id, scan_started_at_epoch_ms, &summary);
         let _ = app.emit(
             "scan://cancelled",
             ScanEvent {
@@ -2489,6 +2509,8 @@ async fn execute_scan_run(
         completed_scan.results,
     )
     .await;
+
+    log_scan_summary("completed", &run_id, scan_started_at_epoch_ms, &summary);
 
     let _ = app.emit(
         "scan://complete",
@@ -2557,6 +2579,14 @@ pub async fn start_scan(
         )
         .await;
         if let Err(error) = outcome {
+            let elapsed_secs =
+                now_epoch_ms().saturating_sub(scan_started_at_epoch_ms) as f64 / 1000.0;
+            log::error!(
+                "Scan {} failed after {:.1}s: {}",
+                run_id_for_task,
+                elapsed_secs,
+                error
+            );
             emit_scan_error_event(&app_for_task, &run_id_for_task, error.to_string());
         }
         clear_scan_state_for_run(
@@ -2583,6 +2613,10 @@ pub async fn start_scan(
 #[tauri::command]
 pub async fn cancel_scan(app: AppHandle, window: Window) -> Result<(), AppError> {
     let state = app.state::<Arc<AppState>>();
+    log::info!(
+        "Scan cancellation requested for window '{}'",
+        window.label()
+    );
     cancel_scan_token(state.inner().as_ref(), window.label()).await;
     Ok(())
 }
@@ -2611,6 +2645,7 @@ pub async fn pause_scan(app: AppHandle, window: Window) -> Result<(), AppError> 
         .await?;
     pause_notify.notify_waiters();
     if let Some(run_id) = run_id {
+        log::info!("Scan {} paused", run_id);
         let _ = app.emit(
             "scan://paused",
             ScanEvent {
@@ -2647,6 +2682,7 @@ pub async fn resume_scan(app: AppHandle, window: Window) -> Result<(), AppError>
         .await?;
     pause_notify.notify_waiters();
     if let Some(run_id) = run_id {
+        log::info!("Scan {} resumed", run_id);
         let _ = app.emit(
             "scan://resumed",
             ScanEvent {
@@ -2701,6 +2737,7 @@ pub async fn quick_check_channel(
     app: AppHandle,
     channel: ChannelResult,
 ) -> Result<ChannelResult, AppError> {
+    let check_started_at = Instant::now();
     let state = app.state::<Arc<AppState>>();
     let settings = state.settings.lock().await.clone();
 
@@ -2739,8 +2776,28 @@ pub async fn quick_check_channel(
     };
 
     let (status, stream_url, latency_ms, error_reason) = match outcome {
-        Ok(o) => (o.status, o.stream_url, o.latency_ms, o.last_error_reason),
-        Err(_) => (ChannelStatus::Dead, None, None, None),
+        Ok(o) => {
+            log::info!(
+                "[Quick Check] #{} {} → {} in {:.1}s (url: {})",
+                channel.index,
+                channel.name,
+                o.status,
+                check_started_at.elapsed().as_secs_f64(),
+                channel.url,
+            );
+            (o.status, o.stream_url, o.latency_ms, o.last_error_reason)
+        }
+        Err(error) => {
+            log::warn!(
+                "[Quick Check] #{} {} failed after {:.1}s: {} (url: {})",
+                channel.index,
+                channel.name,
+                check_started_at.elapsed().as_secs_f64(),
+                error,
+                channel.url,
+            );
+            (ChannelStatus::Dead, None, None, None)
+        }
     };
 
     let mut result = channel;

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -1175,8 +1175,6 @@ pub async fn check_channel_status_with_debug(
             .unwrap_or_else(|_| HeaderValue::from_static("TiviMate/5.1.6 (Android 12)")),
     );
 
-    log::info!("Checking channel: {}", url);
-
     let attempt_check = |current_timeout: f64, attempt_offset: u32| {
         let client = client.clone();
         let headers = headers.clone();
@@ -1261,10 +1259,8 @@ pub async fn check_channel_status_with_debug(
                         drm_system,
                     } => {
                         let status = if drm_system.is_some() {
-                            log::info!("Channel DRM-protected: {}", url);
                             ChannelStatus::Drm
                         } else {
-                            log::info!("Channel alive: {}", url);
                             ChannelStatus::Alive
                         };
                         return Ok(AttemptOutcome {
@@ -1283,7 +1279,6 @@ pub async fn check_channel_status_with_debug(
                         stream_url,
                         latency_ms,
                     } => {
-                        log::info!("Channel placeholder: {}", url);
                         return Ok(AttemptOutcome {
                             status: ChannelStatus::Placeholder,
                             stream_url,
@@ -1297,7 +1292,6 @@ pub async fn check_channel_status_with_debug(
                         });
                     }
                     VerifyResult::Dead { latency_ms, reason } => {
-                        log::info!("Channel dead: {}", url);
                         return Ok(AttemptOutcome {
                             status: ChannelStatus::Dead,
                             stream_url: None,
@@ -1311,7 +1305,6 @@ pub async fn check_channel_status_with_debug(
                         });
                     }
                     VerifyResult::Geoblocked { latency_ms, reason } => {
-                        log::info!("Channel geoblocked: {}", url);
                         return Ok(AttemptOutcome {
                             status: ChannelStatus::Geoblocked,
                             stream_url: None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -802,7 +802,7 @@ export default function App() {
       const playlistPath = paths.find((path) => isPlaylistLikePath(path));
 
       if (!playlistPath) {
-        getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.");
+        getStore().setMenuInfo("Dropped file is not an M3U/M3U8 playlist.", "warn");
         return;
       }
 

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, CircleAlert, CircleCheck, Download, Info, LoaderCircle } f
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type ExportScope, exportScopeFileSuffix, exportScopeLabel } from "../lib/exportScope";
 import { HapticFeedbackPattern, PerformanceTime, triggerHaptic } from "../lib/haptics";
+import { logger } from "../lib/logger";
 import { isScanActive, type ScanState } from "../lib/scanState";
 import { readStoredVisibleColumnOrder } from "../lib/tableColumns";
 import { exportCsv, exportM3u, exportRenamed, exportScanLogJson, exportSplit } from "../lib/tauri";
@@ -24,6 +25,11 @@ interface ExportMenuProps {
   isMac?: boolean;
 }
 
+interface ExportFeedback {
+  kind: "success" | "error" | "info";
+  message: string;
+}
+
 export function ExportMenu({
   scopeCounts,
   resolveScopeResults,
@@ -41,10 +47,7 @@ export function ExportMenu({
   const [busyAction, setBusyAction] = useState<
     "csv" | "split" | "renamed" | "m3u" | "scanlog" | null
   >(null);
-  const [feedback, setFeedback] = useState<{
-    kind: "success" | "error" | "info";
-    message: string;
-  } | null>(null);
+  const [feedback, setFeedback] = useState<ExportFeedback | null>(null);
   const [scope, setScope] = useState<ExportScope>("all");
   const ref = useRef<HTMLDivElement>(null);
   const lastMenuRequestId = useRef<number | null>(null);
@@ -78,6 +81,16 @@ export function ExportMenu({
     : sourceFileName;
   const partialSuffix = isPartial ? "_partial" : "";
 
+  const showFeedback = useCallback((next: ExportFeedback) => {
+    setFeedback(next);
+    const message = `[Export] ${next.message}`;
+    if (next.kind === "error") {
+      logger.error(message);
+    } else {
+      logger.info(message);
+    }
+  }, []);
+
   const resolveScopedResults = useCallback((): ChannelResult[] | null => {
     const scoped = resolveScopeResults(scope);
     if (scoped.length > 0) {
@@ -85,25 +98,25 @@ export function ExportMenu({
     }
 
     if (scope === "selected") {
-      setFeedback({
+      showFeedback({
         kind: "info",
         message: "No selected channels to export.",
       });
       return null;
     }
     if (scope === "filtered") {
-      setFeedback({
+      showFeedback({
         kind: "info",
         message: "No channels match the current filters.",
       });
       return null;
     }
-    setFeedback({
+    showFeedback({
       kind: "info",
       message: "No channels available to export.",
     });
     return null;
-  }, [scope, resolveScopeResults]);
+  }, [scope, resolveScopeResults, showFeedback]);
 
   const handleExportCsv = useCallback(async () => {
     const scoped = resolveScopedResults();
@@ -115,11 +128,14 @@ export function ExportMenu({
       filters: [{ name: "CSV", extensions: ["csv"] }],
     });
     if (!path) {
-      setFeedback({ kind: "info", message: "Export CSV cancelled." });
+      showFeedback({ kind: "info", message: "Export CSV cancelled." });
       return;
     }
 
     setBusyAction("csv");
+    logger.info(
+      `[Export] Starting ${exportScopeLabel(scope)} CSV export: channels=${scoped.length}, path=${path}`,
+    );
     try {
       await exportCsv(
         scoped,
@@ -127,20 +143,20 @@ export function ExportMenu({
         playlistName,
         readStoredVisibleColumnOrder().includes("latency"),
       );
-      setFeedback({
+      showFeedback({
         kind: "success",
         message: `Exported ${exportScopeLabel(scope)} CSV (${scoped.length} channels) to ${path}.`,
       });
       void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.Now);
     } catch (err) {
-      setFeedback({
+      showFeedback({
         kind: "error",
         message: `CSV export failed: ${String(err)}`,
       });
     } finally {
       setBusyAction(null);
     }
-  }, [playlistName, scope, resolveScopedResults]);
+  }, [playlistName, scope, resolveScopedResults, showFeedback]);
 
   const handleExportSplit = useCallback(async () => {
     const scoped = resolveScopedResults();
@@ -148,22 +164,25 @@ export function ExportMenu({
 
     setOpen(false);
     setBusyAction("split");
+    logger.info(
+      `[Export] Starting ${exportScopeLabel(scope)} split export: channels=${scoped.length}, source=${playlistPath}`,
+    );
     try {
       await exportSplit(scoped, playlistPath);
-      setFeedback({
+      showFeedback({
         kind: "success",
         message: `Exported ${exportScopeLabel(scope)} split playlists (${scoped.length} channels) to ${sourceDir}.`,
       });
       void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.Now);
     } catch (err) {
-      setFeedback({
+      showFeedback({
         kind: "error",
         message: `Split export failed: ${String(err)}`,
       });
     } finally {
       setBusyAction(null);
     }
-  }, [playlistPath, scope, sourceDir, resolveScopedResults]);
+  }, [playlistPath, scope, sourceDir, resolveScopedResults, showFeedback]);
 
   const handleExportRenamed = useCallback(async () => {
     const scoped = resolveScopedResults();
@@ -171,22 +190,25 @@ export function ExportMenu({
 
     setOpen(false);
     setBusyAction("renamed");
+    logger.info(
+      `[Export] Starting ${exportScopeLabel(scope)} renamed-playlist export: channels=${scoped.length}, source=${playlistPath}`,
+    );
     try {
       await exportRenamed(scoped, playlistPath);
-      setFeedback({
+      showFeedback({
         kind: "success",
         message: `Exported ${exportScopeLabel(scope)} renamed playlist (${scoped.length} channels) to ${sourceDir}/${sourceStem}_renamed.m3u8.`,
       });
       void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.Now);
     } catch (err) {
-      setFeedback({
+      showFeedback({
         kind: "error",
         message: `Renamed export failed: ${String(err)}`,
       });
     } finally {
       setBusyAction(null);
     }
-  }, [playlistPath, scope, sourceDir, sourceStem, resolveScopedResults]);
+  }, [playlistPath, scope, sourceDir, sourceStem, resolveScopedResults, showFeedback]);
 
   const handleExportM3u = useCallback(async () => {
     const scoped = resolveScopedResults();
@@ -199,31 +221,34 @@ export function ExportMenu({
       filters: [{ name: "M3U Playlist", extensions: ["m3u8", "m3u"] }],
     });
     if (!path) {
-      setFeedback({ kind: "info", message: "M3U export cancelled." });
+      showFeedback({ kind: "info", message: "M3U export cancelled." });
       return;
     }
 
     setBusyAction("m3u");
+    logger.info(
+      `[Export] Starting ${exportScopeLabel(scope)} M3U export: channels=${scoped.length}, path=${path}`,
+    );
     try {
       await exportM3u(scoped, path);
-      setFeedback({
+      showFeedback({
         kind: "success",
         message: `Exported ${exportScopeLabel(scope)} M3U (${scoped.length} channels) to ${path}.`,
       });
       void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.Now);
     } catch (err) {
-      setFeedback({
+      showFeedback({
         kind: "error",
         message: `M3U export failed: ${String(err)}`,
       });
     } finally {
       setBusyAction(null);
     }
-  }, [scope, sourceStem, resolveScopedResults]);
+  }, [scope, sourceStem, resolveScopedResults, showFeedback]);
 
   const handleExportScanLog = useCallback(async () => {
     if (scanState === "idle") {
-      setFeedback({
+      showFeedback({
         kind: "info",
         message: "Run a scan first to generate a scan log.",
       });
@@ -236,27 +261,28 @@ export function ExportMenu({
       filters: [{ name: "JSON", extensions: ["json"] }],
     });
     if (!path) {
-      setFeedback({ kind: "info", message: "Scan log export cancelled." });
+      showFeedback({ kind: "info", message: "Scan log export cancelled." });
       return;
     }
 
     setBusyAction("scanlog");
+    logger.info(`[Export] Starting structured scan log export: path=${path}`);
     try {
       await exportScanLogJson(path);
-      setFeedback({
+      showFeedback({
         kind: "success",
         message: `Exported structured scan log to ${path}.`,
       });
       void triggerHaptic(HapticFeedbackPattern.Generic, PerformanceTime.Now);
     } catch (err) {
-      setFeedback({
+      showFeedback({
         kind: "error",
         message: `Scan log export failed: ${String(err)}`,
       });
     } finally {
       setBusyAction(null);
     }
-  }, [scanState, sourceStem]);
+  }, [scanState, sourceStem, showFeedback]);
 
   const exporting = busyAction !== null;
 

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -733,27 +733,38 @@ export function usePlaylistSources({
     async (draft: SavedPlaylistDraft) => {
       const action = draft.id ? "Updating" : "Saving";
       logger.info(`[Saved Playlists] ${action} "${draft.display_name}"`);
-      try {
-        const result = await upsertSavedPlaylist(draft);
-        getStore().setSavedPlaylists(result.entries);
-        setSavedPlaylistEditorDraft(null);
-        void refreshRecentPlaylists();
-
-        const state = getStore();
-        const currentPlaylist = state.playlist;
-        const currentSaved = currentPlaylist?.saved_playlist_id ?? null;
-        const currentMatch = findSavedPlaylistForCurrentSource(
-          result.entries,
-          state.currentSourceDescriptor,
-          currentSaved,
-        );
-        if (currentMatch && currentMatch.id === result.entry.id) {
-          await openSavedPlaylistById(result.entry.id);
-        }
-        logger.info(`[Saved Playlists] Saved "${result.entry.display_name}"`);
-      } catch (err) {
+      const result = await upsertSavedPlaylist(draft).catch((err: unknown) => {
         logger.error(`[Saved Playlists] Failed to save "${draft.display_name}":`, err);
         throw err;
+      });
+
+      getStore().setSavedPlaylists(result.entries);
+      setSavedPlaylistEditorDraft(null);
+      void refreshRecentPlaylists();
+      logger.info(`[Saved Playlists] Saved "${result.entry.display_name}"`);
+
+      const state = getStore();
+      const currentPlaylist = state.playlist;
+      const currentSaved = currentPlaylist?.saved_playlist_id ?? null;
+      const currentMatch = findSavedPlaylistForCurrentSource(
+        result.entries,
+        state.currentSourceDescriptor,
+        currentSaved,
+      );
+      if (currentMatch && currentMatch.id === result.entry.id) {
+        try {
+          const reloadResult = await openSavedPlaylistById(result.entry.id);
+          if (reloadResult !== true) {
+            logger.warn(
+              `[Saved Playlists] Saved "${result.entry.display_name}", but failed to reload the current source: ${reloadResult}`,
+            );
+          }
+        } catch (err) {
+          logger.warn(
+            `[Saved Playlists] Saved "${result.entry.display_name}", but failed to reload the current source:`,
+            err,
+          );
+        }
       }
     },
     [openSavedPlaylistById, refreshRecentPlaylists],

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -1,11 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  errorToString,
-  formatPlaylistOpenError,
-  formatSourceReloadError,
-  redactUrlCredentials,
-} from "../lib/errors";
+import { errorToString, formatPlaylistOpenError, formatSourceReloadError } from "../lib/errors";
 import { logger } from "../lib/logger";
 import { parseXtreamRecent, serializeXtreamRecent } from "../lib/recentPlaylists";
 import {
@@ -156,8 +151,8 @@ export function usePlaylistSources({
     try {
       const entries = await getRecentPlaylists();
       getStore().setRecentPlaylists(entries);
-    } catch {
-      // Ignore recent-list load failures.
+    } catch (err) {
+      logger.warn("[Recent Playlists] Failed to load entries:", errorToString(err));
     }
   }, []);
 
@@ -166,7 +161,8 @@ export function usePlaylistSources({
       const entries = await getSavedPlaylists();
       getStore().setSavedPlaylists(entries);
       return entries;
-    } catch {
+    } catch (err) {
+      logger.warn("[Saved Playlists] Failed to load entries:", errorToString(err));
       return [];
     }
   }, []);
@@ -175,8 +171,9 @@ export function usePlaylistSources({
     try {
       const entries = await clearRecentPlaylists();
       getStore().setRecentPlaylists(entries);
-    } catch {
-      // Ignore clear failures.
+      logger.info("[Recent Playlists] Cleared entries");
+    } catch (err) {
+      logger.warn("[Recent Playlists] Failed to clear entries:", errorToString(err));
     }
   }, []);
 
@@ -277,11 +274,6 @@ export function usePlaylistSources({
       const loadGeneration = sourceLoadGenerationRef.current + 1;
       sourceLoadGenerationRef.current = loadGeneration;
       const isCurrentLoad = () => sourceLoadGenerationRef.current === loadGeneration;
-      const supersededResult = (): LoadAndCommitSourceResult => ({
-        ok: false,
-        error: "",
-        superseded: true,
-      });
 
       const normalizedSourceFilter = normalizeSourceFilter(channelSearch);
       const currentSourceFilterError = validateSourceFilterPattern(normalizedSourceFilter);
@@ -293,30 +285,42 @@ export function usePlaylistSources({
         getStore().setPlaylistOpenError(error);
         getStore().setPlaylistLoading(false);
         getStore().setPlaylistLoadProgress(null);
+        logger.warn(`[Playlist] Load rejected: ${error}`);
         return { ok: false, error, superseded: false };
       }
 
+      const loadStartedAt = performance.now();
       const sourceLabel = (() => {
         switch (descriptor.kind) {
           case "path":
             return `path=${descriptor.path}`;
           case "url":
-            return `url=${redactUrlCredentials(descriptor.url)}`;
+            return `url=${descriptor.url}`;
           case "saved":
             return `saved id=${descriptor.id}`;
           case "xtream":
-            return `xtream server=${redactUrlCredentials(descriptor.server)}, username=***`;
+            return `xtream server=${descriptor.server}, username=***`;
           case "stalker":
-            return `stalker portal=${redactUrlCredentials(descriptor.portal)}, mac=***`;
+            return `stalker portal=${descriptor.portal}, mac=***`;
         }
       })();
       const loadingAction =
         mode === "reapplySourceFilter" ? "Reloading source with source filter" : "Opening source";
+      const supersededResult = (): LoadAndCommitSourceResult => {
+        logger.info(
+          `[Playlist] ${loadingAction} superseded after ${((performance.now() - loadStartedAt) / 1000).toFixed(1)}s: ${sourceLabel}`,
+        );
+        return {
+          ok: false,
+          error: "",
+          superseded: true,
+        };
+      };
 
       getStore().setPlaylistOpenError(null);
       getStore().setPlaylistLoadProgress(null);
       getStore().setPlaylistLoading(true);
-      logger.info(`[App] ${loadingAction}: ${sourceLabel}`);
+      logger.info(`[Playlist] ${loadingAction}: ${sourceLabel}`);
 
       try {
         const state = getStore();
@@ -372,6 +376,9 @@ export function usePlaylistSources({
         if (!committed) {
           return supersededResult();
         }
+        logger.info(
+          `[Playlist] Loaded ${safeFileName}: visible=${preview.channels.length}, total=${cachedPreview.total_channels}, groups=${preview.groups.length}, preview=${canReuseCachedPreview ? "memory-cache" : "fresh"}, elapsed=${((performance.now() - loadStartedAt) / 1000).toFixed(1)}s`,
+        );
         return { ok: true, preview };
       } catch (err) {
         if (!isCurrentLoad()) {
@@ -380,8 +387,8 @@ export function usePlaylistSources({
 
         logger.error(
           mode === "reapplySourceFilter"
-            ? "[App] Failed to reload source with source filter"
-            : "[App] Failed to open source",
+            ? `[Playlist] Failed to reload source with source filter after ${((performance.now() - loadStartedAt) / 1000).toFixed(1)}s:`
+            : `[Playlist] Failed to open source after ${((performance.now() - loadStartedAt) / 1000).toFixed(1)}s:`,
           err,
         );
         const message =
@@ -531,8 +538,8 @@ export function usePlaylistSources({
           savedEntry.id,
         );
         getStore().setRecentPlaylists(entries);
-      } catch {
-        // Ignore recent-list update failures.
+      } catch (err) {
+        logger.warn("[Recent Playlists] Failed to record saved playlist:", errorToString(err));
       }
 
       return true;
@@ -556,8 +563,8 @@ export function usePlaylistSources({
       try {
         const entries = await addRecentPlaylist("file", selectedPath, null, null);
         getStore().setRecentPlaylists(entries);
-      } catch {
-        // Ignore recent-list update failures.
+      } catch (err) {
+        logger.warn("[Recent Playlists] Failed to record file playlist:", errorToString(err));
       }
     },
     [loadAndCommitSource],
@@ -606,8 +613,8 @@ export function usePlaylistSources({
       try {
         const entries = await addRecentPlaylist("url", url, null, null);
         getStore().setRecentPlaylists(entries);
-      } catch {
-        // Ignore recent-list update failures.
+      } catch (err) {
+        logger.warn("[Recent Playlists] Failed to record URL playlist:", errorToString(err));
       }
 
       return true;
@@ -640,8 +647,7 @@ export function usePlaylistSources({
           Math.min(20, Math.round(result.preview.xtream_max_connections)),
         );
         const message = `Xtream max connections detected: ${result.preview.xtream_max_connections}. Scan concurrency will use ${effectiveConcurrency}.`;
-        logger.warn(message);
-        getStore().setMenuInfo(message);
+        getStore().setMenuInfo(message, "warn");
       }
 
       try {
@@ -656,8 +662,8 @@ export function usePlaylistSources({
           null,
         );
         getStore().setRecentPlaylists(entries);
-      } catch {
-        // Ignore recent-list update failures.
+      } catch (err) {
+        logger.warn("[Recent Playlists] Failed to record Xtream playlist:", errorToString(err));
       }
 
       return true;
@@ -725,21 +731,29 @@ export function usePlaylistSources({
 
   const handleSavePlaylistDraft = useCallback(
     async (draft: SavedPlaylistDraft) => {
-      const result = await upsertSavedPlaylist(draft);
-      getStore().setSavedPlaylists(result.entries);
-      setSavedPlaylistEditorDraft(null);
-      void refreshRecentPlaylists();
+      const action = draft.id ? "Updating" : "Saving";
+      logger.info(`[Saved Playlists] ${action} "${draft.display_name}"`);
+      try {
+        const result = await upsertSavedPlaylist(draft);
+        getStore().setSavedPlaylists(result.entries);
+        setSavedPlaylistEditorDraft(null);
+        void refreshRecentPlaylists();
 
-      const state = getStore();
-      const currentPlaylist = state.playlist;
-      const currentSaved = currentPlaylist?.saved_playlist_id ?? null;
-      const currentMatch = findSavedPlaylistForCurrentSource(
-        result.entries,
-        state.currentSourceDescriptor,
-        currentSaved,
-      );
-      if (currentMatch && currentMatch.id === result.entry.id) {
-        await openSavedPlaylistById(result.entry.id);
+        const state = getStore();
+        const currentPlaylist = state.playlist;
+        const currentSaved = currentPlaylist?.saved_playlist_id ?? null;
+        const currentMatch = findSavedPlaylistForCurrentSource(
+          result.entries,
+          state.currentSourceDescriptor,
+          currentSaved,
+        );
+        if (currentMatch && currentMatch.id === result.entry.id) {
+          await openSavedPlaylistById(result.entry.id);
+        }
+        logger.info(`[Saved Playlists] Saved "${result.entry.display_name}"`);
+      } catch (err) {
+        logger.error(`[Saved Playlists] Failed to save "${draft.display_name}":`, err);
+        throw err;
       }
     },
     [openSavedPlaylistById, refreshRecentPlaylists],
@@ -765,8 +779,9 @@ export function usePlaylistSources({
           state.setCurrentSourceDescriptor(fallbackDescriptor);
           patchCurrentPlaylistMetadata(state.playlist.file_name, null);
         }
+        logger.info(`[Saved Playlists] Deleted "${deletedEntry?.display_name ?? id}"`);
       } catch (err) {
-        getStore().setMenuInfo(errorToString(err));
+        getStore().setMenuInfo(errorToString(err), "error");
       }
     },
     [patchCurrentPlaylistMetadata, refreshRecentPlaylists],
@@ -794,8 +809,11 @@ export function usePlaylistSources({
         if (state.playlist?.saved_playlist_id === entry.id) {
           await openSavedPlaylistById(entry.id);
         }
+        logger.info(
+          `[Saved Playlists] Preferred Xtream server updated for "${entry.display_name}": ${server}`,
+        );
       } catch (err) {
-        getStore().setMenuInfo(errorToString(err));
+        getStore().setMenuInfo(errorToString(err), "error");
       }
     },
     [openSavedPlaylistById],
@@ -851,7 +869,7 @@ export function usePlaylistSources({
       if (entry.kind === "xtream") {
         const source = parseXtreamRecent(entry.value);
         if (!source) {
-          getStore().setMenuInfo("This Xtream recent entry is invalid.");
+          getStore().setMenuInfo("This Xtream recent entry is invalid.", "warn");
           void refreshRecentPlaylists();
           return;
         }

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -97,9 +97,13 @@ export function useUpdateCheck(): {
         }
       } catch (err) {
         if (!isCurrentRequest()) return;
-        logger.error("[Update] Check failed:", errorToString(err));
         if (force) {
-          getStore().setMenuInfo(`Update check failed: ${updateFailureDetail(errorToString(err))}`);
+          getStore().setMenuInfo(
+            `Update check failed: ${updateFailureDetail(errorToString(err))}`,
+            "error",
+          );
+        } else {
+          logger.error("[Update] Check failed:", errorToString(err));
         }
       } finally {
         // Only clear our own phase: an install may have started while this
@@ -127,9 +131,9 @@ export function useUpdateCheck(): {
       try {
         await openManualUpdate();
       } catch (err) {
-        logger.error("[Update] Failed to open the update page:", errorToString(err));
         getStore().setMenuInfo(
           `Could not open the update page: ${updateFailureDetail(errorToString(err))}`,
+          "error",
         );
       }
       return;
@@ -144,8 +148,10 @@ export function useUpdateCheck(): {
         getStore().setMenuInfo("IPTV Checker is already up to date.");
       }
     } catch (err) {
-      logger.error("[Update] Install failed:", errorToString(err));
-      getStore().setMenuInfo(`Update install failed: ${updateFailureDetail(errorToString(err))}`);
+      getStore().setMenuInfo(
+        `Update install failed: ${updateFailureDetail(errorToString(err))}`,
+        "error",
+      );
     } finally {
       getStore().setUpdatePhase("idle");
     }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -31,7 +31,7 @@ function parseLogLevel(raw: unknown): LogLevel | null {
   return null;
 }
 
-const DEFAULT_LOG_LEVEL: LogLevel = import.meta.env.DEV ? "debug" : "error";
+const DEFAULT_LOG_LEVEL: LogLevel = import.meta.env.DEV ? "debug" : "info";
 const CONFIGURED_LEVEL = parseLogLevel(import.meta.env.VITE_LOG_LEVEL);
 const ACTIVE_LOG_LEVEL = CONFIGURED_LEVEL ?? DEFAULT_LOG_LEVEL;
 

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import { logger } from "../../lib/logger";
 import { inferPlatformFromNavigator } from "../../lib/platform";
 import { isScanActive } from "../../lib/scanState";
 import type { AppStore, UiSlice } from "../types";
@@ -90,7 +91,12 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
   setErrorDismissed: (errorDismissed) => set({ errorDismissed }),
   setPlaybackError: (playbackError) => set({ playbackError }),
   setScanInputError: (scanInputError) => set({ scanInputError }),
-  setMenuInfo: (menuInfo) => set({ menuInfo }),
+  setMenuInfo: (menuInfo, logLevel = "info") => {
+    set({ menuInfo });
+    if (menuInfo) {
+      logger[logLevel](`[Notice] ${menuInfo}`);
+    }
+  },
   setMenuExportRequest: (menuExportRequest) => set({ menuExportRequest }),
   queueMenuExportRequest: (action) =>
     set((state) => ({

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -179,7 +179,7 @@ export interface UiSlice {
   setErrorDismissed: (dismissed: boolean) => void;
   setPlaybackError: (error: string | null) => void;
   setScanInputError: (error: string | null) => void;
-  setMenuInfo: (info: string | null) => void;
+  setMenuInfo: (info: string | null, logLevel?: "info" | "warn" | "error") => void;
   setMenuExportRequest: (request: MenuExportRequest | null) => void;
   queueMenuExportRequest: (action: MenuExportRequest["action"]) => void;
   setUpdateNotice: (notice: UpdateNotice | null) => void;


### PR DESCRIPTION
Release builds were suppressing frontend INFO and WARN entries, while transient UI notices and operation lifecycle events were not consistently written to the log. This made expected entries such as playlist loading and Xtream connection warnings disappear.

This enables production INFO and WARN logs, adds lifecycle summaries for playlist loads, scans, quick checks, exports, and saved playlists, and automatically mirrors transient notices at their displayed severity. Per-channel scan output is consolidated into one entry while retaining the full stream URL.

Validation:
- 107 frontend tests
- 286 Rust tests
- TypeScript typecheck
- Rust check and formatting
- Biome lint
- Production build

Ref #224