### PR TITLE
Add configurable external player

### DIFF
--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -18,6 +18,31 @@ const TEMP_PLAYLIST_DELETE_DELAY: std::time::Duration = std::time::Duration::fro
 const STALE_TEMP_PLAYLIST_MAX_AGE: std::time::Duration =
     std::time::Duration::from_secs(6 * 60 * 60);
 
+#[cfg(target_os = "linux")]
+const APPIMAGE_RUNTIME_ENV_VARS: [&str; 15] = [
+    "APPDIR",
+    "APPIMAGE",
+    "ARGV0",
+    "OWD",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "GTK_PATH",
+    "GDK_PIXBUF_MODULEDIR",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GI_TYPELIB_PATH",
+    "GST_PLUGIN_PATH",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_SCANNER",
+    "QT_PLUGIN_PATH",
+    "QML2_IMPORT_PATH",
+];
+
+#[derive(Debug)]
+struct CustomPlayerCommand {
+    command: Command,
+    wait_for_handoff: bool,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct PlayerChannel {
     pub extinf_line: String,
@@ -57,7 +82,7 @@ fn open_with_system_default(path: &Path) -> Result<(), AppError> {
 fn build_custom_player_command(
     player_path: &Path,
     playlist_path: &Path,
-) -> Result<Command, AppError> {
+) -> Result<CustomPlayerCommand, AppError> {
     let metadata = std::fs::metadata(player_path).map_err(|error| {
         AppError::Other(format!(
             "External player is unavailable at {}: {}",
@@ -75,7 +100,10 @@ fn build_custom_player_command(
     {
         let mut command = Command::new("open");
         command.arg("-a").arg(player_path).arg(playlist_path);
-        return Ok(command);
+        return Ok(CustomPlayerCommand {
+            command,
+            wait_for_handoff: true,
+        });
     }
 
     if !metadata.is_file() {
@@ -87,24 +115,77 @@ fn build_custom_player_command(
 
     let mut command = Command::new(player_path);
     command.arg(playlist_path);
-    Ok(command)
+
+    #[cfg(target_os = "linux")]
+    sanitize_appimage_environment(&mut command, std::env::var_os("APPIMAGE").is_some());
+
+    Ok(CustomPlayerCommand {
+        command,
+        wait_for_handoff: false,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn sanitize_appimage_environment(command: &mut Command, running_as_appimage: bool) {
+    if !running_as_appimage {
+        return;
+    }
+
+    for name in APPIMAGE_RUNTIME_ENV_VARS {
+        command.env_remove(name);
+    }
+}
+
+fn launch_error(player_path: &Path, error: impl std::fmt::Display) -> AppError {
+    AppError::Other(format!(
+        "Failed to launch external player at {}: {}",
+        player_path.display(),
+        error
+    ))
 }
 
 fn open_with_custom_player(player_path: &Path, playlist_path: &Path) -> Result<(), AppError> {
-    let mut command = build_custom_player_command(player_path, playlist_path)?;
+    let CustomPlayerCommand {
+        mut command,
+        wait_for_handoff,
+    } = build_custom_player_command(player_path, playlist_path)?;
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map(|_| ())
-        .map_err(|error| {
-            AppError::Other(format!(
-                "Failed to launch external player at {}: {}",
-                player_path.display(),
-                error
+        .stderr(Stdio::null());
+
+    if wait_for_handoff {
+        let status = command
+            .status()
+            .map_err(|error| launch_error(player_path, error))?;
+        return if status.success() {
+            Ok(())
+        } else {
+            Err(launch_error(
+                player_path,
+                format!("launcher exited with {status}"),
             ))
-        })
+        };
+    }
+
+    let child = command
+        .spawn()
+        .map_err(|error| launch_error(player_path, error))?;
+
+    #[cfg(unix)]
+    {
+        let mut child = child;
+        let _ = std::thread::spawn(move || {
+            if let Err(error) = child.wait() {
+                log::warn!("Failed to reap external player process: {error}");
+            }
+        });
+    }
+
+    #[cfg(not(unix))]
+    drop(child);
+
+    Ok(())
 }
 
 fn write_unique_temp_playlist(content: &str) -> Result<PathBuf, AppError> {
@@ -259,6 +340,8 @@ mod tests {
         cleanup_stale_temp_playlists_in_dir, is_temp_playlist_file, spawn_temp_playlist_cleanup,
         write_unique_temp_playlist_in_dir,
     };
+    #[cfg(target_os = "linux")]
+    use super::{sanitize_appimage_environment, APPIMAGE_RUNTIME_ENV_VARS};
     #[cfg(target_os = "macos")]
     use std::ffi::OsStr;
     use std::time::{Duration, SystemTime};
@@ -299,12 +382,13 @@ mod tests {
         let playlist = root.join("channel with spaces.m3u8");
         std::fs::write(&player, "test").expect("Failed to create fake player");
 
-        let command = build_custom_player_command(&player, &playlist)
+        let built = build_custom_player_command(&player, &playlist)
             .expect("Custom player command should be created");
 
-        assert_eq!(command.get_program(), player.as_os_str());
+        assert!(!built.wait_for_handoff);
+        assert_eq!(built.command.get_program(), player.as_os_str());
         assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
+            built.command.get_args().collect::<Vec<_>>(),
             vec![playlist.as_os_str()]
         );
 
@@ -319,12 +403,13 @@ mod tests {
         let playlist = root.join("channel.m3u8");
         std::fs::create_dir_all(&player).expect("Failed to create fake app bundle");
 
-        let command = build_custom_player_command(&player, &playlist)
+        let built = build_custom_player_command(&player, &playlist)
             .expect("macOS app command should be created");
 
-        assert_eq!(command.get_program(), OsStr::new("open"));
+        assert!(built.wait_for_handoff);
+        assert_eq!(built.command.get_program(), OsStr::new("open"));
         assert_eq!(
-            command.get_args().collect::<Vec<_>>(),
+            built.command.get_args().collect::<Vec<_>>(),
             vec![OsStr::new("-a"), player.as_os_str(), playlist.as_os_str()]
         );
 
@@ -338,6 +423,19 @@ mod tests {
             .expect_err("Missing custom player should be rejected");
 
         assert!(error.to_string().contains("External player is unavailable"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn appimage_environment_is_removed_from_custom_player_commands() {
+        let mut command = std::process::Command::new("player");
+        sanitize_appimage_environment(&mut command, true);
+
+        for name in APPIMAGE_RUNTIME_ENV_VARS {
+            assert!(command
+                .get_envs()
+                .any(|(key, value)| key == std::ffi::OsStr::new(name) && value.is_none()));
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/player.rs
+++ b/src-tauri/src/commands/player.rs
@@ -1,11 +1,15 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
+use tauri::Manager;
 
 use crate::error::AppError;
+use crate::state::AppState;
 
 static NEXT_TEMP_PLAYLIST_ID: AtomicU64 = AtomicU64::new(0);
 const TEMP_PLAYLIST_PREFIX: &str = "iptv-checker-single-channel-";
@@ -48,6 +52,59 @@ fn open_with_system_default(path: &Path) -> Result<(), AppError> {
             "Failed to open playlist with system default player".to_string(),
         ))
     }
+}
+
+fn build_custom_player_command(
+    player_path: &Path,
+    playlist_path: &Path,
+) -> Result<Command, AppError> {
+    let metadata = std::fs::metadata(player_path).map_err(|error| {
+        AppError::Other(format!(
+            "External player is unavailable at {}: {}",
+            player_path.display(),
+            error
+        ))
+    })?;
+
+    #[cfg(target_os = "macos")]
+    if metadata.is_dir()
+        && player_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("app"))
+    {
+        let mut command = Command::new("open");
+        command.arg("-a").arg(player_path).arg(playlist_path);
+        return Ok(command);
+    }
+
+    if !metadata.is_file() {
+        return Err(AppError::Other(format!(
+            "External player path does not point to an application: {}",
+            player_path.display()
+        )));
+    }
+
+    let mut command = Command::new(player_path);
+    command.arg(playlist_path);
+    Ok(command)
+}
+
+fn open_with_custom_player(player_path: &Path, playlist_path: &Path) -> Result<(), AppError> {
+    let mut command = build_custom_player_command(player_path, playlist_path)?;
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| {
+            AppError::Other(format!(
+                "Failed to launch external player at {}: {}",
+                player_path.display(),
+                error
+            ))
+        })
 }
 
 fn write_unique_temp_playlist(content: &str) -> Result<PathBuf, AppError> {
@@ -140,7 +197,10 @@ fn spawn_temp_playlist_cleanup(
 }
 
 #[tauri::command]
-pub async fn open_channel_in_player(channel: PlayerChannel) -> Result<(), AppError> {
+pub async fn open_channel_in_player(
+    app: tauri::AppHandle,
+    channel: PlayerChannel,
+) -> Result<(), AppError> {
     let mut content = String::from("#EXTM3U\n");
     content.push_str(channel.extinf_line.trim_end());
     content.push('\n');
@@ -163,7 +223,17 @@ pub async fn open_channel_in_player(channel: PlayerChannel) -> Result<(), AppErr
         log::error!("Failed to write temp playlist for external player: {error}");
         error
     })?;
-    match open_with_system_default(&temp_path) {
+    let external_player_path = {
+        let state = app.state::<Arc<AppState>>();
+        let settings = state.settings.lock().await;
+        settings.external_player_path.clone()
+    };
+    let open_result = match external_player_path.as_deref() {
+        Some(player_path) => open_with_custom_player(Path::new(player_path), &temp_path),
+        None => open_with_system_default(&temp_path),
+    };
+
+    match open_result {
         Ok(()) => {
             log::info!("Opened channel in external player");
             let _ = spawn_temp_playlist_cleanup(temp_path, TEMP_PLAYLIST_DELETE_DELAY);
@@ -185,9 +255,12 @@ pub async fn get_streaming_proxy_port(app: tauri::AppHandle) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_unique_temp_playlist_path, cleanup_stale_temp_playlists_in_dir,
-        is_temp_playlist_file, spawn_temp_playlist_cleanup, write_unique_temp_playlist_in_dir,
+        build_custom_player_command, build_unique_temp_playlist_path,
+        cleanup_stale_temp_playlists_in_dir, is_temp_playlist_file, spawn_temp_playlist_cleanup,
+        write_unique_temp_playlist_in_dir,
     };
+    #[cfg(target_os = "macos")]
+    use std::ffi::OsStr;
     use std::time::{Duration, SystemTime};
 
     fn test_temp_dir(prefix: &str) -> std::path::PathBuf {
@@ -211,6 +284,60 @@ mod tests {
             .to_string_lossy()
             .starts_with("iptv-checker-single-channel-"));
         assert_eq!(first.extension().and_then(|ext| ext.to_str()), Some("m3u8"));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn custom_player_command_passes_playlist_as_one_argument() {
+        let root = test_temp_dir("iptv-player-custom-command");
+        std::fs::create_dir_all(&root).expect("Failed to create test directory");
+        let player = root.join(if cfg!(target_os = "windows") {
+            "Player With Spaces.exe"
+        } else {
+            "player with spaces"
+        });
+        let playlist = root.join("channel with spaces.m3u8");
+        std::fs::write(&player, "test").expect("Failed to create fake player");
+
+        let command = build_custom_player_command(&player, &playlist)
+            .expect("Custom player command should be created");
+
+        assert_eq!(command.get_program(), player.as_os_str());
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![playlist.as_os_str()]
+        );
+
+        std::fs::remove_dir_all(&root).expect("Failed to remove test directory");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_app_bundle_uses_open_application_mode() {
+        let root = test_temp_dir("iptv-player-macos-app");
+        let player = root.join("VLC.app");
+        let playlist = root.join("channel.m3u8");
+        std::fs::create_dir_all(&player).expect("Failed to create fake app bundle");
+
+        let command = build_custom_player_command(&player, &playlist)
+            .expect("macOS app command should be created");
+
+        assert_eq!(command.get_program(), OsStr::new("open"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("-a"), player.as_os_str(), playlist.as_os_str()]
+        );
+
+        std::fs::remove_dir_all(&root).expect("Failed to remove test directory");
+    }
+
+    #[test]
+    fn custom_player_command_rejects_missing_application() {
+        let root = test_temp_dir("iptv-player-missing-app");
+        let error = build_custom_player_command(&root.join("missing"), &root.join("channel.m3u8"))
+            .expect_err("Missing custom player should be rejected");
+
+        assert!(error.to_string().contains("External player is unavailable"));
     }
 
     #[test]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -178,6 +178,16 @@ fn normalize_preset_name(name: &str) -> Result<String, AppError> {
     Ok(trimmed.to_string())
 }
 
+fn validate_external_player_path(path: Option<&str>) -> Result<(), AppError> {
+    if path.is_some_and(|path| !Path::new(path).is_absolute()) {
+        return Err(AppError::Validation(
+            "External player path must be absolute".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn load_scan_presets(app: &tauri::AppHandle) -> ScanPresetCollection {
     let Ok(store) = app.store("settings.json") else {
         return ScanPresetCollection::default();
@@ -726,6 +736,8 @@ pub async fn update_settings(app: tauri::AppHandle, settings: AppSettings) -> Re
         )));
     }
 
+    validate_external_player_path(settings.external_player_path.as_deref())?;
+
     let state = app.state::<Arc<AppState>>();
     let mut current = state.settings.lock().await;
     crate::STDOUT_LOG_LEVEL.store(
@@ -1048,10 +1060,24 @@ pub fn evict_for_disk_space(
 mod tests {
     use super::{
         collect_dir_stats, normalize_preset_name, preset_index_by_name, sort_scan_presets,
-        validate_screenshot_path,
+        validate_external_player_path, validate_screenshot_path,
     };
     use crate::models::settings::{ScanPresetConfig, ScanSettingsPreset};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn external_player_path_must_be_absolute() {
+        let absolute_path = std::env::current_dir()
+            .expect("current directory should be available")
+            .join("VLC Player");
+
+        assert!(validate_external_player_path(None).is_ok());
+        assert!(validate_external_player_path(absolute_path.to_str()).is_ok());
+
+        let error = validate_external_player_path(Some("players/vlc"))
+            .expect_err("relative player path should be rejected");
+        assert!(error.to_string().contains("must be absolute"));
+    }
 
     #[test]
     fn collect_dir_stats_counts_nested_files_and_bytes() {

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -91,6 +91,9 @@ pub struct AppSettings {
     pub low_space_threshold_gb: f64,
     pub separate_placeholder_status: bool,
     pub show_header_button_text: bool,
+    /// Application used by explicit "Open in External Player" actions.
+    /// `None` preserves the operating system's file association behavior.
+    pub external_player_path: Option<String>,
     /// Keep the Xtream max-connections notice visible until it is dismissed.
     pub persistent_xtream_connection_notice: bool,
     /// Look for a signed update on launch and every six hours. Discovery only
@@ -217,6 +220,7 @@ impl Default for AppSettings {
             low_space_threshold_gb: 5.0,
             separate_placeholder_status: true,
             show_header_button_text: !cfg!(target_os = "macos"),
+            external_player_path: None,
             persistent_xtream_connection_notice: false,
             automatic_update_checks: true,
         }
@@ -287,6 +291,7 @@ mod tests {
         assert_eq!(settings.low_fps_threshold, 23.0);
         assert_eq!(settings.channel_logo_size, super::ChannelLogoSize::Small);
         assert_eq!(settings.show_header_button_text, !cfg!(target_os = "macos"));
+        assert_eq!(settings.external_player_path, None);
         // Pre-existing installs have no `title_bar` key in settings.json.
         assert_eq!(settings.title_bar, super::TitleBarPreference::Auto);
     }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -172,6 +172,7 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
   const [associationBusy, setAssociationBusy] = useState(false);
   const [associationNotice, setAssociationNotice] = useState<string | null>(null);
   const [associationError, setAssociationError] = useState<string | null>(null);
+  const [externalPlayerError, setExternalPlayerError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
@@ -321,6 +322,33 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
     if (path) {
       updateSetting("screenshots_dir", path as string, { immediate: true });
     }
+  };
+
+  const handleSelectExternalPlayer = async () => {
+    setExternalPlayerError(null);
+    try {
+      const filters =
+        platform === "macos"
+          ? [{ name: "Applications", extensions: ["app"] }]
+          : platform === "windows"
+            ? [{ name: "Applications", extensions: ["exe"] }]
+            : undefined;
+      const path = await open({
+        multiple: false,
+        title: "Choose External Player",
+        ...(filters ? { filters } : {}),
+      });
+      if (typeof path === "string") {
+        updateSetting("external_player_path", path, { immediate: true });
+      }
+    } catch (error) {
+      setExternalPlayerError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleUseSystemDefaultPlayer = () => {
+    setExternalPlayerError(null);
+    updateSetting("external_player_path", null, { immediate: true });
   };
 
   const handleClearScreenshotCache = async () => {
@@ -593,6 +621,44 @@ export function SettingsPanel({ settings, onSave }: SettingsPanelProps) {
                     <option value="hide">Hidden</option>
                   </select>
                 </div>
+              )}
+            </section>
+
+            <section className={blockClass}>
+              <div className={rowClass}>
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium">External player</p>
+                  <p
+                    className="text-[11px] text-text-tertiary mt-0.5 truncate"
+                    title={draft.external_player_path ?? "System default"}
+                  >
+                    {draft.external_player_path ??
+                      "Use the operating system default for external playback."}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    onClick={handleSelectExternalPlayer}
+                    className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                    type="button"
+                  >
+                    {draft.external_player_path ? "Change" : "Choose App"}
+                  </button>
+                  {draft.external_player_path && (
+                    <button
+                      onClick={handleUseSystemDefaultPlayer}
+                      className="macos-btn px-3 py-1.5 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
+                      type="button"
+                    >
+                      System Default
+                    </button>
+                  )}
+                </div>
+              </div>
+              {externalPlayerError && (
+                <p className="px-4 py-2 text-[11px] text-red-400 border-t border-border-subtle">
+                  {externalPlayerError}
+                </p>
               )}
             </section>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -322,6 +322,7 @@ export interface AppSettings {
   low_space_threshold_gb: number;
   separate_placeholder_status: boolean;
   show_header_button_text: boolean;
+  external_player_path: string | null;
   persistent_xtream_connection_notice: boolean;
   automatic_update_checks: boolean;
 }

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -36,6 +36,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   low_space_threshold_gb: 5.0,
   separate_placeholder_status: true,
   show_header_button_text: defaultShowHeaderButtonText,
+  external_player_path: null,
   persistent_xtream_connection_notice: false,
   automatic_update_checks: true,
 };


### PR DESCRIPTION
The external-player action currently relies entirely on the operating system file association, which can open an unrelated application.

This adds a separate External player setting and launches the selected application directly. macOS app bundles, Windows executables, and Linux executables are supported, while System Default preserves the existing behavior.

Ref #223

## Validation

- `bun run typecheck`
- `bun test tests`
- `bun run build`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- Live Tauri UI and launch-path verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional external media player setting.
  * Select a compatible player on macOS or Windows from Settings.
  * Open channel playlists with the selected player or the system default.
  * Reset the configuration to use system-default playback.
  * Supports external player launching across supported desktop platforms.

* **Bug Fixes**
  * Added validation requiring configured player paths to be absolute.
  * Added inline error messages for invalid player paths.
  * Improved handling of missing or unavailable external players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->