### PR TITLE
feat(catchup): EPG store, archive playback, and spot probes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "csv",
  "fancy-regex",
+ "flate2",
  "fs2",
  "futures",
  "libc",
@@ -2422,6 +2423,7 @@ dependencies = [
  "log",
  "mdns-sd",
  "objc2",
+ "quick-xml 0.37.5",
  "rand 0.10.2",
  "regex",
  "reqwest",
@@ -3575,7 +3577,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -3796,6 +3798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6920,7 +6931,7 @@ checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
- "quick-xml",
+ "quick-xml 0.41.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3806,6 +3806,7 @@ version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ tauri-plugin-log = "2"
 tauri-plugin-os = "2"
 base64 = "0.22.1"
 sha2 = "0.10"
-quick-xml = "0.37"
+quick-xml = { version = "0.37", features = ["encoding"] }
 flate2 = "1"
 tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,8 @@ tauri-plugin-log = "2"
 tauri-plugin-os = "2"
 base64 = "0.22.1"
 sha2 = "0.10"
+quick-xml = "0.37"
+flate2 = "1"
 tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 # rev-pinned: the fuzz crate resolves this git dep independently of the main

--- a/src-tauri/src/commands/chromecast.rs
+++ b/src-tauri/src/commands/chromecast.rs
@@ -58,6 +58,7 @@ pub async fn cast_to_device(
             app.clone(),
             request.original_url.clone(),
             request.stream_kind,
+            request.is_finite,
         )
         .await
         {
@@ -126,6 +127,7 @@ pub async fn cast_to_device(
         app.clone(),
         request.original_url.clone(),
         request.stream_kind,
+        request.is_finite,
     )
     .await?;
     let cast_url = proxy_handle.url.clone();

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -97,6 +97,8 @@ pub async fn load_epg(
 
     let mut index = EpgIndex::default();
     let mut failed_sources = Vec::new();
+    let mut failed_source_ids = HashSet::new();
+    let mut loaded_source_ids = HashSet::new();
     let mut sources_loaded = 0usize;
 
     for source in sources {
@@ -151,18 +153,30 @@ pub async fn load_epg(
         match outcome {
             Ok(partial) => {
                 index.merge(partial);
+                loaded_source_ids.insert(source);
                 sources_loaded += 1;
             }
             Err(error) => {
-                let source = epg::redact_epg_source(&source);
-                log::warn!("EPG source {source} failed: {error}");
-                failed_sources.push(source);
+                failed_source_ids.insert(source.clone());
+                let redacted_source = epg::redact_epg_source(&source);
+                log::warn!("EPG source {redacted_source} failed: {error}");
+                failed_sources.push(redacted_source);
             }
         }
     }
 
     if cancel.is_cancelled() {
         return Err(superseded_error());
+    }
+
+    if sources_loaded > 0 {
+        failed_source_ids.retain(|source| !loaded_source_ids.contains(source));
+        if !failed_source_ids.is_empty() {
+            let previous = state.epg.lock().await.clone();
+            if let Some(previous) = previous {
+                index.merge_sources_from(&previous, &failed_source_ids, &wanted);
+            }
+        }
     }
 
     let summary = EpgLoadSummary {

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -67,6 +67,7 @@ pub async fn load_epg(
                 sources_loaded += 1;
             }
             Err(error) => {
+                let source = epg::redact_epg_source(&source);
                 log::warn!("EPG source {source} failed: {error}");
                 failed_sources.push(source);
             }

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -50,10 +50,11 @@ pub async fn load_epg(
                 epg::download_epg_source(&source, &cache_dir, accept_invalid_certs, force_refresh)
                     .await?;
             let wanted = wanted.clone();
+            let source_identity = source.clone();
             tokio::task::spawn_blocking(move || {
                 let mut partial = EpgIndex::default();
                 let reader = epg::open_guide_file(&path)?;
-                epg::parse_xmltv_into(reader, &wanted, &mut partial)?;
+                epg::parse_xmltv_into_with_source(reader, &wanted, &source_identity, &mut partial)?;
                 Ok::<EpgIndex, AppError>(partial)
             })
             .await
@@ -95,12 +96,13 @@ pub async fn load_epg(
 #[tauri::command]
 pub async fn get_epg_programmes(
     state: tauri::State<'_, Arc<AppState>>,
+    sources: Vec<String>,
     tvg_id: String,
     from: i64,
     to: i64,
 ) -> Result<Vec<EpgProgramme>, AppError> {
     let index = state.epg.lock().await.clone();
     Ok(index
-        .map(|index| index.programmes_for(&tvg_id, from, to))
+        .map(|index| index.programmes_for_sources(&sources, &tvg_id, from, to))
         .unwrap_or_default())
 }

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -51,14 +51,22 @@ pub async fn load_epg(
                     .await?;
             let wanted = wanted.clone();
             let source_identity = source.clone();
-            tokio::task::spawn_blocking(move || {
+            let parse_path = path.clone();
+            let parse_result = match tokio::task::spawn_blocking(move || {
                 let mut partial = EpgIndex::default();
-                let reader = epg::open_guide_file(&path)?;
+                let reader = epg::open_guide_file(&parse_path)?;
                 epg::parse_xmltv_into_with_source(reader, &wanted, &source_identity, &mut partial)?;
                 Ok::<EpgIndex, AppError>(partial)
             })
             .await
-            .map_err(|error| AppError::Other(format!("EPG parse task failed: {error}")))?
+            {
+                Ok(result) => result,
+                Err(error) => Err(AppError::Other(format!("EPG parse task failed: {error}"))),
+            };
+            if parse_result.is_err() {
+                let _ = std::fs::remove_file(path);
+            }
+            parse_result
         }
         .await;
 

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -43,11 +43,22 @@ pub async fn load_epg(
     }
 
     let _guard = state.epg_load_lock.lock().await;
+    let sources_requested = sources.len();
+    let wanted: HashSet<String> = tvg_ids.into_iter().filter(|id| !id.is_empty()).collect();
+    if wanted.is_empty() {
+        *state.epg.lock().await = Some(Arc::new(EpgIndex::default()));
+        return Ok(EpgLoadSummary {
+            sources_requested,
+            sources_loaded: 0,
+            failed_sources: Vec::new(),
+            channels_matched: 0,
+            programme_count: 0,
+        });
+    }
+
     let accept_invalid_certs = state.settings.lock().await.accept_invalid_certs;
     let cache_dir = epg_cache_dir(&app);
-    let wanted: HashSet<String> = tvg_ids.into_iter().filter(|id| !id.is_empty()).collect();
 
-    let sources_requested = sources.len();
     let mut index = EpgIndex::default();
     let mut failed_sources = Vec::new();
     let mut sources_loaded = 0usize;

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -179,12 +179,18 @@ pub async fn load_epg(
         }
     }
 
+    let retained_index = if sources_requested > 0 && sources_loaded == 0 {
+        state.epg.lock().await.clone()
+    } else {
+        None
+    };
+    let summary_index = retained_index.as_deref().unwrap_or(&index);
     let summary = EpgLoadSummary {
         sources_requested,
         sources_loaded,
         failed_sources,
-        channels_matched: index.matched_channel_count(&tvg_ids),
-        programme_count: index.programme_count(),
+        channels_matched: summary_index.matched_channel_count(&tvg_ids),
+        programme_count: summary_index.programme_count(),
     };
     log::info!(
         "EPG loaded: {} sources, {} channels, {} programmes",

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -8,6 +8,8 @@ use crate::engine::epg::{self, EpgIndex, EpgProgramme};
 use crate::error::AppError;
 use crate::state::AppState;
 
+const MAX_EPG_SOURCES_PER_LOAD: usize = 32;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EpgLoadSummary {
     pub sources_requested: usize,
@@ -34,6 +36,12 @@ pub async fn load_epg(
     tvg_ids: Vec<String>,
     force_refresh: bool,
 ) -> Result<EpgLoadSummary, AppError> {
+    if sources.len() > MAX_EPG_SOURCES_PER_LOAD {
+        return Err(AppError::Other(format!(
+            "EPG source count exceeds the limit of {MAX_EPG_SOURCES_PER_LOAD}"
+        )));
+    }
+
     let _guard = state.epg_load_lock.lock().await;
     let accept_invalid_certs = state.settings.lock().await.accept_invalid_certs;
     let cache_dir = epg_cache_dir(&app);

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -1,14 +1,37 @@
 use std::collections::HashSet;
+use std::io::Read;
 use std::sync::Arc;
 
 use serde::Serialize;
 use tauri::Manager;
+use tokio_util::sync::CancellationToken;
 
 use crate::engine::epg::{self, EpgIndex, EpgProgramme};
 use crate::error::AppError;
 use crate::state::AppState;
 
 const MAX_EPG_SOURCES_PER_LOAD: usize = 32;
+
+struct CancellableReader<R> {
+    inner: R,
+    cancel: CancellationToken,
+}
+
+impl<R: Read> Read for CancellableReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if self.cancel.is_cancelled() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "EPG load superseded",
+            ));
+        }
+        self.inner.read(buffer)
+    }
+}
+
+fn superseded_error() -> AppError {
+    AppError::Other("EPG load superseded".to_string())
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EpgLoadSummary {
@@ -42,7 +65,16 @@ pub async fn load_epg(
         )));
     }
 
-    let _guard = state.epg_load_lock.lock().await;
+    let cancel = {
+        let mut current = state.epg_load_cancel.lock().await;
+        current.cancel();
+        *current = CancellationToken::new();
+        current.clone()
+    };
+    let _guard = tokio::select! {
+        _ = cancel.cancelled() => return Err(superseded_error()),
+        guard = state.epg_load_lock.lock() => guard,
+    };
     let sources_requested = sources.len();
     let wanted: HashSet<String> = tvg_ids.into_iter().filter(|id| !id.is_empty()).collect();
     if wanted.is_empty() {
@@ -64,17 +96,34 @@ pub async fn load_epg(
     let mut sources_loaded = 0usize;
 
     for source in sources {
+        if cancel.is_cancelled() {
+            return Err(superseded_error());
+        }
         let outcome = async {
-            let path =
-                epg::download_epg_source(&source, &cache_dir, accept_invalid_certs, force_refresh)
-                    .await?;
+            let path = epg::download_epg_source(
+                &source,
+                &cache_dir,
+                accept_invalid_certs,
+                force_refresh,
+                &cancel,
+            )
+            .await?;
             let wanted = wanted.clone();
             let source_identity = source.clone();
             let parse_path = path.clone();
+            let parse_cancel = cancel.clone();
             let parse_result = match tokio::task::spawn_blocking(move || {
                 let mut partial = EpgIndex::default();
                 let reader = epg::open_guide_file(&parse_path)?;
-                epg::parse_xmltv_into_with_source(reader, &wanted, &source_identity, &mut partial)?;
+                epg::parse_xmltv_into_with_source(
+                    CancellableReader {
+                        inner: reader,
+                        cancel: parse_cancel,
+                    },
+                    &wanted,
+                    &source_identity,
+                    &mut partial,
+                )?;
                 Ok::<EpgIndex, AppError>(partial)
             })
             .await
@@ -82,6 +131,9 @@ pub async fn load_epg(
                 Ok(result) => result,
                 Err(error) => Err(AppError::Other(format!("EPG parse task failed: {error}"))),
             };
+            if cancel.is_cancelled() {
+                return Err(superseded_error());
+            }
             if parse_result.is_err() {
                 let _ = std::fs::remove_file(path);
             }
@@ -89,6 +141,9 @@ pub async fn load_epg(
         }
         .await;
 
+        if cancel.is_cancelled() {
+            return Err(superseded_error());
+        }
         match outcome {
             Ok(partial) => {
                 index.merge(partial);
@@ -100,6 +155,10 @@ pub async fn load_epg(
                 failed_sources.push(source);
             }
         }
+    }
+
+    if cancel.is_cancelled() {
+        return Err(superseded_error());
     }
 
     let summary = EpgLoadSummary {
@@ -117,6 +176,12 @@ pub async fn load_epg(
     );
     *state.epg.lock().await = Some(Arc::new(index));
     Ok(summary)
+}
+
+#[tauri::command]
+pub async fn cancel_epg_load(state: tauri::State<'_, Arc<AppState>>) -> Result<(), AppError> {
+    state.epg_load_cancel.lock().await.cancel();
+    Ok(())
 }
 
 /// Programmes for one channel overlapping `[from, to)` (epoch seconds).

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -178,7 +178,11 @@ pub async fn load_epg(
         summary.channels_matched,
         summary.programme_count
     );
-    *state.epg.lock().await = Some(Arc::new(index));
+    if sources_requested == 0 || sources_loaded > 0 {
+        *state.epg.lock().await = Some(Arc::new(index));
+    } else {
+        log::warn!("All EPG sources failed; retaining the previously loaded guide");
+    }
     Ok(summary)
 }
 

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -1,0 +1,105 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::Manager;
+
+use crate::engine::epg::{self, EpgIndex, EpgProgramme};
+use crate::error::AppError;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EpgLoadSummary {
+    pub sources_requested: usize,
+    pub sources_loaded: usize,
+    pub failed_sources: Vec<String>,
+    pub channels_matched: usize,
+    pub programme_count: usize,
+}
+
+fn epg_cache_dir(app: &tauri::AppHandle) -> std::path::PathBuf {
+    app.path()
+        .app_cache_dir()
+        .unwrap_or_else(|_| std::env::temp_dir().join("iptv-checker"))
+        .join("epg")
+}
+
+/// Download and index the given XMLTV sources, keeping only programmes for
+/// the supplied tvg-ids. Replaces the app-wide EPG index.
+#[tauri::command]
+pub async fn load_epg(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+    sources: Vec<String>,
+    tvg_ids: Vec<String>,
+    force_refresh: bool,
+) -> Result<EpgLoadSummary, AppError> {
+    let _guard = state.epg_load_lock.lock().await;
+    let accept_invalid_certs = state.settings.lock().await.accept_invalid_certs;
+    let cache_dir = epg_cache_dir(&app);
+    let wanted: HashSet<String> = tvg_ids.into_iter().filter(|id| !id.is_empty()).collect();
+
+    let sources_requested = sources.len();
+    let mut index = EpgIndex::default();
+    let mut failed_sources = Vec::new();
+    let mut sources_loaded = 0usize;
+
+    for source in sources {
+        let outcome = async {
+            let path =
+                epg::download_epg_source(&source, &cache_dir, accept_invalid_certs, force_refresh)
+                    .await?;
+            let wanted = wanted.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut partial = EpgIndex::default();
+                let reader = epg::open_guide_file(&path)?;
+                epg::parse_xmltv_into(reader, &wanted, &mut partial)?;
+                Ok::<EpgIndex, AppError>(partial)
+            })
+            .await
+            .map_err(|error| AppError::Other(format!("EPG parse task failed: {error}")))?
+        }
+        .await;
+
+        match outcome {
+            Ok(partial) => {
+                index.merge(partial);
+                sources_loaded += 1;
+            }
+            Err(error) => {
+                log::warn!("EPG source {source} failed: {error}");
+                failed_sources.push(source);
+            }
+        }
+    }
+
+    let summary = EpgLoadSummary {
+        sources_requested,
+        sources_loaded,
+        failed_sources,
+        channels_matched: index.channel_count(),
+        programme_count: index.programme_count(),
+    };
+    log::info!(
+        "EPG loaded: {} sources, {} channels, {} programmes",
+        summary.sources_loaded,
+        summary.channels_matched,
+        summary.programme_count
+    );
+    *state.epg.lock().await = Some(Arc::new(index));
+    Ok(summary)
+}
+
+/// Programmes for one channel overlapping `[from, to)` (epoch seconds).
+#[tauri::command]
+pub async fn get_epg_programmes(
+    state: tauri::State<'_, Arc<AppState>>,
+    tvg_id: String,
+    from: i64,
+    to: i64,
+) -> Result<Vec<EpgProgramme>, AppError> {
+    let index = state.epg.lock().await.clone();
+    Ok(index
+        .map(|index| index.programmes_for(&tvg_id, from, to))
+        .unwrap_or_default())
+}

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -76,7 +76,11 @@ pub async fn load_epg(
         guard = state.epg_load_lock.lock() => guard,
     };
     let sources_requested = sources.len();
-    let wanted: HashSet<String> = tvg_ids.into_iter().filter(|id| !id.is_empty()).collect();
+    let wanted: HashSet<String> = tvg_ids
+        .iter()
+        .filter(|id| !id.is_empty())
+        .cloned()
+        .collect();
     if wanted.is_empty() {
         *state.epg.lock().await = Some(Arc::new(EpgIndex::default()));
         return Ok(EpgLoadSummary {
@@ -165,7 +169,7 @@ pub async fn load_epg(
         sources_requested,
         sources_loaded,
         failed_sources,
-        channels_matched: index.channel_count(),
+        channels_matched: index.matched_channel_count(&tvg_ids),
         programme_count: index.programme_count(),
     };
     log::info!(

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod chromecast;
+pub mod epg;
 pub mod export;
 pub mod history;
 pub mod player;

--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -18,8 +18,9 @@ use crate::engine::stalker::{
     STALKER_API_TIMEOUT,
 };
 use crate::engine::xtream::{
-    apply_xtream_archive_flags, build_xtream_download_url, fetch_xtream_account_info,
-    fetch_xtream_live_streams, fetch_xtream_playlist_via_json_api, xtream_archive_flags,
+    apply_xtream_archive_flags, build_xtream_download_url, build_xtream_xmltv_url,
+    fetch_xtream_account_info, fetch_xtream_live_streams, fetch_xtream_playlist_via_json_api,
+    xtream_archive_flags,
 };
 use crate::error::AppError;
 use crate::models::channel::Channel;
@@ -790,6 +791,10 @@ pub(crate) async fn open_playlist_xtream_inner(
     } else {
         HashMap::new()
     };
+    let xmltv_source = build_xtream_xmltv_url(&server, &username, &password).to_string();
+    if !preview.epg_sources.contains(&xmltv_source) {
+        preview.epg_sources.push(xmltv_source);
+    }
     if !archive_flags.is_empty() {
         apply_xtream_archive_flags(&mut preview.channels, &archive_flags);
     }

--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -793,7 +793,14 @@ pub(crate) async fn open_playlist_xtream_inner(
     };
     let xmltv_source = build_xtream_xmltv_url(&server, &username, &password).to_string();
     if !preview.epg_sources.contains(&xmltv_source) {
-        preview.epg_sources.push(xmltv_source);
+        preview.epg_sources.push(xmltv_source.clone());
+    }
+    let playlist_sources = preview
+        .epg_sources_by_playlist
+        .entry(preview.file_name.clone())
+        .or_default();
+    if !playlist_sources.contains(&xmltv_source) {
+        playlist_sources.push(xmltv_source);
     }
     if !archive_flags.is_empty() {
         apply_xtream_archive_flags(&mut preview.channels, &archive_flags);

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1297,7 +1297,7 @@ struct ResumeState {
     scope_suffix: String,
 }
 
-fn refresh_resumed_catchup_metadata(
+fn refresh_resumed_playlist_metadata(
     entries: &mut [resume::CheckpointResumeEntry],
     channels: &[Channel],
 ) {
@@ -1308,6 +1308,7 @@ fn refresh_resumed_catchup_metadata(
 
     for entry in entries {
         if let Some(channel) = channels_by_index.get(&entry.result.index) {
+            entry.result.tvg_id = channel.tvg_id.clone();
             entry.result.catchup = channel.catchup.clone();
             entry.result.catchup_days = channel.catchup_days;
             entry.result.catchup_source = channel.catchup_source.clone();
@@ -1371,7 +1372,7 @@ async fn load_resume_state(
         .filter(|entry| channel_indices.contains(&entry.result.index))
         .collect::<Vec<_>>();
     resumed_entries.sort_by_key(|entry| entry.result.index);
-    refresh_resumed_catchup_metadata(&mut resumed_entries, channels);
+    refresh_resumed_playlist_metadata(&mut resumed_entries, channels);
 
     let resumed_indices: HashSet<usize> = resumed_entries
         .iter()
@@ -2939,7 +2940,7 @@ mod tests {
     }
 
     #[test]
-    fn resumed_results_use_current_catchup_metadata() {
+    fn resumed_results_use_current_playlist_metadata() {
         let mut result = make_result(1, ChannelStatus::Alive, false, false);
         result.catchup = Some("stale".to_string());
         result.catchup_days = Some(1);
@@ -2949,13 +2950,15 @@ mod tests {
             channel_log: None,
         }];
         let mut channel = make_channel(1);
+        channel.tvg_id = Some("current-epg-id".to_string());
         channel.catchup = Some("xc".to_string());
         channel.catchup_days = Some(7);
         channel.catchup_source = Some("https://new.example/archive".to_string());
         channel.extinf_line = "#EXTINF:-1 catchup=\"xc\" catchup-days=\"7\",Test".to_string();
 
-        refresh_resumed_catchup_metadata(&mut entries, std::slice::from_ref(&channel));
+        refresh_resumed_playlist_metadata(&mut entries, std::slice::from_ref(&channel));
 
+        assert_eq!(entries[0].result.tvg_id.as_deref(), Some("current-epg-id"));
         assert_eq!(entries[0].result.catchup.as_deref(), Some("xc"));
         assert_eq!(entries[0].result.catchup_days, Some(7));
         assert_eq!(

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2798,6 +2798,7 @@ pub async fn quick_check_channel(
         .await
     };
 
+    let redacted_url = stream_proxy::redact_url(&channel.url);
     let (status, stream_url, latency_ms, error_reason) = match outcome {
         Ok(o) => {
             log::info!(
@@ -2806,7 +2807,7 @@ pub async fn quick_check_channel(
                 channel.name,
                 o.status,
                 check_started_at.elapsed().as_secs_f64(),
-                channel.url,
+                redacted_url,
             );
             (o.status, o.stream_url, o.latency_ms, o.last_error_reason)
         }
@@ -2817,7 +2818,7 @@ pub async fn quick_check_channel(
                 channel.name,
                 check_started_at.elapsed().as_secs_f64(),
                 error,
-                channel.url,
+                redacted_url,
             );
             (ChannelStatus::Dead, None, None, None)
         }

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
 use tauri::{AppHandle, Emitter, Manager, Window};
@@ -29,6 +29,8 @@ const CHECKPOINT_FLUSH_INTERVAL_MS: u64 = 250;
 const CHECKPOINT_FLUSH_MAX_BATCH: usize = 128;
 const RESULT_BATCH_MAX_ITEMS: usize = 64;
 const MIN_SCREENSHOT_DIAGNOSTIC_TIMEOUT_SECS: f64 = 15.0;
+static DIAGNOSTIC_URL_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"(?i)\b(?:https?|rtsp|rtmp)://[^\s'"]+"#).unwrap());
 
 #[derive(Debug, Clone)]
 struct SharedUrlResult {
@@ -2037,7 +2039,24 @@ fn redact_channel_debug_log(mut channel_log: ChannelDebugLog) -> ChannelDebugLog
             .map(|url| stream_proxy::redact_url(url))
             .collect();
     }
+    channel_log.diagnostics_output = channel_log
+        .diagnostics_output
+        .map(|text| redact_urls_in_text(&text));
+    channel_log.final_reason = channel_log
+        .final_reason
+        .map(|text| redact_urls_in_text(&text));
+    channel_log.screenshot_error_reason = channel_log
+        .screenshot_error_reason
+        .map(|text| redact_urls_in_text(&text));
     channel_log
+}
+
+fn redact_urls_in_text(text: &str) -> String {
+    DIAGNOSTIC_URL_RE
+        .replace_all(text, |captures: &regex::Captures<'_>| {
+            stream_proxy::redact_url(&captures[0])
+        })
+        .into_owned()
 }
 
 /// Store the finished scan's debug log on the window scan state.
@@ -2965,6 +2984,9 @@ mod tests {
         let redacted = redact_channel_debug_log(ChannelDebugLog {
             channel_url: sensitive_url.to_string(),
             redirect_chain: vec![sensitive_url.to_string()],
+            diagnostics_output: Some(format!(r#"{{"filename":"{sensitive_url}"}}"#)),
+            final_reason: Some(format!("Probe failed for {sensitive_url}")),
+            screenshot_error_reason: Some(format!("Screenshot failed for {sensitive_url}")),
             attempts: vec![crate::models::scan_log::ChannelAttemptDebugLog {
                 redirect_chain: vec![sensitive_url.to_string()],
                 ..Default::default()
@@ -2983,6 +3005,18 @@ mod tests {
         assert_eq!(
             redacted.attempts[0].redirect_chain.as_slice(),
             std::slice::from_ref(&redacted.channel_url)
+        );
+        assert_eq!(
+            redacted.diagnostics_output.as_deref(),
+            Some(r#"{"filename":"http://provider.example/live/***/***/42.ts?***"}"#)
+        );
+        assert_eq!(
+            redacted.final_reason.as_deref(),
+            Some("Probe failed for http://provider.example/live/***/***/42.ts?***")
+        );
+        assert_eq!(
+            redacted.screenshot_error_reason.as_deref(),
+            Some("Screenshot failed for http://provider.example/live/***/***/42.ts?***")
         );
     }
 

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2023,6 +2023,23 @@ async fn append_history_blocking(
     .await;
 }
 
+fn redact_channel_debug_log(mut channel_log: ChannelDebugLog) -> ChannelDebugLog {
+    channel_log.channel_url = stream_proxy::redact_url(&channel_log.channel_url);
+    channel_log.redirect_chain = channel_log
+        .redirect_chain
+        .into_iter()
+        .map(|url| stream_proxy::redact_url(&url))
+        .collect();
+    for attempt in &mut channel_log.attempts {
+        attempt.redirect_chain = attempt
+            .redirect_chain
+            .iter()
+            .map(|url| stream_proxy::redact_url(url))
+            .collect();
+    }
+    channel_log
+}
+
 /// Store the finished scan's debug log on the window scan state.
 async fn store_scan_log(
     state: &Arc<AppState>,
@@ -2045,7 +2062,10 @@ async fn store_scan_log(
                 started_at_epoch_ms,
                 finished_at_epoch_ms: now_epoch_ms(),
                 summary,
-                channels: channel_logs,
+                channels: channel_logs
+                    .into_iter()
+                    .map(redact_channel_debug_log)
+                    .collect(),
             });
         })
         .await;
@@ -2937,6 +2957,33 @@ mod tests {
             error_reason: None,
             channel_log: ChannelDebugLog::default(),
         }
+    }
+
+    #[test]
+    fn scan_debug_log_redacts_all_url_fields_before_storage() {
+        let sensitive_url = "http://provider.example/live/user/pass/42.ts?token=secret";
+        let redacted = redact_channel_debug_log(ChannelDebugLog {
+            channel_url: sensitive_url.to_string(),
+            redirect_chain: vec![sensitive_url.to_string()],
+            attempts: vec![crate::models::scan_log::ChannelAttemptDebugLog {
+                redirect_chain: vec![sensitive_url.to_string()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+
+        assert_eq!(
+            redacted.channel_url,
+            "http://provider.example/live/***/***/42.ts?***"
+        );
+        assert_eq!(
+            redacted.redirect_chain.as_slice(),
+            std::slice::from_ref(&redacted.channel_url)
+        );
+        assert_eq!(
+            redacted.attempts[0].redirect_chain.as_slice(),
+            std::slice::from_ref(&redacted.channel_url)
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -310,6 +310,14 @@ fn hls_muxer_options(is_finite: bool) -> (&'static str, &'static str) {
     }
 }
 
+fn dash_window_size(is_finite: bool) -> &'static str {
+    if is_finite {
+        "0"
+    } else {
+        REMUX_PLAYLIST_SEGMENTS
+    }
+}
+
 /// Spawn ffmpeg to remux the upstream MPEG-TS into a sliding-window HLS
 /// playlist on disk. Waits for the playlist file to appear (so the Cast
 /// device's first GET doesn't 404) before returning.
@@ -439,13 +447,14 @@ async fn start_remux(
         // which the muxer rejects.
         cmd.arg("-avoid_negative_ts").arg("make_zero");
 
-        // Keep both live and finite streams bounded. Finite inputs are paced
-        // above, giving the receiver time to fetch segments before removal.
+        // Live streams use a bounded sliding window. Finite streams retain
+        // every segment so receiver-side pauses and buffering cannot make an
+        // earlier segment disappear before it is fetched.
         cmd.arg("-f").arg("dash");
         cmd.arg("-seg_duration").arg("4");
-        cmd.arg("-window_size").arg(REMUX_PLAYLIST_SEGMENTS);
-        cmd.arg("-extra_window_size").arg("2");
+        cmd.arg("-window_size").arg(dash_window_size(is_finite));
         if !is_finite {
+            cmd.arg("-extra_window_size").arg("2");
             cmd.arg("-remove_at_exit").arg("1");
         }
         cmd.arg("-use_template").arg("1");
@@ -1593,6 +1602,12 @@ mod tests {
         assert!(!flags.split('+').any(|flag| flag == "delete_segments"));
         assert!(!flags.split('+').any(|flag| flag == "omit_endlist"));
         assert!(flags.split('+').any(|flag| flag == "independent_segments"));
+    }
+
+    #[test]
+    fn finite_dash_remux_keeps_all_segments() {
+        assert_eq!(dash_window_size(true), "0");
+        assert_eq!(dash_window_size(false), REMUX_PLAYLIST_SEGMENTS);
     }
 
     #[test]

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -391,6 +391,12 @@ async fn start_remux(
 
     cmd.arg("-hide_banner").arg("-loglevel").arg("warning");
     cmd.arg("-fflags").arg("+genpts+discardcorrupt");
+    // Archive endpoints may deliver the complete recording as fast as the
+    // connection allows. Pace them so the receiver can consume each segment
+    // before the sliding HLS/DASH window removes it.
+    if is_finite {
+        cmd.arg("-re");
+    }
     if is_hevc {
         cmd.arg("-f").arg("mpegts");
         cmd.arg("-i").arg("pipe:0");
@@ -436,13 +442,13 @@ async fn start_remux(
         // which the muxer rejects.
         cmd.arg("-avoid_negative_ts").arg("make_zero");
 
-        // DASH uses a sliding window for live streams and retains every
-        // segment for finite streams so ffmpeg can finalize a static MPD.
+        // Keep both live and finite streams bounded. Finite inputs are paced
+        // above, giving the receiver time to fetch segments before removal.
         cmd.arg("-f").arg("dash");
         cmd.arg("-seg_duration").arg("4");
+        cmd.arg("-window_size").arg(REMUX_PLAYLIST_SEGMENTS);
+        cmd.arg("-extra_window_size").arg("2");
         if !is_finite {
-            cmd.arg("-window_size").arg("6");
-            cmd.arg("-extra_window_size").arg("2");
             cmd.arg("-remove_at_exit").arg("1");
         }
         cmd.arg("-use_template").arg("1");

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -54,6 +54,11 @@ const MANIFEST_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 const REMUX_PLAYLIST_READY_TIMEOUT: Duration = Duration::from_secs(20);
 const REMUX_PLAYLIST_POLL_INTERVAL: Duration = Duration::from_millis(150);
 const REMUX_PLAYLIST_SEGMENTS: &str = "6";
+/// Finite remuxes retain all segments so a Cast receiver can buffer or pause
+/// without losing earlier media. Stop a malformed finite endpoint before it
+/// can consume unbounded temporary storage.
+const FINITE_REMUX_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const FINITE_REMUX_STORAGE_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// Hard cap on manifest body buffered into memory before rewriting. Real HLS
 /// playlists are well under a megabyte; this exists so a misclassified upstream
 /// (URL ends in `.m3u8` but body is actually a long-running MPEG-TS or live
@@ -500,6 +505,10 @@ async fn start_remux(
         ))
     })?;
 
+    if is_finite {
+        spawn_finite_remux_storage_guard(tmpdir.clone(), cancel.clone());
+    }
+
     // For HEVC, pump upstream bytes into ffmpeg's stdin via our own
     // reconnecting fetcher. ffmpeg's built-in `-reconnect 1 -reconnect_streamed
     // 1` opens a fresh HTTP response each time the upstream hangs up; the
@@ -668,6 +677,56 @@ async fn wait_for_manifest(
 
 async fn cleanup_remux_async(state: RemuxState) {
     let _ = tokio::fs::remove_dir_all(&state.tmpdir).await;
+}
+
+fn spawn_finite_remux_storage_guard(tmpdir: PathBuf, cancel: CancellationToken) {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = tokio::time::sleep(FINITE_REMUX_STORAGE_POLL_INTERVAL) => {}
+            }
+
+            let path = tmpdir.clone();
+            let size = tokio::task::spawn_blocking(move || remux_directory_size(&path))
+                .await
+                .unwrap_or(0);
+            if size < FINITE_REMUX_MAX_BYTES {
+                continue;
+            }
+
+            log::warn!(
+                "[CastProxy] Finite remux reached the {} MiB storage limit; stopping",
+                FINITE_REMUX_MAX_BYTES / (1024 * 1024)
+            );
+            cancel.cancel();
+            return;
+        }
+    });
+}
+
+fn remux_directory_size(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut directories = vec![path.to_path_buf()];
+
+    while let Some(directory) = directories.pop() {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                directories.push(entry.path());
+            } else if file_type.is_file() {
+                total = total
+                    .saturating_add(entry.metadata().map(|metadata| metadata.len()).unwrap_or(0));
+            }
+        }
+    }
+
+    total
 }
 
 /// Pump bytes from the upstream IPTV URL into ffmpeg's stdin, transparently

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -301,10 +301,7 @@ struct RemuxStartInfo {
 
 fn hls_muxer_options(is_finite: bool) -> (&'static str, &'static str) {
     if is_finite {
-        (
-            REMUX_PLAYLIST_SEGMENTS,
-            "delete_segments+independent_segments",
-        )
+        ("0", "independent_segments")
     } else {
         (
             REMUX_PLAYLIST_SEGMENTS,
@@ -1589,12 +1586,13 @@ mod tests {
     }
 
     #[test]
-    fn finite_hls_remux_prunes_segments_but_keeps_endlist() {
+    fn finite_hls_remux_keeps_all_segments_and_endlist() {
         let (playlist_size, flags) = hls_muxer_options(true);
 
-        assert_ne!(playlist_size, "0");
-        assert!(flags.split('+').any(|flag| flag == "delete_segments"));
+        assert_eq!(playlist_size, "0");
+        assert!(!flags.split('+').any(|flag| flag == "delete_segments"));
         assert!(!flags.split('+').any(|flag| flag == "omit_endlist"));
+        assert!(flags.split('+').any(|flag| flag == "independent_segments"));
     }
 
     #[test]

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -53,6 +53,7 @@ const CAST_READ_TIMEOUT: Duration = Duration::from_secs(20);
 const MANIFEST_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 const REMUX_PLAYLIST_READY_TIMEOUT: Duration = Duration::from_secs(20);
 const REMUX_PLAYLIST_POLL_INTERVAL: Duration = Duration::from_millis(150);
+const REMUX_PLAYLIST_SEGMENTS: &str = "6";
 /// Hard cap on manifest body buffered into memory before rewriting. Real HLS
 /// playlists are well under a megabyte; this exists so a misclassified upstream
 /// (URL ends in `.m3u8` but body is actually a long-running MPEG-TS or live
@@ -298,6 +299,20 @@ struct RemuxStartInfo {
     is_dash: bool,
 }
 
+fn hls_muxer_options(is_finite: bool) -> (&'static str, &'static str) {
+    if is_finite {
+        (
+            REMUX_PLAYLIST_SEGMENTS,
+            "delete_segments+independent_segments",
+        )
+    } else {
+        (
+            REMUX_PLAYLIST_SEGMENTS,
+            "delete_segments+omit_endlist+independent_segments",
+        )
+    }
+}
+
 /// Spawn ffmpeg to remux the upstream MPEG-TS into a sliding-window HLS
 /// playlist on disk. Waits for the playlist file to appear (so the Cast
 /// device's first GET doesn't 404) before returning.
@@ -451,15 +466,11 @@ async fn start_remux(
             cmd.arg("-c:a").arg("copy");
         }
         let segment_pattern = tmpdir.join("seg_%05d.ts");
+        let (playlist_size, hls_flags) = hls_muxer_options(is_finite);
         cmd.arg("-f").arg("hls");
         cmd.arg("-hls_time").arg("4");
-        cmd.arg("-hls_list_size")
-            .arg(if is_finite { "0" } else { "6" });
-        cmd.arg("-hls_flags").arg(if is_finite {
-            "independent_segments"
-        } else {
-            "delete_segments+omit_endlist+independent_segments"
-        });
+        cmd.arg("-hls_list_size").arg(playlist_size);
+        cmd.arg("-hls_flags").arg(hls_flags);
         cmd.arg("-hls_segment_filename").arg(&segment_pattern);
     }
     cmd.arg(&manifest_path);
@@ -1569,6 +1580,15 @@ mod tests {
         assert!(token
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+
+    #[test]
+    fn finite_hls_remux_prunes_segments_but_keeps_endlist() {
+        let (playlist_size, flags) = hls_muxer_options(true);
+
+        assert_ne!(playlist_size, "0");
+        assert!(flags.split('+').any(|flag| flag == "delete_segments"));
+        assert!(!flags.split('+').any(|flag| flag == "omit_endlist"));
     }
 
     #[test]

--- a/src-tauri/src/engine/cast_proxy.rs
+++ b/src-tauri/src/engine/cast_proxy.rs
@@ -161,6 +161,7 @@ pub async fn start(
     app: AppHandle,
     upstream_url: String,
     stream_kind: CastStreamKind,
+    is_finite: bool,
 ) -> Result<CastProxyHandle, AppError> {
     let token = generate_token();
     let lan_ip = detect_lan_ip()
@@ -204,6 +205,7 @@ pub async fn start(
             cancel.clone(),
             remux_state.clone(),
             client.clone(),
+            is_finite,
         )
         .await?;
         (
@@ -306,6 +308,7 @@ async fn start_remux(
     cancel: CancellationToken,
     remux_state: Arc<Mutex<Option<RemuxState>>>,
     client: Arc<reqwest::Client>,
+    is_finite: bool,
 ) -> Result<RemuxStartInfo, AppError> {
     let tmpdir = std::env::temp_dir().join(format!("iptv-cast-{token}"));
     std::fs::create_dir_all(&tmpdir).map_err(AppError::Io)?;
@@ -418,15 +421,15 @@ async fn start_remux(
         // which the muxer rejects.
         cmd.arg("-avoid_negative_ts").arg("make_zero");
 
-        // DASH muxer: sliding-window live profile, fMP4 segments under
-        // SegmentTemplate so Shaka can index by $Number$. `remove_at_exit`
-        // pairs with `extra_window_size` so segments stay on disk a couple
-        // of windows past the manifest tail (covers receiver reconnects).
+        // DASH uses a sliding window for live streams and retains every
+        // segment for finite streams so ffmpeg can finalize a static MPD.
         cmd.arg("-f").arg("dash");
         cmd.arg("-seg_duration").arg("4");
-        cmd.arg("-window_size").arg("6");
-        cmd.arg("-extra_window_size").arg("2");
-        cmd.arg("-remove_at_exit").arg("1");
+        if !is_finite {
+            cmd.arg("-window_size").arg("6");
+            cmd.arg("-extra_window_size").arg("2");
+            cmd.arg("-remove_at_exit").arg("1");
+        }
         cmd.arg("-use_template").arg("1");
         cmd.arg("-use_timeline").arg("1");
         cmd.arg("-init_seg_name")
@@ -450,9 +453,13 @@ async fn start_remux(
         let segment_pattern = tmpdir.join("seg_%05d.ts");
         cmd.arg("-f").arg("hls");
         cmd.arg("-hls_time").arg("4");
-        cmd.arg("-hls_list_size").arg("6");
-        cmd.arg("-hls_flags")
-            .arg("delete_segments+omit_endlist+independent_segments");
+        cmd.arg("-hls_list_size")
+            .arg(if is_finite { "0" } else { "6" });
+        cmd.arg("-hls_flags").arg(if is_finite {
+            "independent_segments"
+        } else {
+            "delete_segments+omit_endlist+independent_segments"
+        });
         cmd.arg("-hls_segment_filename").arg(&segment_pattern);
     }
     cmd.arg(&manifest_path);
@@ -488,6 +495,7 @@ async fn start_remux(
                 client.clone(),
                 stdin,
                 cancel.clone(),
+                is_finite,
             );
         }
     }
@@ -529,6 +537,9 @@ async fn start_remux(
                             "[CastProxy/ffmpeg] Exited cleanly for {}",
                             redact_url(&upstream_for_worker)
                         );
+                        if is_finite {
+                            return;
+                        }
                     }
                     Ok(s) => {
                         log::warn!(
@@ -545,8 +556,9 @@ async fn start_remux(
                         log::warn!("[CastProxy/ffmpeg] wait() failed: {err}");
                     }
                 }
-                // ffmpeg ended on its own — also cancel the listener so the
-                // session tears down rather than serving a dead playlist.
+                // A completed finite remux must remain available while the
+                // receiver consumes its final segments. Other exits tear down
+                // the listener rather than leaving a dead live playlist.
                 cancel_for_worker.cancel();
                 let mut guard = remux_state_for_worker.lock().await;
                 if let Some(state) = guard.take() {
@@ -651,6 +663,7 @@ fn spawn_upstream_pump(
     client: Arc<reqwest::Client>,
     mut stdin: tokio::process::ChildStdin,
     cancel: CancellationToken,
+    is_finite: bool,
 ) {
     tokio::spawn(async move {
         use futures::StreamExt;
@@ -747,6 +760,12 @@ fn spawn_upstream_pump(
                                 break;
                             }
                             None => {
+                                if is_finite {
+                                    log::info!(
+                                        "[CastProxy/pump] Upstream EOF ({label}); finite stream complete"
+                                    );
+                                    break 'session;
+                                }
                                 log::info!(
                                     "[CastProxy/pump] Upstream EOF ({label}); reconnecting"
                                 );

--- a/src-tauri/src/engine/checker.rs
+++ b/src-tauri/src/engine/checker.rs
@@ -1179,6 +1179,7 @@ pub async fn check_channel_status_with_debug(
         let client = client.clone();
         let headers = headers.clone();
         let url = url.to_string();
+        let redacted_url = crate::engine::stream_proxy::redact_url(&url);
         let cancel = cancel_token.clone();
         async move {
             let mut retries_used = 0u32;
@@ -1197,7 +1198,7 @@ pub async fn check_channel_status_with_debug(
                     "Attempt {}/{} for {} (timeout: {}s, max_retries: {}, backoff: {:?})",
                     attempt + 1,
                     attempts,
-                    url,
+                    redacted_url,
                     current_timeout,
                     retries,
                     retry_backoff
@@ -1321,7 +1322,7 @@ pub async fn check_channel_status_with_debug(
                         if let Some(reason) = reason {
                             last_error_reason = Some(reason);
                         }
-                        log::debug!("Retrying channel: {}", url);
+                        log::debug!("Retrying channel: {}", redacted_url);
                         if attempt < retries {
                             retries_used = retries_used.saturating_add(1);
                             let delay = retry_delay_seconds(retry_backoff, attempt);

--- a/src-tauri/src/engine/chromecast.rs
+++ b/src-tauri/src/engine/chromecast.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use cast_sender::namespace::media::Media;
+use cast_sender::namespace::media::{IdleReason, Media, PlayerState};
 use cast_sender::namespace::{Custom, NamespaceUrn};
 use cast_sender::{App as CastApp, AppId, Payload, Receiver};
 use mdns_sd::{ServiceDaemon, ServiceEvent};
@@ -203,7 +203,7 @@ impl ActiveCastSession {
 
 /// Start a Cast session: connect, launch the default media receiver, load
 /// media. Spawns a tokio task that owns the `Receiver` and watches for stop
-/// signals or device disconnect.
+/// signals, device disconnect, or finite media completion.
 pub async fn start_session(
     app: AppHandle,
     device: ChromecastDevice,
@@ -321,11 +321,11 @@ async fn run_session_worker(
     )
     .await;
 
-    // For self-exit paths (device disconnected, error) we clear the stored
-    // session so a remounted frontend calling `get_cast_status()` doesn't see
-    // a stale Playing state. On manual stop the caller already cleared the
-    // session before sending Stop, so we skip. The uid match prevents
-    // clearing a successor session started after we exited.
+    // For self-exit paths (device disconnected or finite media completed) we
+    // clear the stored session so a remounted frontend calling
+    // `get_cast_status()` doesn't see a stale Playing state. On manual stop
+    // the caller already cleared the session before sending Stop, so we skip.
+    // The uid match prevents clearing a successor session started after exit.
     if !manual_stop {
         let app_for_cleanup = app.clone();
         tokio::spawn(async move {
@@ -441,8 +441,19 @@ async fn send_load(
     Ok(())
 }
 
+fn media_has_finished(payload: &Payload) -> bool {
+    let Payload::Media(Media::MediaStatus(response)) = payload else {
+        return false;
+    };
+
+    response.status.iter().any(|status| {
+        matches!(&status.player_state, PlayerState::Idle)
+            && matches!(&status.idle_reason, Some(IdleReason::Finished))
+    })
+}
+
 /// Returns `true` if the session ended due to an explicit stop signal,
-/// `false` if the device disconnected on its own.
+/// `false` if it ended on its own.
 async fn drive_session(
     app: &AppHandle,
     device: &ChromecastDevice,
@@ -479,6 +490,37 @@ async fn drive_session(
                     log::info!("[Chromecast] Receiver connection lost on '{}'", device.friendly_name);
                     emit_state(app, device, CastSessionState::Stopped, &cast_url, &request, None);
                     return false;
+                }
+                if request.is_finite {
+                    match receiver
+                        .send_request(cast_app, Media::GetStatus(Default::default()))
+                        .await
+                    {
+                        Ok(response) if media_has_finished(&response.payload) => {
+                            let _ = receiver.stop_app(cast_app).await;
+                            receiver.disconnect().await;
+                            emit_state(
+                                app,
+                                device,
+                                CastSessionState::Stopped,
+                                &cast_url,
+                                &request,
+                                None,
+                            );
+                            log::info!(
+                                "[Chromecast] Buffered playback finished on '{}'",
+                                device.friendly_name
+                            );
+                            return false;
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            log::debug!(
+                                "[Chromecast] Media status poll failed on '{}': {error}",
+                                device.friendly_name
+                            );
+                        }
+                    }
                 }
             }
             maybe_swap = swap_rx.recv() => {
@@ -576,5 +618,21 @@ mod tests {
 
         assert_eq!(finite.fields["media"]["streamType"], "BUFFERED");
         assert_eq!(live.fields["media"]["streamType"], "LIVE");
+    }
+
+    #[test]
+    fn detects_finished_buffered_media_status() {
+        use cast_sender::namespace::media::{MediaStatus, ResponseData};
+
+        let status = MediaStatus {
+            player_state: PlayerState::Idle,
+            idle_reason: Some(IdleReason::Finished),
+            ..Default::default()
+        };
+        let finished = Payload::Media(Media::MediaStatus(ResponseData {
+            status: vec![status],
+        }));
+
+        assert!(media_has_finished(&finished));
     }
 }

--- a/src-tauri/src/engine/chromecast.rs
+++ b/src-tauri/src/engine/chromecast.rs
@@ -441,14 +441,35 @@ async fn send_load(
     Ok(())
 }
 
-fn media_has_finished(payload: &Payload) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+enum BufferedPlaybackEnd {
+    Finished,
+    Failed(&'static str),
+}
+
+fn buffered_playback_end(payload: &Payload) -> Option<BufferedPlaybackEnd> {
     let Payload::Media(Media::MediaStatus(response)) = payload else {
-        return false;
+        return None;
     };
 
-    response.status.iter().any(|status| {
-        matches!(&status.player_state, PlayerState::Idle)
-            && matches!(&status.idle_reason, Some(IdleReason::Finished))
+    response.status.iter().find_map(|status| {
+        if !matches!(&status.player_state, PlayerState::Idle) {
+            return None;
+        }
+
+        match &status.idle_reason {
+            Some(IdleReason::Finished) => Some(BufferedPlaybackEnd::Finished),
+            Some(IdleReason::Error) => Some(BufferedPlaybackEnd::Failed(
+                "Chromecast reported a playback error",
+            )),
+            Some(IdleReason::Cancelled) => {
+                Some(BufferedPlaybackEnd::Failed("Chromecast cancelled playback"))
+            }
+            Some(IdleReason::Interrupted) => Some(BufferedPlaybackEnd::Failed(
+                "Chromecast interrupted playback",
+            )),
+            None => None,
+        }
     })
 }
 
@@ -496,24 +517,43 @@ async fn drive_session(
                         .send_request(cast_app, Media::GetStatus(Default::default()))
                         .await
                     {
-                        Ok(response) if media_has_finished(&response.payload) => {
-                            let _ = receiver.stop_app(cast_app).await;
-                            receiver.disconnect().await;
-                            emit_state(
-                                app,
-                                device,
-                                CastSessionState::Stopped,
-                                &cast_url,
-                                &request,
-                                None,
-                            );
-                            log::info!(
-                                "[Chromecast] Buffered playback finished on '{}'",
-                                device.friendly_name
-                            );
-                            return false;
+                        Ok(response) => {
+                            if let Some(playback_end) = buffered_playback_end(&response.payload) {
+                                let _ = receiver.stop_app(cast_app).await;
+                                receiver.disconnect().await;
+                                match playback_end {
+                                    BufferedPlaybackEnd::Finished => {
+                                        emit_state(
+                                            app,
+                                            device,
+                                            CastSessionState::Stopped,
+                                            &cast_url,
+                                            &request,
+                                            None,
+                                        );
+                                        log::info!(
+                                            "[Chromecast] Buffered playback finished on '{}'",
+                                            device.friendly_name
+                                        );
+                                    }
+                                    BufferedPlaybackEnd::Failed(message) => {
+                                        emit_state(
+                                            app,
+                                            device,
+                                            CastSessionState::Error,
+                                            &cast_url,
+                                            &request,
+                                            Some(message.to_string()),
+                                        );
+                                        log::warn!(
+                                            "[Chromecast] Buffered playback failed on '{}': {message}",
+                                            device.friendly_name
+                                        );
+                                    }
+                                }
+                                return false;
+                            }
                         }
-                        Ok(_) => {}
                         Err(error) => {
                             log::debug!(
                                 "[Chromecast] Media status poll failed on '{}': {error}",
@@ -620,19 +660,42 @@ mod tests {
         assert_eq!(live.fields["media"]["streamType"], "LIVE");
     }
 
-    #[test]
-    fn detects_finished_buffered_media_status() {
+    fn buffered_media_status(idle_reason: IdleReason) -> Payload {
         use cast_sender::namespace::media::{MediaStatus, ResponseData};
 
         let status = MediaStatus {
             player_state: PlayerState::Idle,
-            idle_reason: Some(IdleReason::Finished),
+            idle_reason: Some(idle_reason),
             ..Default::default()
         };
-        let finished = Payload::Media(Media::MediaStatus(ResponseData {
+        Payload::Media(Media::MediaStatus(ResponseData {
             status: vec![status],
-        }));
+        }))
+    }
 
-        assert!(media_has_finished(&finished));
+    #[test]
+    fn detects_finished_buffered_media_status() {
+        let finished = buffered_media_status(IdleReason::Finished);
+
+        assert_eq!(
+            buffered_playback_end(&finished),
+            Some(BufferedPlaybackEnd::Finished)
+        );
+    }
+
+    #[test]
+    fn detects_failed_buffered_media_statuses() {
+        for reason in [
+            IdleReason::Error,
+            IdleReason::Cancelled,
+            IdleReason::Interrupted,
+        ] {
+            let failed = buffered_media_status(reason);
+
+            assert!(matches!(
+                buffered_playback_end(&failed),
+                Some(BufferedPlaybackEnd::Failed(_))
+            ));
+        }
     }
 }

--- a/src-tauri/src/engine/chromecast.rs
+++ b/src-tauri/src/engine/chromecast.rs
@@ -381,7 +381,14 @@ fn build_load_payload(request: &CastMediaRequest, cast_url: &str, is_dash: bool)
     let mut media_obj = serde_json::Map::new();
     media_obj.insert("contentId".to_string(), json!(cast_url));
     media_obj.insert("contentType".to_string(), json!(content_type));
-    media_obj.insert("streamType".to_string(), json!("LIVE"));
+    media_obj.insert(
+        "streamType".to_string(),
+        json!(if request.is_finite {
+            "BUFFERED"
+        } else {
+            "LIVE"
+        }),
+    );
     media_obj.insert("metadata".to_string(), Value::Object(metadata));
 
     let mut fields = HashMap::new();
@@ -545,5 +552,29 @@ pub struct CastSessionHandle(pub Mutex<Option<ActiveCastSession>>);
 impl CastSessionHandle {
     pub fn new() -> Arc<Self> {
         Arc::new(Self(Mutex::new(None)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn media_request(is_finite: bool) -> CastMediaRequest {
+        CastMediaRequest {
+            original_url: "https://example.com/stream.ts".to_string(),
+            channel_name: Some("Example".to_string()),
+            channel_logo: None,
+            stream_kind: CastStreamKind::MpegTs,
+            is_finite,
+        }
+    }
+
+    #[test]
+    fn finite_media_uses_buffered_cast_stream_type() {
+        let finite = build_load_payload(&media_request(true), "http://127.0.0.1/archive", false);
+        let live = build_load_payload(&media_request(false), "http://127.0.0.1/live", false);
+
+        assert_eq!(finite.fields["media"]["streamType"], "BUFFERED");
+        assert_eq!(live.fields["media"]["streamType"], "LIVE");
     }
 }

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -15,6 +15,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
 
+use crate::engine::remote_cache::PLAYLIST_DOWNLOAD_USER_AGENT;
 use crate::error::AppError;
 
 const EPG_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
@@ -96,6 +97,18 @@ impl EpgIndex {
             .map(|(_, tvg_id)| tvg_id)
             .collect::<HashSet<_>>()
             .len()
+    }
+
+    pub fn matched_channel_count(&self, tvg_ids: &[String]) -> usize {
+        let matched_ids = self
+            .programmes
+            .keys()
+            .map(|(_, tvg_id)| tvg_id.as_str())
+            .collect::<HashSet<_>>();
+        tvg_ids
+            .iter()
+            .filter(|tvg_id| matched_ids.contains(tvg_id.as_str()))
+            .count()
     }
 
     pub fn programme_count(&self) -> usize {
@@ -540,7 +553,10 @@ pub async fn download_epg_source(
 
     let response = tokio::select! {
         _ = cancel.cancelled() => return Err(AppError::Other("EPG load superseded".to_string())),
-        response = client.get(url).send() => response.map_err(|error| {
+        response = client
+            .get(url)
+            .header(reqwest::header::USER_AGENT, PLAYLIST_DOWNLOAD_USER_AGENT)
+            .send() => response.map_err(|error| {
             AppError::Other(format!("EPG download failed: {}", error.without_url()))
         })?,
     };
@@ -590,6 +606,8 @@ pub async fn download_epg_source(
 mod tests {
     use super::*;
     use std::io::Write;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     #[test]
     fn parses_xmltv_timestamps_with_and_without_offsets() {
@@ -632,6 +650,14 @@ mod tests {
         parse_xmltv_into(xml.as_bytes(), &wanted, &mut index).expect("xmltv should parse");
 
         assert_eq!(index.channel_count(), 1);
+        assert_eq!(
+            index.matched_channel_count(&[
+                "nrk1.no".to_string(),
+                "nrk1.no".to_string(),
+                "unwanted.tv".to_string(),
+            ]),
+            2
+        );
         assert_eq!(index.programme_count(), 2);
         let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
         assert_eq!(programmes[0].title, "Dagsrevyen");
@@ -857,6 +883,65 @@ mod tests {
         .expect_err("cancelled EPG download should stop");
 
         assert!(error.to_string().contains("superseded"));
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[tokio::test]
+    async fn downloads_epg_with_iptv_user_agent() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test server should have local address");
+        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("test server should accept");
+            let mut request = Vec::new();
+            loop {
+                let mut chunk = [0u8; 1024];
+                let read = socket
+                    .read(&mut chunk)
+                    .await
+                    .expect("test server should read request");
+                request.extend_from_slice(&chunk[..read]);
+                if read == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let _ = request_tx.send(String::from_utf8_lossy(&request).into_owned());
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n<tv/>",
+                )
+                .await
+                .expect("test server should write response");
+        });
+
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-user-agent-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let cancel = CancellationToken::new();
+        download_epg_source(
+            &format!("http://{address}/guide.xml"),
+            &dir,
+            false,
+            false,
+            &cancel,
+        )
+        .await
+        .expect("EPG should download");
+
+        let request = request_rx.await.expect("request should be captured");
+        assert!(request.to_ascii_lowercase().contains(&format!(
+            "user-agent: {}",
+            PLAYLIST_DOWNLOAD_USER_AGENT.to_ascii_lowercase()
+        )));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -3,7 +3,7 @@
 //! multi-hundred-MB provider guide does not balloon into memory.
 
 use std::collections::{HashMap, HashSet};
-use std::io::{BufReader, Read, Write};
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -12,6 +12,7 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::AppError;
@@ -552,7 +553,7 @@ pub async fn download_epg_source(
 
     let temp = temporary_cache_path(&target);
     let _partial_download = PartialEpgDownload { path: temp.clone() };
-    let mut file = std::fs::File::create(&temp).map_err(AppError::Io)?;
+    let mut file = tokio::fs::File::create(&temp).await.map_err(AppError::Io)?;
     let mut downloaded: u64 = 0;
     let mut stream = response;
     loop {
@@ -572,9 +573,9 @@ pub async fn download_epg_source(
                 EPG_MAX_DOWNLOAD_BYTES / (1024 * 1024)
             )));
         }
-        file.write_all(&chunk).map_err(AppError::Io)?;
+        file.write_all(&chunk).await.map_err(AppError::Io)?;
     }
-    file.flush().map_err(AppError::Io)?;
+    file.flush().await.map_err(AppError::Io)?;
     drop(file);
     crate::engine::disk::atomic_rename(&target, &temp)?;
     prune_epg_cache(cache_dir, &target, EPG_CACHE_MAX_BYTES);
@@ -588,6 +589,7 @@ pub async fn download_epg_source(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn parses_xmltv_timestamps_with_and_without_offsets() {

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -256,6 +256,8 @@ pub fn parse_xmltv_into_with_source<R: Read>(
     let mut current_title: Option<String> = None;
     let mut in_title = false;
     let mut saw_xmltv_root = false;
+    let mut closed_xmltv_root = false;
+    let mut element_depth = 0usize;
 
     loop {
         buffer.clear();
@@ -269,6 +271,7 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                     }
                     saw_xmltv_root = true;
                 }
+                element_depth += 1;
 
                 match element.name().as_ref() {
                     b"programme" => {
@@ -310,6 +313,7 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                         ));
                     }
                     saw_xmltv_root = true;
+                    closed_xmltv_root = true;
                 }
             }
             Ok(Event::Text(text)) => {
@@ -330,34 +334,46 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                     in_title = false;
                 }
             }
-            Ok(Event::End(element)) => match element.name().as_ref() {
-                b"programme" => {
-                    if let Some((channel, start, stop)) = current.take() {
-                        if stop.is_none_or(|stop| stop > start) {
-                            index
-                                .programmes
-                                .entry((source_identity.to_string(), channel))
-                                .or_default()
-                                .push(EpgProgramme {
-                                    start,
-                                    // `start` is an internal sentinel for an omitted stop time;
-                                    // finalize replaces it with the following programme or fallback.
-                                    stop: stop.unwrap_or(start),
-                                    title: current_title
-                                        .take()
-                                        .unwrap_or_else(|| "Untitled".to_string()),
-                                });
+            Ok(Event::End(element)) => {
+                let closes_root = element_depth == 1 && element.name().as_ref() == b"tv";
+                match element.name().as_ref() {
+                    b"programme" => {
+                        if let Some((channel, start, stop)) = current.take() {
+                            if stop.is_none_or(|stop| stop > start) {
+                                index
+                                    .programmes
+                                    .entry((source_identity.to_string(), channel))
+                                    .or_default()
+                                    .push(EpgProgramme {
+                                        start,
+                                        // `start` is an internal sentinel for an omitted stop time;
+                                        // finalize replaces it with the following programme or fallback.
+                                        stop: stop.unwrap_or(start),
+                                        title: current_title
+                                            .take()
+                                            .unwrap_or_else(|| "Untitled".to_string()),
+                                    });
+                            }
                         }
+                        in_title = false;
                     }
-                    in_title = false;
+                    b"title" => in_title = false,
+                    _ => {}
                 }
-                b"title" => in_title = false,
-                _ => {}
-            },
+                if closes_root {
+                    closed_xmltv_root = true;
+                }
+                element_depth = element_depth.saturating_sub(1);
+            }
             Ok(Event::Eof) => {
                 if !saw_xmltv_root {
                     return Err(AppError::Other(
                         "Failed to parse XMLTV: missing <tv> root".to_string(),
+                    ));
+                }
+                if !closed_xmltv_root {
+                    return Err(AppError::Other(
+                        "Failed to parse XMLTV: document ended before </tv>".to_string(),
                     ));
                 }
                 break;
@@ -409,6 +425,7 @@ pub fn redact_epg_source(source: &str) -> String {
     };
     let _ = url.set_username("");
     let _ = url.set_password(None);
+    url.set_path("/");
     url.set_query(None);
     url.set_fragment(None);
     url.to_string()
@@ -425,6 +442,35 @@ fn cache_is_fresh(path: &Path) -> bool {
 fn temporary_cache_path(target: &Path) -> PathBuf {
     let id = NEXT_TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
     target.with_extension(format!("{}.{}.part", std::process::id(), id))
+}
+
+fn remove_stale_partial_downloads(cache_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(cache_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("epg-") || !name.ends_with(".part") {
+            continue;
+        }
+        let is_stale = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age >= EPG_DOWNLOAD_TIMEOUT);
+        if is_stale {
+            if let Err(error) = std::fs::remove_file(&path) {
+                log::warn!(
+                    "Failed to remove stale partial EPG download {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
 }
 
 fn prune_epg_cache(cache_dir: &Path, keep: &Path, max_bytes: u64) {
@@ -473,13 +519,14 @@ pub async fn download_epg_source(
     accept_invalid_certs: bool,
     force_refresh: bool,
 ) -> Result<PathBuf, AppError> {
+    std::fs::create_dir_all(cache_dir).map_err(AppError::Io)?;
+    remove_stale_partial_downloads(cache_dir);
     let target = cache_path_for(cache_dir, url);
     if !force_refresh && cache_is_fresh(&target) {
         log::info!("EPG cache hit for {}", redact_epg_source(url));
         return Ok(target);
     }
 
-    std::fs::create_dir_all(cache_dir).map_err(AppError::Io)?;
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(10))
         .connect_timeout(EPG_DOWNLOAD_CONNECT_TIMEOUT)
@@ -639,6 +686,17 @@ mod tests {
     }
 
     #[test]
+    fn rejects_xmltv_documents_with_an_unclosed_root() {
+        let xml = r#"<tv><programme start="20260828200000" stop="20260828210000" channel="news"><title>News</title></programme>"#;
+        let mut index = EpgIndex::default();
+
+        let error = parse_xmltv_into(xml.as_bytes(), &HashSet::new(), &mut index)
+            .expect_err("truncated XMLTV document should fail");
+
+        assert!(error.to_string().contains("before </tv>"));
+    }
+
+    #[test]
     fn parses_windows_1252_channel_ids_and_titles() {
         let xml = b"<?xml version=\"1.0\" encoding=\"windows-1252\"?><tv><programme start=\"20260828200000\" stop=\"20260828210000\" channel=\"caf\xe9\"><title>Caf\xe9 News</title></programme></tv>";
         let wanted = HashSet::from(["café".to_string()]);
@@ -681,7 +739,11 @@ mod tests {
             redact_epg_source(
                 "https://alice:secret@example.com/xmltv.php?username=alice&password=secret"
             ),
-            "https://example.com/xmltv.php"
+            "https://example.com/"
+        );
+        assert_eq!(
+            redact_epg_source("https://example.com/xmltv/alice/secret"),
+            "https://example.com/"
         );
     }
 
@@ -731,6 +793,32 @@ mod tests {
         assert!(!oldest.exists());
         assert!(newest.exists());
         assert!(keep.exists());
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn removes_stale_partial_epg_downloads() {
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-partial-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let stale = dir.join("epg-stale.1.0.part");
+        let unrelated = dir.join("other-stale.part");
+        std::fs::write(&stale, [0; 4]).expect("write stale partial");
+        std::fs::write(&unrelated, [0; 4]).expect("write unrelated partial");
+        std::fs::File::open(&stale)
+            .expect("open stale partial")
+            .set_modified(std::time::SystemTime::UNIX_EPOCH)
+            .expect("age stale partial");
+
+        remove_stale_partial_downloads(&dir);
+
+        assert!(!stale.exists());
+        assert!(unrelated.exists());
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -89,7 +89,11 @@ pub struct EpgIndex {
 
 impl EpgIndex {
     pub fn channel_count(&self) -> usize {
-        self.programmes.len()
+        self.programmes
+            .keys()
+            .map(|(_, tvg_id)| tvg_id)
+            .collect::<HashSet<_>>()
+            .len()
     }
 
     pub fn programme_count(&self) -> usize {
@@ -609,6 +613,7 @@ mod tests {
         parse_xmltv_into_with_source(second.as_bytes(), &wanted, &second_source, &mut index)
             .expect("second source should parse");
 
+        assert_eq!(index.channel_count(), 1);
         assert_eq!(
             index.programmes_for_sources(&[first_source], "news", 0, i64::MAX)[0].title,
             "Provider A"

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -166,6 +166,23 @@ impl EpgIndex {
         }
     }
 
+    pub fn merge_sources_from(
+        &mut self,
+        other: &Self,
+        sources: &HashSet<String>,
+        tvg_ids: &HashSet<String>,
+    ) {
+        self.programmes.extend(
+            other
+                .programmes
+                .iter()
+                .filter(|((source, tvg_id), _)| {
+                    sources.contains(source) && tvg_ids.contains(tvg_id)
+                })
+                .map(|(channel, programmes)| (channel.clone(), programmes.clone())),
+        );
+    }
+
     fn finalize(&mut self) {
         for programmes in self.programmes.values_mut() {
             Self::finalize_programmes(programmes);
@@ -771,6 +788,52 @@ mod tests {
             index.programmes_for_sources(&[second_source], "news", 0, i64::MAX)[0].title,
             "Provider B"
         );
+    }
+
+    #[test]
+    fn merges_only_programmes_from_requested_sources() {
+        let parsed_ids = HashSet::from(["news".to_string(), "old".to_string()]);
+        let retained_source = "https://failed.example/epg.xml".to_string();
+        let replaced_source = "https://loaded.example/epg.xml".to_string();
+        let mut previous = EpgIndex::default();
+        parse_xmltv_into_with_source(
+            r#"<tv><programme start="20260828200000" stop="20260828210000" channel="news"><title>Retained</title></programme><programme start="20260828200000" stop="20260828210000" channel="old"><title>Stale</title></programme></tv>"#.as_bytes(),
+            &parsed_ids,
+            &retained_source,
+            &mut previous,
+        )
+        .expect("retained source should parse");
+        parse_xmltv_into_with_source(
+            r#"<tv><programme start="20260828200000" stop="20260828210000" channel="news"><title>Old</title></programme></tv>"#.as_bytes(),
+            &parsed_ids,
+            &replaced_source,
+            &mut previous,
+        )
+        .expect("replaced source should parse");
+
+        let mut refreshed = EpgIndex::default();
+        refreshed.merge_sources_from(
+            &previous,
+            &HashSet::from([retained_source.clone()]),
+            &HashSet::from(["news".to_string()]),
+        );
+
+        assert_eq!(
+            refreshed.programmes_for_sources(
+                std::slice::from_ref(&retained_source),
+                "news",
+                0,
+                i64::MAX,
+            )[0]
+            .title,
+            "Retained"
+        );
+        assert!(refreshed
+            .programmes_for_sources(std::slice::from_ref(&replaced_source), "news", 0, i64::MAX,)
+            .is_empty());
+        assert!(refreshed
+            .programmes_for_sources(std::slice::from_ref(&retained_source), "old", 0, i64::MAX,)
+            .is_empty());
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -40,7 +40,7 @@ pub struct EpgProgramme {
 
 #[derive(Debug, Default)]
 pub struct EpgIndex {
-    programmes: HashMap<String, Vec<EpgProgramme>>,
+    programmes: HashMap<(String, String), Vec<EpgProgramme>>,
 }
 
 impl EpgIndex {
@@ -53,23 +53,46 @@ impl EpgIndex {
     }
 
     pub fn has_channel(&self, tvg_id: &str) -> bool {
-        self.programmes.contains_key(tvg_id)
+        self.programmes.keys().any(|(_, id)| id == tvg_id)
     }
 
     pub fn matched_channel_ids(&self) -> Vec<String> {
-        self.programmes.keys().cloned().collect()
+        self.programmes
+            .keys()
+            .map(|(_, tvg_id)| tvg_id.clone())
+            .collect()
     }
 
     /// Programmes overlapping `[from, to)`, oldest first.
     pub fn programmes_for(&self, tvg_id: &str, from: i64, to: i64) -> Vec<EpgProgramme> {
-        let Some(programmes) = self.programmes.get(tvg_id) else {
-            return Vec::new();
-        };
-        programmes
+        self.programmes_for_sources(&[], tvg_id, from, to)
+    }
+
+    pub fn programmes_for_sources(
+        &self,
+        sources: &[String],
+        tvg_id: &str,
+        from: i64,
+        to: i64,
+    ) -> Vec<EpgProgramme> {
+        let mut programmes = self
+            .programmes
             .iter()
+            .filter(|((source, id), _)| {
+                id == tvg_id
+                    && if sources.is_empty() {
+                        source.is_empty()
+                    } else {
+                        sources.contains(source)
+                    }
+            })
+            .flat_map(|(_, programmes)| programmes.iter())
             .filter(|programme| programme.stop > from && programme.start < to)
             .cloned()
-            .collect()
+            .collect::<Vec<_>>();
+        programmes.sort_by_key(|programme| programme.start);
+        programmes.dedup();
+        programmes
     }
 
     pub fn merge(&mut self, other: EpgIndex) {
@@ -156,6 +179,16 @@ pub fn parse_xmltv_into<R: Read>(
     wanted: &HashSet<String>,
     index: &mut EpgIndex,
 ) -> Result<(), AppError> {
+    parse_xmltv_into_with_source(source, wanted, "", index)
+}
+
+/// Parse one XMLTV source while retaining the source identity in the index.
+pub fn parse_xmltv_into_with_source<R: Read>(
+    source: R,
+    wanted: &HashSet<String>,
+    source_identity: &str,
+    index: &mut EpgIndex,
+) -> Result<(), AppError> {
     let mut reader = Reader::from_reader(BufReader::new(source));
     reader.config_mut().trim_text(true);
 
@@ -220,7 +253,7 @@ pub fn parse_xmltv_into<R: Read>(
                         if stop > start {
                             index
                                 .programmes
-                                .entry(channel)
+                                .entry((source_identity.to_string(), channel))
                                 .or_default()
                                 .push(EpgProgramme {
                                     start,
@@ -418,6 +451,30 @@ mod tests {
 
         let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
         assert_eq!(programmes[0].title, "News & Weather");
+    }
+
+    #[test]
+    fn keeps_programmes_with_matching_ids_scoped_to_their_source() {
+        let first = r#"<tv><programme start="20260828200000" stop="20260828210000" channel="news"><title>Provider A</title></programme></tv>"#;
+        let second = r#"<tv><programme start="20260828200000" stop="20260828210000" channel="news"><title>Provider B</title></programme></tv>"#;
+        let wanted = HashSet::from(["news".to_string()]);
+        let first_source = "https://provider-a.example/epg.xml".to_string();
+        let second_source = "https://provider-b.example/epg.xml".to_string();
+        let mut index = EpgIndex::default();
+
+        parse_xmltv_into_with_source(first.as_bytes(), &wanted, &first_source, &mut index)
+            .expect("first source should parse");
+        parse_xmltv_into_with_source(second.as_bytes(), &wanted, &second_source, &mut index)
+            .expect("second source should parse");
+
+        assert_eq!(
+            index.programmes_for_sources(&[first_source], "news", 0, i64::MAX)[0].title,
+            "Provider A"
+        );
+        assert_eq!(
+            index.programmes_for_sources(&[second_source], "news", 0, i64::MAX)[0].title,
+            "Provider B"
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -12,6 +12,7 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
 
 use crate::error::AppError;
 
@@ -518,6 +519,7 @@ pub async fn download_epg_source(
     cache_dir: &Path,
     accept_invalid_certs: bool,
     force_refresh: bool,
+    cancel: &CancellationToken,
 ) -> Result<PathBuf, AppError> {
     std::fs::create_dir_all(cache_dir).map_err(AppError::Io)?;
     remove_stale_partial_downloads(cache_dir);
@@ -535,9 +537,12 @@ pub async fn download_epg_source(
         .build()
         .map_err(|error| AppError::Other(format!("Failed to build HTTP client: {error}")))?;
 
-    let response = client.get(url).send().await.map_err(|error| {
-        AppError::Other(format!("EPG download failed: {}", error.without_url()))
-    })?;
+    let response = tokio::select! {
+        _ = cancel.cancelled() => return Err(AppError::Other("EPG load superseded".to_string())),
+        response = client.get(url).send() => response.map_err(|error| {
+            AppError::Other(format!("EPG download failed: {}", error.without_url()))
+        })?,
+    };
     if !response.status().is_success() {
         return Err(AppError::Other(format!(
             "EPG download failed: HTTP {}",
@@ -550,11 +555,16 @@ pub async fn download_epg_source(
     let mut file = std::fs::File::create(&temp).map_err(AppError::Io)?;
     let mut downloaded: u64 = 0;
     let mut stream = response;
-    while let Some(chunk) = stream
-        .chunk()
-        .await
-        .map_err(|error| AppError::Other(format!("EPG download failed: {}", error.without_url())))?
-    {
+    loop {
+        let chunk = tokio::select! {
+            _ = cancel.cancelled() => return Err(AppError::Other("EPG load superseded".to_string())),
+            chunk = stream.chunk() => chunk.map_err(|error| {
+                AppError::Other(format!("EPG download failed: {}", error.without_url()))
+            })?,
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
         downloaded += chunk.len() as u64;
         if downloaded > EPG_MAX_DOWNLOAD_BYTES {
             return Err(AppError::Other(format!(
@@ -819,6 +829,32 @@ mod tests {
 
         assert!(!stale.exists());
         assert!(unrelated.exists());
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[tokio::test]
+    async fn cancels_epg_downloads_before_connecting() {
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-cancel-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let error = download_epg_source(
+            "https://example.invalid/guide.xml",
+            &dir,
+            false,
+            false,
+            &cancel,
+        )
+        .await
+        .expect_err("cancelled EPG download should stop");
+
+        assert!(error.to_string().contains("superseded"));
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -5,6 +5,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use quick_xml::events::Event;
@@ -19,6 +20,7 @@ const EPG_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const EPG_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Hard cap on a single downloaded guide; anything larger is a broken feed.
 const EPG_MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
+static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
 struct PartialEpgDownload {
     path: PathBuf,
@@ -324,6 +326,11 @@ fn cache_is_fresh(path: &Path) -> bool {
         .is_some_and(|age| age < EPG_CACHE_TTL)
 }
 
+fn temporary_cache_path(target: &Path) -> PathBuf {
+    let id = NEXT_TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
+    target.with_extension(format!("{}.{}.part", std::process::id(), id))
+}
+
 /// Download one EPG source into the cache (streamed), reusing a fresh copy.
 pub async fn download_epg_source(
     url: &str,
@@ -356,7 +363,7 @@ pub async fn download_epg_source(
         )));
     }
 
-    let temp = target.with_extension("part");
+    let temp = temporary_cache_path(&target);
     let _partial_download = PartialEpgDownload { path: temp.clone() };
     let mut file = std::fs::File::create(&temp).map_err(AppError::Io)?;
     let mut downloaded: u64 = 0;
@@ -485,6 +492,13 @@ mod tests {
             ),
             "https://example.com/xmltv.php"
         );
+    }
+
+    #[test]
+    fn uses_unique_temporary_cache_paths() {
+        let target = Path::new("epg-cache.bin");
+
+        assert_ne!(temporary_cache_path(target), temporary_cache_path(target));
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -1,0 +1,406 @@
+//! XMLTV EPG store: streamed download with a disk cache, gzip-aware parsing,
+//! and an in-memory programme index filtered to the playlist's tvg-ids so a
+//! multi-hundred-MB provider guide does not balloon into memory.
+
+use std::collections::{HashMap, HashSet};
+use std::io::{BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::AppError;
+
+const EPG_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+const EPG_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const EPG_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+/// Hard cap on a single downloaded guide; anything larger is a broken feed.
+const EPG_MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// One XMLTV programme; times are unix epoch seconds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EpgProgramme {
+    pub start: i64,
+    pub stop: i64,
+    pub title: String,
+}
+
+#[derive(Debug, Default)]
+pub struct EpgIndex {
+    programmes: HashMap<String, Vec<EpgProgramme>>,
+}
+
+impl EpgIndex {
+    pub fn channel_count(&self) -> usize {
+        self.programmes.len()
+    }
+
+    pub fn programme_count(&self) -> usize {
+        self.programmes.values().map(Vec::len).sum()
+    }
+
+    pub fn has_channel(&self, tvg_id: &str) -> bool {
+        self.programmes.contains_key(tvg_id)
+    }
+
+    pub fn matched_channel_ids(&self) -> Vec<String> {
+        self.programmes.keys().cloned().collect()
+    }
+
+    /// Programmes overlapping `[from, to)`, oldest first.
+    pub fn programmes_for(&self, tvg_id: &str, from: i64, to: i64) -> Vec<EpgProgramme> {
+        let Some(programmes) = self.programmes.get(tvg_id) else {
+            return Vec::new();
+        };
+        programmes
+            .iter()
+            .filter(|programme| programme.stop > from && programme.start < to)
+            .cloned()
+            .collect()
+    }
+
+    pub fn merge(&mut self, other: EpgIndex) {
+        for (channel, mut programmes) in other.programmes {
+            self.programmes
+                .entry(channel)
+                .or_default()
+                .append(&mut programmes);
+        }
+        self.finalize();
+    }
+
+    fn finalize(&mut self) {
+        for programmes in self.programmes.values_mut() {
+            programmes.sort_by_key(|programme| programme.start);
+            programmes.dedup();
+        }
+    }
+}
+
+/// Howard Hinnant's days-from-civil: days since 1970-01-01 for a Gregorian date.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month_prime = (month + 9) % 12;
+    let day_of_year = (153 * month_prime + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146097 + day_of_era - 719468
+}
+
+/// Parse an XMLTV timestamp (`YYYYMMDDHHMMSS ±HHMM`, seconds and offset
+/// optional) into unix epoch seconds. Timestamps without an offset are UTC.
+pub fn parse_xmltv_time(raw: &str) -> Option<i64> {
+    let raw = raw.trim();
+    // The offset starts at the first space or sign after the date digits.
+    let (digits, offset) = match raw.find([' ', '+', '-']) {
+        Some(position) if position >= 12 => (&raw[..position], raw[position..].trim()),
+        _ => (raw, ""),
+    };
+
+    if digits.len() < 12 || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let field = |from: usize, to: usize| digits[from..to].parse::<i64>().ok();
+    let year = field(0, 4)?;
+    let month = field(4, 6)?;
+    let day = field(6, 8)?;
+    let hour = field(8, 10)?;
+    let minute = field(10, 12)?;
+    let second = if digits.len() >= 14 {
+        field(12, 14)?
+    } else {
+        0
+    };
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) || hour > 23 || minute > 59 {
+        return None;
+    }
+
+    let mut epoch =
+        days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second;
+
+    // Offset formats: "+0200", "-0530", "0200" (sign consumed by split above).
+    let offset = offset.trim();
+    if !offset.is_empty() {
+        let (sign, body) = match offset.as_bytes()[0] {
+            b'-' => (-1, &offset[1..]),
+            b'+' => (1, &offset[1..]),
+            _ => (1, offset),
+        };
+        if body.len() == 4 && body.chars().all(|c| c.is_ascii_digit()) {
+            let hours = body[0..2].parse::<i64>().ok()?;
+            let minutes = body[2..4].parse::<i64>().ok()?;
+            epoch -= sign * (hours * 3_600 + minutes * 60);
+        }
+    }
+    Some(epoch)
+}
+
+/// Parse an XMLTV document into `index`, keeping only programmes whose
+/// `channel` is in `wanted` (an empty filter keeps everything).
+pub fn parse_xmltv_into<R: Read>(
+    source: R,
+    wanted: &HashSet<String>,
+    index: &mut EpgIndex,
+) -> Result<(), AppError> {
+    let mut reader = Reader::from_reader(BufReader::new(source));
+    reader.config_mut().trim_text(true);
+
+    let mut buffer = Vec::new();
+    let mut current: Option<(String, i64, i64)> = None;
+    let mut current_title: Option<String> = None;
+    let mut in_title = false;
+
+    loop {
+        buffer.clear();
+        match reader.read_event_into(&mut buffer) {
+            Ok(Event::Start(element)) => match element.name().as_ref() {
+                b"programme" => {
+                    let mut channel = None;
+                    let mut start = None;
+                    let mut stop = None;
+                    for attribute in element.attributes().flatten() {
+                        let value = attribute.unescape_value().unwrap_or_default();
+                        match attribute.key.as_ref() {
+                            b"channel" => channel = Some(value.into_owned()),
+                            b"start" => start = parse_xmltv_time(&value),
+                            b"stop" => stop = parse_xmltv_time(&value),
+                            _ => {}
+                        }
+                    }
+                    current = match (channel, start, stop) {
+                        (Some(channel), Some(start), Some(stop))
+                            if wanted.is_empty() || wanted.contains(&channel) =>
+                        {
+                            Some((channel, start, stop))
+                        }
+                        _ => None,
+                    };
+                    current_title = None;
+                }
+                b"title" if current.is_some() && current_title.is_none() => {
+                    in_title = true;
+                }
+                _ => {}
+            },
+            Ok(Event::Text(text)) => {
+                if in_title {
+                    let value = text.unescape().unwrap_or_default().into_owned();
+                    if !value.trim().is_empty() {
+                        current_title = Some(value.trim().to_string());
+                    }
+                    in_title = false;
+                }
+            }
+            Ok(Event::End(element)) => match element.name().as_ref() {
+                b"programme" => {
+                    if let Some((channel, start, stop)) = current.take() {
+                        if stop > start {
+                            index
+                                .programmes
+                                .entry(channel)
+                                .or_default()
+                                .push(EpgProgramme {
+                                    start,
+                                    stop,
+                                    title: current_title
+                                        .take()
+                                        .unwrap_or_else(|| "Untitled".to_string()),
+                                });
+                        }
+                    }
+                    in_title = false;
+                }
+                b"title" => in_title = false,
+                _ => {}
+            },
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(error) => {
+                return Err(AppError::Other(format!("Failed to parse XMLTV: {error}")));
+            }
+        }
+    }
+
+    index.finalize();
+    Ok(())
+}
+
+/// Open a cached guide file, transparently gunzipping `.gz` payloads.
+pub fn open_guide_file(path: &Path) -> Result<Box<dyn Read + Send>, AppError> {
+    let mut file = std::fs::File::open(path).map_err(AppError::Io)?;
+    let mut magic = [0u8; 2];
+    let read = std::io::Read::read(&mut file, &mut magic).map_err(AppError::Io)?;
+    use std::io::Seek;
+    file.seek(std::io::SeekFrom::Start(0))
+        .map_err(AppError::Io)?;
+    if read == 2 && magic == [0x1f, 0x8b] {
+        Ok(Box::new(flate2::read::GzDecoder::new(file)))
+    } else {
+        Ok(Box::new(file))
+    }
+}
+
+pub fn cache_path_for(cache_dir: &Path, url: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(url.as_bytes());
+    let hash = hasher.finalize();
+    let hex: String = hash.iter().take(16).map(|b| format!("{b:02x}")).collect();
+    cache_dir.join(format!("epg-{hex}.bin"))
+}
+
+fn cache_is_fresh(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age < EPG_CACHE_TTL)
+}
+
+/// Download one EPG source into the cache (streamed), reusing a fresh copy.
+pub async fn download_epg_source(
+    url: &str,
+    cache_dir: &Path,
+    accept_invalid_certs: bool,
+    force_refresh: bool,
+) -> Result<PathBuf, AppError> {
+    let target = cache_path_for(cache_dir, url);
+    if !force_refresh && cache_is_fresh(&target) {
+        log::info!("EPG cache hit for {url}");
+        return Ok(target);
+    }
+
+    std::fs::create_dir_all(cache_dir).map_err(AppError::Io)?;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .connect_timeout(EPG_DOWNLOAD_CONNECT_TIMEOUT)
+        .timeout(EPG_DOWNLOAD_TIMEOUT)
+        .danger_accept_invalid_certs(accept_invalid_certs)
+        .build()
+        .map_err(|error| AppError::Other(format!("Failed to build HTTP client: {error}")))?;
+
+    let response = client.get(url).send().await.map_err(|error| {
+        AppError::Other(format!("EPG download failed: {}", error.without_url()))
+    })?;
+    if !response.status().is_success() {
+        return Err(AppError::Other(format!(
+            "EPG download failed: HTTP {}",
+            response.status()
+        )));
+    }
+
+    let temp = target.with_extension("part");
+    let mut file = std::fs::File::create(&temp).map_err(AppError::Io)?;
+    let mut downloaded: u64 = 0;
+    let mut stream = response;
+    while let Some(chunk) = stream
+        .chunk()
+        .await
+        .map_err(|error| AppError::Other(format!("EPG download failed: {}", error.without_url())))?
+    {
+        downloaded += chunk.len() as u64;
+        if downloaded > EPG_MAX_DOWNLOAD_BYTES {
+            let _ = std::fs::remove_file(&temp);
+            return Err(AppError::Other(format!(
+                "EPG source exceeds {} MB limit",
+                EPG_MAX_DOWNLOAD_BYTES / (1024 * 1024)
+            )));
+        }
+        file.write_all(&chunk).map_err(AppError::Io)?;
+    }
+    file.flush().map_err(AppError::Io)?;
+    drop(file);
+    std::fs::rename(&temp, &target).map_err(AppError::Io)?;
+    log::info!("Downloaded EPG {url} ({downloaded} bytes)");
+    Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_xmltv_timestamps_with_and_without_offsets() {
+        // 2026-08-29 06:30:00 UTC
+        assert_eq!(parse_xmltv_time("20260829063000"), Some(1_787_985_000));
+        // Same instant expressed with +02:00
+        assert_eq!(
+            parse_xmltv_time("20260829083000 +0200"),
+            Some(1_787_985_000)
+        );
+        assert_eq!(
+            parse_xmltv_time("20260829043000 -0200"),
+            Some(1_787_985_000)
+        );
+        // Minute precision only
+        assert_eq!(parse_xmltv_time("202608290630"), Some(1_787_985_000));
+        assert_eq!(parse_xmltv_time("garbage"), None);
+        assert_eq!(parse_xmltv_time(""), None);
+    }
+
+    #[test]
+    fn parses_programmes_filtered_by_channel() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="nrk1.no"><display-name>NRK1</display-name></channel>
+  <programme start="20260828200000 +0000" stop="20260828210000 +0000" channel="nrk1.no">
+    <title lang="no">Dagsrevyen</title>
+    <desc>News broadcast</desc>
+  </programme>
+  <programme start="20260828210000 +0000" stop="20260828220000 +0000" channel="nrk1.no">
+    <title>Exit</title>
+  </programme>
+  <programme start="20260828200000 +0000" stop="20260828210000 +0000" channel="unwanted.tv">
+    <title>Skipped</title>
+  </programme>
+</tv>"#;
+
+        let wanted = HashSet::from(["nrk1.no".to_string()]);
+        let mut index = EpgIndex::default();
+        parse_xmltv_into(xml.as_bytes(), &wanted, &mut index).expect("xmltv should parse");
+
+        assert_eq!(index.channel_count(), 1);
+        assert_eq!(index.programme_count(), 2);
+        let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
+        assert_eq!(programmes[0].title, "Dagsrevyen");
+        assert_eq!(programmes[1].title, "Exit");
+        assert_eq!(programmes[1].stop - programmes[1].start, 3600);
+
+        // Window queries clip to overlapping programmes.
+        let start = programmes[0].start;
+        let only_first = index.programmes_for("nrk1.no", start, start + 1800);
+        assert_eq!(only_first.len(), 1);
+        assert!(index.programmes_for("unwanted.tv", 0, i64::MAX).is_empty());
+    }
+
+    #[test]
+    fn gunzips_cached_guides_transparently() {
+        let xml = "<tv><programme start=\"20260828200000\" stop=\"20260828210000\" channel=\"a\"><title>T</title></programme></tv>";
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("guide.xml.gz");
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(xml.as_bytes()).expect("gzip write");
+        std::fs::write(&path, encoder.finish().expect("gzip finish")).expect("write");
+
+        let mut index = EpgIndex::default();
+        parse_xmltv_into(
+            open_guide_file(&path).expect("open"),
+            &HashSet::new(),
+            &mut index,
+        )
+        .expect("parse");
+        assert_eq!(index.programme_count(), 1);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+}

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -344,7 +344,7 @@ pub async fn download_epg_source(
     }
     file.flush().map_err(AppError::Io)?;
     drop(file);
-    std::fs::rename(&temp, &target).map_err(AppError::Io)?;
+    crate::engine::disk::atomic_rename(&target, &temp)?;
     log::info!(
         "Downloaded EPG {} ({downloaded} bytes)",
         redact_epg_source(url)

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -20,6 +20,16 @@ const EPG_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Hard cap on a single downloaded guide; anything larger is a broken feed.
 const EPG_MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
 
+struct PartialEpgDownload {
+    path: PathBuf,
+}
+
+impl Drop for PartialEpgDownload {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 /// One XMLTV programme; times are unix epoch seconds.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EpgProgramme {
@@ -195,6 +205,15 @@ pub fn parse_xmltv_into<R: Read>(
                     in_title = false;
                 }
             }
+            Ok(Event::CData(text)) => {
+                if in_title {
+                    let value = text.decode().unwrap_or_default().into_owned();
+                    if !value.trim().is_empty() {
+                        current_title = Some(value.trim().to_string());
+                    }
+                    in_title = false;
+                }
+            }
             Ok(Event::End(element)) => match element.name().as_ref() {
                 b"programme" => {
                     if let Some((channel, start, stop)) = current.take() {
@@ -252,6 +271,18 @@ pub fn cache_path_for(cache_dir: &Path, url: &str) -> PathBuf {
     cache_dir.join(format!("epg-{hex}.bin"))
 }
 
+/// Return a safe source label for logs and UI-visible failure summaries.
+pub fn redact_epg_source(source: &str) -> String {
+    let Ok(mut url) = url::Url::parse(source) else {
+        return "<invalid EPG source>".to_string();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
 fn cache_is_fresh(path: &Path) -> bool {
     std::fs::metadata(path)
         .and_then(|meta| meta.modified())
@@ -269,7 +300,7 @@ pub async fn download_epg_source(
 ) -> Result<PathBuf, AppError> {
     let target = cache_path_for(cache_dir, url);
     if !force_refresh && cache_is_fresh(&target) {
-        log::info!("EPG cache hit for {url}");
+        log::info!("EPG cache hit for {}", redact_epg_source(url));
         return Ok(target);
     }
 
@@ -293,6 +324,7 @@ pub async fn download_epg_source(
     }
 
     let temp = target.with_extension("part");
+    let _partial_download = PartialEpgDownload { path: temp.clone() };
     let mut file = std::fs::File::create(&temp).map_err(AppError::Io)?;
     let mut downloaded: u64 = 0;
     let mut stream = response;
@@ -303,7 +335,6 @@ pub async fn download_epg_source(
     {
         downloaded += chunk.len() as u64;
         if downloaded > EPG_MAX_DOWNLOAD_BYTES {
-            let _ = std::fs::remove_file(&temp);
             return Err(AppError::Other(format!(
                 "EPG source exceeds {} MB limit",
                 EPG_MAX_DOWNLOAD_BYTES / (1024 * 1024)
@@ -314,7 +345,10 @@ pub async fn download_epg_source(
     file.flush().map_err(AppError::Io)?;
     drop(file);
     std::fs::rename(&temp, &target).map_err(AppError::Io)?;
-    log::info!("Downloaded EPG {url} ({downloaded} bytes)");
+    log::info!(
+        "Downloaded EPG {} ({downloaded} bytes)",
+        redact_epg_source(url)
+    );
     Ok(target)
 }
 
@@ -374,6 +408,26 @@ mod tests {
         let only_first = index.programmes_for("nrk1.no", start, start + 1800);
         assert_eq!(only_first.len(), 1);
         assert!(index.programmes_for("unwanted.tv", 0, i64::MAX).is_empty());
+    }
+
+    #[test]
+    fn parses_cdata_programme_titles() {
+        let xml = r#"<tv><programme start="20260828200000" stop="20260828210000" channel="nrk1.no"><title><![CDATA[News & Weather]]></title></programme></tv>"#;
+        let mut index = EpgIndex::default();
+        parse_xmltv_into(xml.as_bytes(), &HashSet::new(), &mut index).expect("xmltv should parse");
+
+        let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
+        assert_eq!(programmes[0].title, "News & Weather");
+    }
+
+    #[test]
+    fn redacts_epg_source_credentials() {
+        assert_eq!(
+            redact_epg_source(
+                "https://alice:secret@example.com/xmltv.php?username=alice&password=secret"
+            ),
+            "https://example.com/xmltv.php"
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -108,7 +108,8 @@ impl EpgIndex {
         tvg_ids
             .iter()
             .filter(|tvg_id| matched_ids.contains(tvg_id.as_str()))
-            .count()
+            .collect::<HashSet<_>>()
+            .len()
     }
 
     pub fn programme_count(&self) -> usize {
@@ -138,18 +139,17 @@ impl EpgIndex {
         from: i64,
         to: i64,
     ) -> Vec<EpgProgramme> {
-        let mut programmes = self
-            .programmes
+        let default_source = String::new();
+        let requested_sources = if sources.is_empty() {
+            std::slice::from_ref(&default_source)
+        } else {
+            sources
+        };
+        let tvg_id = tvg_id.to_string();
+        let mut programmes = requested_sources
             .iter()
-            .filter(|((source, id), _)| {
-                id == tvg_id
-                    && if sources.is_empty() {
-                        source.is_empty()
-                    } else {
-                        sources.contains(source)
-                    }
-            })
-            .flat_map(|(_, programmes)| programmes.iter())
+            .filter_map(|source| self.programmes.get(&(source.clone(), tvg_id.clone())))
+            .flat_map(|programmes| programmes.iter())
             .filter(|programme| programme.stop > from && programme.start < to)
             .cloned()
             .collect::<Vec<_>>();
@@ -160,30 +160,32 @@ impl EpgIndex {
 
     pub fn merge(&mut self, other: EpgIndex) {
         for (channel, mut programmes) in other.programmes {
-            self.programmes
-                .entry(channel)
-                .or_default()
-                .append(&mut programmes);
+            let merged = self.programmes.entry(channel).or_default();
+            merged.append(&mut programmes);
+            Self::finalize_programmes(merged);
         }
-        self.finalize();
     }
 
     fn finalize(&mut self) {
         for programmes in self.programmes.values_mut() {
-            programmes.sort_by_key(|programme| programme.start);
-            for index in 0..programmes.len() {
-                if programmes[index].stop == programmes[index].start {
-                    let start = programmes[index].start;
-                    let stop = programmes[index + 1..]
-                        .iter()
-                        .find(|programme| programme.start > start)
-                        .map(|programme| programme.start)
-                        .unwrap_or(start.saturating_add(EPG_MISSING_STOP_FALLBACK));
-                    programmes[index].stop = stop;
-                }
-            }
-            programmes.dedup();
+            Self::finalize_programmes(programmes);
         }
+    }
+
+    fn finalize_programmes(programmes: &mut Vec<EpgProgramme>) {
+        programmes.sort_by_key(|programme| programme.start);
+        for index in 0..programmes.len() {
+            if programmes[index].stop == programmes[index].start {
+                let start = programmes[index].start;
+                let stop = programmes[index + 1..]
+                    .iter()
+                    .find(|programme| programme.start > start)
+                    .map(|programme| programme.start)
+                    .unwrap_or(start.saturating_add(EPG_MISSING_STOP_FALLBACK));
+                programmes[index].stop = stop;
+            }
+        }
+        programmes.dedup();
     }
 }
 
@@ -414,7 +416,7 @@ pub fn open_guide_file(path: &Path) -> Result<Box<dyn Read + Send>, AppError> {
         .map_err(AppError::Io)?;
     if read == 2 && magic == [0x1f, 0x8b] {
         Ok(Box::new(LimitedReader::new(
-            flate2::read::GzDecoder::new(file),
+            flate2::read::MultiGzDecoder::new(file),
             EPG_MAX_DECOMPRESSED_BYTES,
         )))
     } else {
@@ -656,7 +658,7 @@ mod tests {
                 "nrk1.no".to_string(),
                 "unwanted.tv".to_string(),
             ]),
-            2
+            1
         );
         assert_eq!(index.programme_count(), 2);
         let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
@@ -960,6 +962,44 @@ mod tests {
         let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
         encoder.write_all(xml.as_bytes()).expect("gzip write");
         std::fs::write(&path, encoder.finish().expect("gzip finish")).expect("write");
+
+        let mut index = EpgIndex::default();
+        parse_xmltv_into(
+            open_guide_file(&path).expect("open"),
+            &HashSet::new(),
+            &mut index,
+        )
+        .expect("parse");
+        assert_eq!(index.programme_count(), 1);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn gunzips_concatenated_cached_guides_transparently() {
+        let chunks = [
+            "<tv><programme start=\"20260828200000\" stop=\"20260828210000\" channel=\"a\">",
+            "<title>T</title></programme></tv>",
+        ];
+        let compressed = chunks
+            .into_iter()
+            .flat_map(|chunk| {
+                let mut encoder =
+                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+                encoder.write_all(chunk.as_bytes()).expect("gzip write");
+                encoder.finish().expect("gzip finish")
+            })
+            .collect::<Vec<_>>();
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-multigzip-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("guide.xml.gz");
+        std::fs::write(&path, compressed).expect("write");
 
         let mut index = EpgIndex::default();
         parse_xmltv_into(

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -208,7 +208,9 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                     let mut start = None;
                     let mut stop = None;
                     for attribute in element.attributes().flatten() {
-                        let value = attribute.unescape_value().unwrap_or_default();
+                        let value = attribute
+                            .decode_and_unescape_value(reader.decoder())
+                            .unwrap_or_default();
                         match attribute.key.as_ref() {
                             b"channel" => channel = Some(value.into_owned()),
                             b"start" => start = parse_xmltv_time(&value),
@@ -458,6 +460,18 @@ mod tests {
 
         let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
         assert_eq!(programmes[0].title, "News & Weather");
+    }
+
+    #[test]
+    fn parses_windows_1252_channel_ids_and_titles() {
+        let xml = b"<?xml version=\"1.0\" encoding=\"windows-1252\"?><tv><programme start=\"20260828200000\" stop=\"20260828210000\" channel=\"caf\xe9\"><title>Caf\xe9 News</title></programme></tv>";
+        let wanted = HashSet::from(["café".to_string()]);
+        let mut index = EpgIndex::default();
+
+        parse_xmltv_into(xml.as_slice(), &wanted, &mut index).expect("xmltv should parse");
+
+        let programmes = index.programmes_for("café", 0, i64::MAX);
+        assert_eq!(programmes[0].title, "Café News");
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -255,41 +255,63 @@ pub fn parse_xmltv_into_with_source<R: Read>(
     let mut current: Option<(String, i64, Option<i64>)> = None;
     let mut current_title: Option<String> = None;
     let mut in_title = false;
+    let mut saw_xmltv_root = false;
 
     loop {
         buffer.clear();
         match reader.read_event_into(&mut buffer) {
-            Ok(Event::Start(element)) => match element.name().as_ref() {
-                b"programme" => {
-                    let mut channel = None;
-                    let mut start = None;
-                    let mut stop = None;
-                    for attribute in element.attributes().flatten() {
-                        let value = attribute
-                            .decode_and_unescape_value(reader.decoder())
-                            .unwrap_or_default();
-                        match attribute.key.as_ref() {
-                            b"channel" => channel = Some(value.into_owned()),
-                            b"start" => start = parse_xmltv_time(&value),
-                            b"stop" => stop = parse_xmltv_time(&value),
-                            _ => {}
-                        }
+            Ok(Event::Start(element)) => {
+                if !saw_xmltv_root {
+                    if element.name().as_ref() != b"tv" {
+                        return Err(AppError::Other(
+                            "Failed to parse XMLTV: document root is not <tv>".to_string(),
+                        ));
                     }
-                    current = match (channel, start, stop) {
-                        (Some(channel), Some(start), stop)
-                            if wanted.is_empty() || wanted.contains(&channel) =>
-                        {
-                            Some((channel, start, stop))
+                    saw_xmltv_root = true;
+                }
+
+                match element.name().as_ref() {
+                    b"programme" => {
+                        let mut channel = None;
+                        let mut start = None;
+                        let mut stop = None;
+                        for attribute in element.attributes().flatten() {
+                            let value = attribute
+                                .decode_and_unescape_value(reader.decoder())
+                                .unwrap_or_default();
+                            match attribute.key.as_ref() {
+                                b"channel" => channel = Some(value.into_owned()),
+                                b"start" => start = parse_xmltv_time(&value),
+                                b"stop" => stop = parse_xmltv_time(&value),
+                                _ => {}
+                            }
                         }
-                        _ => None,
-                    };
-                    current_title = None;
+                        current = match (channel, start, stop) {
+                            (Some(channel), Some(start), stop)
+                                if wanted.is_empty() || wanted.contains(&channel) =>
+                            {
+                                Some((channel, start, stop))
+                            }
+                            _ => None,
+                        };
+                        current_title = None;
+                    }
+                    b"title" if current.is_some() && current_title.is_none() => {
+                        in_title = true;
+                    }
+                    _ => {}
                 }
-                b"title" if current.is_some() && current_title.is_none() => {
-                    in_title = true;
+            }
+            Ok(Event::Empty(element)) => {
+                if !saw_xmltv_root {
+                    if element.name().as_ref() != b"tv" {
+                        return Err(AppError::Other(
+                            "Failed to parse XMLTV: document root is not <tv>".to_string(),
+                        ));
+                    }
+                    saw_xmltv_root = true;
                 }
-                _ => {}
-            },
+            }
             Ok(Event::Text(text)) => {
                 if in_title {
                     let value = text.unescape().unwrap_or_default().into_owned();
@@ -332,7 +354,14 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                 b"title" => in_title = false,
                 _ => {}
             },
-            Ok(Event::Eof) => break,
+            Ok(Event::Eof) => {
+                if !saw_xmltv_root {
+                    return Err(AppError::Other(
+                        "Failed to parse XMLTV: missing <tv> root".to_string(),
+                    ));
+                }
+                break;
+            }
             Ok(_) => {}
             Err(error) => {
                 return Err(AppError::Other(format!("Failed to parse XMLTV: {error}")));
@@ -585,6 +614,28 @@ mod tests {
 
         let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
         assert_eq!(programmes[0].title, "News & Weather");
+    }
+
+    #[test]
+    fn accepts_an_empty_xmltv_guide() {
+        let mut index = EpgIndex::default();
+
+        parse_xmltv_into("<tv/>".as_bytes(), &HashSet::new(), &mut index)
+            .expect("empty XMLTV guide should parse");
+
+        assert_eq!(index.programme_count(), 0);
+    }
+
+    #[test]
+    fn rejects_documents_without_an_xmltv_root() {
+        for document in ["", "<html><body>Sign in</body></html>"] {
+            let mut index = EpgIndex::default();
+
+            let error = parse_xmltv_into(document.as_bytes(), &HashSet::new(), &mut index)
+                .expect_err("non-XMLTV document should fail");
+
+            assert!(error.to_string().contains("XMLTV"));
+        }
     }
 
     #[test]

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -20,6 +20,12 @@ const EPG_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const EPG_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Hard cap on a single downloaded guide; anything larger is a broken feed.
 const EPG_MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
+/// Prevent compressed XMLTV feeds from expanding without bound while parsing.
+const EPG_MAX_DECOMPRESSED_BYTES: u64 = 1024 * 1024 * 1024;
+/// Missing XMLTV stop times use the following programme, or this fallback.
+const EPG_MISSING_STOP_FALLBACK: i64 = 6 * 60 * 60;
+/// Keep recently used EPG downloads bounded across distinct playlist sources.
+const EPG_CACHE_MAX_BYTES: u64 = 5 * 1024 * 1024 * 1024;
 static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
 struct PartialEpgDownload {
@@ -29,6 +35,42 @@ struct PartialEpgDownload {
 impl Drop for PartialEpgDownload {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+struct LimitedReader<R> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R: Read> LimitedReader<R> {
+    fn new(inner: R, limit: u64) -> Self {
+        Self {
+            inner,
+            remaining: limit,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            let mut extra = [0u8; 1];
+            return match self.inner.read(&mut extra)? {
+                0 => Ok(0),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "EPG source exceeds decompressed size limit",
+                )),
+            };
+        }
+        let readable = buffer.len().min(self.remaining as usize);
+        let read = self.inner.read(&mut buffer[..readable])?;
+        self.remaining -= read as u64;
+        Ok(read)
     }
 }
 
@@ -110,6 +152,17 @@ impl EpgIndex {
     fn finalize(&mut self) {
         for programmes in self.programmes.values_mut() {
             programmes.sort_by_key(|programme| programme.start);
+            for index in 0..programmes.len() {
+                if programmes[index].stop == programmes[index].start {
+                    let start = programmes[index].start;
+                    let stop = programmes[index + 1..]
+                        .iter()
+                        .find(|programme| programme.start > start)
+                        .map(|programme| programme.start)
+                        .unwrap_or(start.saturating_add(EPG_MISSING_STOP_FALLBACK));
+                    programmes[index].stop = stop;
+                }
+            }
             programmes.dedup();
         }
     }
@@ -195,7 +248,7 @@ pub fn parse_xmltv_into_with_source<R: Read>(
     reader.config_mut().trim_text(true);
 
     let mut buffer = Vec::new();
-    let mut current: Option<(String, i64, i64)> = None;
+    let mut current: Option<(String, i64, Option<i64>)> = None;
     let mut current_title: Option<String> = None;
     let mut in_title = false;
 
@@ -219,7 +272,7 @@ pub fn parse_xmltv_into_with_source<R: Read>(
                         }
                     }
                     current = match (channel, start, stop) {
-                        (Some(channel), Some(start), Some(stop))
+                        (Some(channel), Some(start), stop)
                             if wanted.is_empty() || wanted.contains(&channel) =>
                         {
                             Some((channel, start, stop))
@@ -254,14 +307,16 @@ pub fn parse_xmltv_into_with_source<R: Read>(
             Ok(Event::End(element)) => match element.name().as_ref() {
                 b"programme" => {
                     if let Some((channel, start, stop)) = current.take() {
-                        if stop > start {
+                        if stop.is_none_or(|stop| stop > start) {
                             index
                                 .programmes
                                 .entry((source_identity.to_string(), channel))
                                 .or_default()
                                 .push(EpgProgramme {
                                     start,
-                                    stop,
+                                    // `start` is an internal sentinel for an omitted stop time;
+                                    // finalize replaces it with the following programme or fallback.
+                                    stop: stop.unwrap_or(start),
                                     title: current_title
                                         .take()
                                         .unwrap_or_else(|| "Untitled".to_string()),
@@ -294,9 +349,15 @@ pub fn open_guide_file(path: &Path) -> Result<Box<dyn Read + Send>, AppError> {
     file.seek(std::io::SeekFrom::Start(0))
         .map_err(AppError::Io)?;
     if read == 2 && magic == [0x1f, 0x8b] {
-        Ok(Box::new(flate2::read::GzDecoder::new(file)))
+        Ok(Box::new(LimitedReader::new(
+            flate2::read::GzDecoder::new(file),
+            EPG_MAX_DECOMPRESSED_BYTES,
+        )))
     } else {
-        Ok(Box::new(file))
+        Ok(Box::new(LimitedReader::new(
+            file,
+            EPG_MAX_DECOMPRESSED_BYTES,
+        )))
     }
 }
 
@@ -331,6 +392,45 @@ fn cache_is_fresh(path: &Path) -> bool {
 fn temporary_cache_path(target: &Path) -> PathBuf {
     let id = NEXT_TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
     target.with_extension(format!("{}.{}.part", std::process::id(), id))
+}
+
+fn prune_epg_cache(cache_dir: &Path, keep: &Path, max_bytes: u64) {
+    let Ok(entries) = std::fs::read_dir(cache_dir) else {
+        return;
+    };
+    let mut cached = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            if path == keep || !name.starts_with("epg-") || !name.ends_with(".bin") {
+                return None;
+            }
+            let metadata = entry.metadata().ok()?;
+            metadata.is_file().then_some((
+                metadata
+                    .modified()
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+                metadata.len(),
+                path,
+            ))
+        })
+        .collect::<Vec<_>>();
+    let mut total_bytes = cached.iter().map(|(_, size, _)| size).sum::<u64>();
+    total_bytes += std::fs::metadata(keep)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    cached.sort_by_key(|(modified, _, _)| *modified);
+
+    for (_, size, path) in cached {
+        if total_bytes <= max_bytes {
+            break;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => total_bytes = total_bytes.saturating_sub(size),
+            Err(error) => log::warn!("Failed to prune EPG cache {}: {error}", path.display()),
+        }
+    }
 }
 
 /// Download one EPG source into the cache (streamed), reusing a fresh copy.
@@ -387,6 +487,7 @@ pub async fn download_epg_source(
     file.flush().map_err(AppError::Io)?;
     drop(file);
     crate::engine::disk::atomic_rename(&target, &temp)?;
+    prune_epg_cache(cache_dir, &target, EPG_CACHE_MAX_BYTES);
     log::info!(
         "Downloaded EPG {} ({downloaded} bytes)",
         redact_epg_source(url)
@@ -453,6 +554,26 @@ mod tests {
     }
 
     #[test]
+    fn infers_missing_programme_stop_times() {
+        let xml = r#"<tv>
+  <programme start="20260828200000" channel="nrk1.no"><title>News</title></programme>
+  <programme start="20260828210000" stop="20260828211000" channel="nrk1.no"><title>Weather</title></programme>
+  <programme start="20260828220000" channel="nrk1.no"><title>Late</title></programme>
+</tv>"#;
+        let mut index = EpgIndex::default();
+
+        parse_xmltv_into(xml.as_bytes(), &HashSet::new(), &mut index).expect("xmltv should parse");
+
+        let programmes = index.programmes_for("nrk1.no", 0, i64::MAX);
+        assert_eq!(programmes.len(), 3);
+        assert_eq!(programmes[0].stop, programmes[1].start);
+        assert_eq!(
+            programmes[2].stop - programmes[2].start,
+            EPG_MISSING_STOP_FALLBACK
+        );
+    }
+
+    #[test]
     fn parses_cdata_programme_titles() {
         let xml = r#"<tv><programme start="20260828200000" stop="20260828210000" channel="nrk1.no"><title><![CDATA[News & Weather]]></title></programme></tv>"#;
         let mut index = EpgIndex::default();
@@ -513,6 +634,48 @@ mod tests {
         let target = Path::new("epg-cache.bin");
 
         assert_ne!(temporary_cache_path(target), temporary_cache_path(target));
+    }
+
+    #[test]
+    fn rejects_readers_that_exceed_the_decompressed_limit() {
+        let mut reader = LimitedReader::new("too long".as_bytes(), 3);
+        let mut output = Vec::new();
+
+        let error = reader
+            .read_to_end(&mut output)
+            .expect_err("should exceed limit");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(output, b"too");
+    }
+
+    #[test]
+    fn prunes_old_epg_cache_entries_but_keeps_current_download() {
+        let dir = std::env::temp_dir().join(format!(
+            "iptv-epg-cache-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let oldest = dir.join("epg-oldest.bin");
+        let newest = dir.join("epg-newest.bin");
+        let keep = dir.join("epg-keep.bin");
+        std::fs::write(&oldest, [0; 4]).expect("write oldest");
+        std::fs::write(&newest, [0; 4]).expect("write newest");
+        std::fs::write(&keep, [0; 4]).expect("write keep");
+        std::fs::File::open(&oldest)
+            .expect("open oldest")
+            .set_modified(std::time::SystemTime::UNIX_EPOCH)
+            .expect("age oldest");
+
+        prune_epg_cache(&dir, &keep, 8);
+
+        assert!(!oldest.exists());
+        assert!(newest.exists());
+        assert!(keep.exists());
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     #[test]

--- a/src-tauri/src/engine/ffmpeg.rs
+++ b/src-tauri/src/engine/ffmpeg.rs
@@ -41,6 +41,8 @@ static FORMAT_BR_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"bitrate:\s*(\d+)\s*kb/s").unwrap());
 static BYTES_READ_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(\d+)\s+bytes\s+read").unwrap());
+static FFMPEG_URL_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"(?i)\b(?:https?|rtsp|rtmp)://[^\s'"]+"#).unwrap());
 static AUDIO_LAYOUT_VALUE_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(\d+(?:\.\d+)?)").unwrap());
 
@@ -352,7 +354,11 @@ pub(crate) fn sanitize_ffmpeg_stderr_line(line: &str) -> String {
         }
         return "Input #<REDACTED> from '<REDACTED_URL>'".to_string();
     }
-    trimmed.to_string()
+    FFMPEG_URL_RE
+        .replace_all(trimmed, |captures: &regex::Captures<'_>| {
+            redact_url(&captures[0])
+        })
+        .into_owned()
 }
 
 fn should_route_tool_through_stream_proxy(url: &str) -> bool {
@@ -2116,10 +2122,11 @@ mod tests {
         format_ffmpeg_exit_reason, normalize_superscript, parse_bytes_read, parse_ffmpeg_stderr,
         parse_ffprobe_fps, parse_probe_snapshot, parse_stream_track_presence,
         proxy_upstream_source_url, resolution_label, resolve_binary_from_dir,
-        sanitize_screenshot_stem, screenshot_header_is_valid, should_retry_screenshot_as_png,
-        should_route_tool_through_stream_proxy, should_route_tool_through_stream_proxy_with_hint,
-        stderr_excerpt, unique_screenshot_output_path, validate_captured_screenshot,
-        ScreenshotFormat, MAX_SCREENSHOT_STEM_LEN, TARGET_TRIPLE,
+        sanitize_ffmpeg_stderr_line, sanitize_screenshot_stem, screenshot_header_is_valid,
+        should_retry_screenshot_as_png, should_route_tool_through_stream_proxy,
+        should_route_tool_through_stream_proxy_with_hint, stderr_excerpt,
+        unique_screenshot_output_path, validate_captured_screenshot, ScreenshotFormat,
+        MAX_SCREENSHOT_STEM_LEN, TARGET_TRIPLE,
     };
     use crate::error::AppError;
     use tokio_util::sync::CancellationToken;
@@ -2662,6 +2669,16 @@ Exiting with exit code -1482175992
         assert_eq!(
             stderr_excerpt(stderr),
             "server rejected ffmpeg connection (HTTP 5XX)"
+        );
+    }
+
+    #[test]
+    fn sanitize_ffmpeg_stderr_line_redacts_stream_url_credentials() {
+        assert_eq!(
+            sanitize_ffmpeg_stderr_line(
+                "[rtsp @ 0x123] Failed to open rtsp://alice:secret@example.com/live?token=value"
+            ),
+            "Failed to open rtsp://***@example.com/live?***"
         );
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -3,6 +3,7 @@ pub mod checker;
 pub mod chromecast;
 pub mod connectivity;
 pub mod disk;
+pub mod epg;
 pub mod ffmpeg;
 #[cfg(target_os = "macos")]
 pub mod macos_dmg_update;

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -10,6 +10,33 @@ use crate::models::playlist::PlaylistPreview;
 const PLAYLIST_GROUP_PREFIX: &str = "Playlist: ";
 const MAX_PLAYLIST_DISCOVERY_DEPTH: usize = 64;
 
+fn epg_sources_for_channels(
+    epg_sources: &[String],
+    epg_sources_by_playlist: &BTreeMap<String, Vec<String>>,
+    channels: &[Channel],
+) -> (Vec<String>, BTreeMap<String, Vec<String>>) {
+    let represented_playlists = channels
+        .iter()
+        .map(|channel| channel.playlist.as_str())
+        .collect::<BTreeSet<_>>();
+    let filtered_by_playlist = epg_sources_by_playlist
+        .iter()
+        .filter(|(playlist, _)| represented_playlists.contains(playlist.as_str()))
+        .map(|(playlist, sources)| (playlist.clone(), sources.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let represented_sources = filtered_by_playlist
+        .values()
+        .flatten()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let filtered_sources = epg_sources
+        .iter()
+        .filter(|source| represented_sources.contains(source.as_str()))
+        .cloned()
+        .collect();
+    (filtered_sources, filtered_by_playlist)
+}
+
 /// Escape provider-supplied text before embedding it in a generated EXTINF
 /// line. Newlines are flattened so a value cannot inject extra playlist tags.
 pub(crate) fn escape_extinf_value(value: &str) -> String {
@@ -506,6 +533,18 @@ pub fn filter_playlist_preview(
     }
 
     let (live_count, movie_count, series_count) = content_type_totals(&channels);
+    let (epg_sources, epg_sources_by_playlist) = if source_is_directory {
+        epg_sources_for_channels(
+            &preview.epg_sources,
+            &preview.epg_sources_by_playlist,
+            &channels,
+        )
+    } else {
+        (
+            preview.epg_sources.clone(),
+            preview.epg_sources_by_playlist.clone(),
+        )
+    };
     Ok(PlaylistPreview {
         file_path: preview.file_path.clone(),
         file_name: preview.file_name.clone(),
@@ -520,8 +559,8 @@ pub fn filter_playlist_preview(
         movie_count,
         series_count,
         groups: preview.groups.clone(),
-        epg_sources: preview.epg_sources.clone(),
-        epg_sources_by_playlist: preview.epg_sources_by_playlist.clone(),
+        epg_sources,
+        epg_sources_by_playlist,
         channels,
     })
 }
@@ -840,6 +879,8 @@ fn parse_playlist_directory(
         .unwrap_or_else(|| dir_path.to_string());
 
     let (live_count, movie_count, series_count) = content_type_totals(&channels);
+    let (epg_sources, epg_sources_by_playlist) =
+        epg_sources_for_channels(&epg_sources, &epg_sources_by_playlist, &channels);
     Ok(PlaylistPreview {
         file_path: dir_path.to_string(),
         file_name: dir_name,
@@ -1305,6 +1346,29 @@ http://example.com/beta.m3u8
         assert_eq!(playlist_filtered.total_channels, 1);
         assert_eq!(playlist_filtered.channels[0].name, "Beta");
         assert_eq!(playlist_filtered.channels[0].index, 1);
+        assert_eq!(
+            playlist_filtered.epg_sources,
+            vec!["http://provider-b.example/epg.xml".to_string()]
+        );
+        assert_eq!(playlist_filtered.epg_sources_by_playlist.len(), 1);
+        assert_eq!(
+            playlist_filtered
+                .epg_sources_by_playlist
+                .get("nested/live.m3u8"),
+            Some(&vec!["http://provider-b.example/epg.xml".to_string()])
+        );
+
+        let cached_filtered = filter_playlist_preview(
+            &preview,
+            &Some("Playlist: nested/live.m3u8".to_string()),
+            &None,
+        )
+        .expect("cached directory preview should filter");
+        assert_eq!(cached_filtered.epg_sources, playlist_filtered.epg_sources);
+        assert_eq!(
+            cached_filtered.epg_sources_by_playlist,
+            playlist_filtered.epg_sources_by_playlist
+        );
 
         std::fs::remove_dir_all(root).expect("fixture directory should be removable");
     }

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::BufRead;
 use std::path::Path;
 
@@ -521,6 +521,7 @@ pub fn filter_playlist_preview(
         series_count,
         groups: preview.groups.clone(),
         epg_sources: preview.epg_sources.clone(),
+        epg_sources_by_playlist: preview.epg_sources_by_playlist.clone(),
         channels,
     })
 }
@@ -662,10 +663,12 @@ fn parse_playlist_reader<R: BufRead>(
         groups.len()
     );
     let (live_count, movie_count, series_count) = content_type_totals(&channels);
+    let epg_sources_by_playlist = BTreeMap::from([(playlist_name.clone(), epg_sources.clone())]);
     Ok(PlaylistPreview {
         file_path: file_path.to_string(),
         file_name: playlist_name,
         epg_sources,
+        epg_sources_by_playlist,
         source_identity: None,
         saved_playlist_id: None,
         server_location: None,
@@ -767,6 +770,7 @@ fn parse_playlist_directory(
     let mut source_index = 0usize;
     let mut parsed_progress = ParseProgress::default();
     let mut epg_sources: Vec<String> = Vec::new();
+    let mut epg_sources_by_playlist = BTreeMap::new();
 
     for file in files {
         let last_reported = std::cell::Cell::new(ParseProgress::default());
@@ -788,6 +792,7 @@ fn parse_playlist_directory(
                 epg_sources.push(source.clone());
             }
         }
+        epg_sources_by_playlist.insert(parsed.file_name.clone(), parsed.epg_sources.clone());
         let last = last_reported.get();
         parsed_progress = ParseProgress {
             channels_found: base_progress.channels_found + last.channels_found,
@@ -833,6 +838,7 @@ fn parse_playlist_directory(
         file_path: dir_path.to_string(),
         file_name: dir_name,
         epg_sources,
+        epg_sources_by_playlist,
         source_identity: None,
         saved_playlist_id: None,
         server_location: None,
@@ -1258,6 +1264,10 @@ http://example.com/beta.m3u8
         assert!(preview.groups.contains(&"News".to_string()));
         assert!(preview.groups.contains(&"Playlist: first.m3u8".to_string()));
         assert!(preview.groups.contains(&"Playlist: second.m3u".to_string()));
+        assert_eq!(
+            preview.epg_sources_by_playlist.get("first.m3u8"),
+            Some(&Vec::new())
+        );
 
         let playlist_filtered = parse_playlist(
             &root.to_string_lossy(),

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -232,6 +232,31 @@ pub fn extract_tvg_metadata(
     tvg_metadata_from_attrs(&extinf_attributes_for(extinf_line))
 }
 
+/// Extract XMLTV EPG source URLs from a playlist `#EXTM3U` header line.
+/// Both `x-tvg-url` and `url-tvg` occur in the wild, each possibly holding a
+/// comma-separated list of URLs.
+fn parse_header_epg_sources(header_line: &str) -> Vec<String> {
+    // parse_extinf_attributes drops everything before the first ':', which in
+    // an #EXTM3U header would be the colon of the first quoted URL. Insert a
+    // separator right after the tag so the attribute payload survives intact.
+    let doctored = header_line.replacen("#EXTM3U", "#EXTM3U:", 1);
+    let attrs = parse_extinf_attributes(&doctored);
+    let mut sources = Vec::new();
+    for key in ["x-tvg-url", "url-tvg"] {
+        if let Some(value) = attr_value(&attrs, key) {
+            for url in value.split(',') {
+                let url = url.trim();
+                if (url.starts_with("http://") || url.starts_with("https://"))
+                    && !sources.iter().any(|existing| existing == url)
+                {
+                    sources.push(url.to_string());
+                }
+            }
+        }
+    }
+    sources
+}
+
 fn parse_catchup_days(raw: &str) -> Option<u32> {
     let digits: String = raw
         .trim()
@@ -495,6 +520,7 @@ pub fn filter_playlist_preview(
         movie_count,
         series_count,
         groups: preview.groups.clone(),
+        epg_sources: preview.epg_sources.clone(),
         channels,
     })
 }
@@ -529,6 +555,7 @@ fn parse_playlist_reader<R: BufRead>(
     let mut pending_extinf: Option<PendingExtinf> = None;
     let mut pending_metadata: Vec<String> = Vec::new();
     let mut orphaned_extinf = 0u32;
+    let mut epg_sources: Vec<String> = Vec::new();
 
     for raw_line in reader.split(b'\n') {
         let raw_line = raw_line.map_err(AppError::Io)?;
@@ -537,6 +564,15 @@ fn parse_playlist_reader<R: BufRead>(
             line.pop();
         }
         let line = line.trim().to_string();
+
+        if !pending_channel && line.starts_with("#EXTM3U") {
+            for source in parse_header_epg_sources(&line) {
+                if !epg_sources.contains(&source) {
+                    epg_sources.push(source);
+                }
+            }
+            continue;
+        }
 
         if line.starts_with("#EXTINF") {
             // A new EXTINF supersedes any pending entry that never got a stream URL.
@@ -629,6 +665,7 @@ fn parse_playlist_reader<R: BufRead>(
     Ok(PlaylistPreview {
         file_path: file_path.to_string(),
         file_name: playlist_name,
+        epg_sources,
         source_identity: None,
         saved_playlist_id: None,
         server_location: None,
@@ -729,6 +766,7 @@ fn parse_playlist_directory(
     let mut groups = BTreeSet::new();
     let mut source_index = 0usize;
     let mut parsed_progress = ParseProgress::default();
+    let mut epg_sources: Vec<String> = Vec::new();
 
     for file in files {
         let last_reported = std::cell::Cell::new(ParseProgress::default());
@@ -745,6 +783,11 @@ fn parse_playlist_directory(
             }
         };
         let parsed = parse_playlist_with_progress(&file, &None, &None, Some(&child_progress))?;
+        for source in &parsed.epg_sources {
+            if !epg_sources.contains(source) {
+                epg_sources.push(source.clone());
+            }
+        }
         let last = last_reported.get();
         parsed_progress = ParseProgress {
             channels_found: base_progress.channels_found + last.channels_found,
@@ -789,6 +832,7 @@ fn parse_playlist_directory(
     Ok(PlaylistPreview {
         file_path: dir_path.to_string(),
         file_name: dir_name,
+        epg_sources,
         source_identity: None,
         saved_playlist_id: None,
         server_location: None,
@@ -943,6 +987,27 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_header_epg_sources_reads_both_keys_and_lists() {
+        assert_eq!(
+            parse_header_epg_sources("#EXTM3U x-tvg-url=\"http://epg.example.com/guide.xml.gz\""),
+            vec!["http://epg.example.com/guide.xml.gz".to_string()]
+        );
+
+        let line =
+            "#EXTM3U x-tvg-url=\"http://a/epg.xml\" url-tvg=\"http://a/epg.xml,http://b/epg.xml\"";
+        assert_eq!(
+            parse_header_epg_sources(line),
+            vec![
+                "http://a/epg.xml".to_string(),
+                "http://b/epg.xml".to_string()
+            ]
+        );
+
+        assert!(parse_header_epg_sources("#EXTM3U").is_empty());
+        assert!(parse_header_epg_sources("#EXTM3U x-tvg-url=\"not-a-url\"").is_empty());
+    }
+
+    #[test]
     fn test_catchup_metadata_reads_explicit_attributes() {
         let attrs = parse_extinf_attributes(
             "#EXTINF:-1 catchup=\"shift\" catchup-days=\"7\" catchup-source=\"http://x/${start}\",Ch",
@@ -1011,7 +1076,7 @@ mod tests {
         let path = std::env::temp_dir().join(format!("iptv-parser-streaming-{unique}.m3u8"));
 
         let playlist = "\
-#EXTM3U
+#EXTM3U x-tvg-url=\"http://epg.example.com/all.xml\"
 #EXTINF:-1 group-title=\"Sports\",Channel One
 #KODIPROP:inputstream=ffmpegdirect
 http://example.com/one.m3u8
@@ -1040,6 +1105,10 @@ http://example.com/three.m3u8
         assert_eq!(preview.channels[1].name, "Channel Three");
         assert!(preview.groups.contains(&"Sports".to_string()));
         assert!(preview.groups.contains(&"News".to_string()));
+        assert_eq!(
+            preview.epg_sources,
+            vec!["http://epg.example.com/all.xml".to_string()]
+        );
 
         std::fs::remove_file(path).expect("fixture file should be removable");
     }
@@ -1092,7 +1161,7 @@ http://example.com/three.mp4
         let path = std::env::temp_dir().join(format!("iptv-parser-stable-index-{unique}.m3u8"));
 
         let playlist = "\
-#EXTM3U
+#EXTM3U x-tvg-url=\"http://epg.example.com/all.xml\"
 #EXTINF:-1 group-title=\"Sports\",Channel One
 http://example.com/one.m3u8
 #EXTINF:-1 group-title=\"News\",Channel Two

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -564,7 +564,7 @@ fn parse_playlist_reader<R: BufRead>(
         if line.ends_with('\r') {
             line.pop();
         }
-        let line = line.trim().to_string();
+        let line = line.trim().trim_start_matches('\u{feff}').to_string();
 
         if !pending_channel && line.starts_with("#EXTM3U") {
             for source in parse_header_epg_sources(&line) {
@@ -1017,6 +1017,21 @@ mod tests {
 
         assert!(parse_header_epg_sources("#EXTM3U").is_empty());
         assert!(parse_header_epg_sources("#EXTM3U x-tvg-url=\"not-a-url\"").is_empty());
+    }
+
+    #[test]
+    fn test_parse_m3u_reads_epg_sources_from_a_bom_prefixed_header() {
+        let playlist = "\u{feff}#EXTM3U x-tvg-url=\"http://epg.example.com/guide.xml\"\n\
+#EXTINF:-1,Channel One\n\
+http://example.com/one.m3u8\n";
+
+        let parsed = parse_m3u(playlist.as_bytes(), "bom.m3u8", &None, &None)
+            .expect("BOM-prefixed playlist should parse");
+
+        assert_eq!(
+            parsed.epg_sources,
+            vec!["http://epg.example.com/guide.xml".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -276,6 +276,7 @@ fn parse_header_epg_sources(header_line: &str) -> Vec<String> {
     let mut sources = Vec::new();
     for key in ["x-tvg-url", "url-tvg"] {
         if let Some(value) = attr_value(&attrs, key) {
+            let value = value.replace("&amp;", "&");
             for url in value.split(',') {
                 let url = url.trim();
                 if Url::parse(url).is_ok_and(|parsed| matches!(parsed.scheme(), "http" | "https"))
@@ -1077,6 +1078,12 @@ mod tests {
         assert_eq!(
             parse_header_epg_sources("#EXTM3U x-tvg-url=\"HTTPS://epg.example.com/guide.xml\""),
             vec!["HTTPS://epg.example.com/guide.xml".to_string()]
+        );
+        assert_eq!(
+            parse_header_epg_sources(
+                "#EXTM3U x-tvg-url=\"https://epg.example.com/xmltv.php?username=u&amp;password=p\""
+            ),
+            vec!["https://epg.example.com/xmltv.php?username=u&password=p".to_string()]
         );
     }
 

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::BufRead;
 use std::path::Path;
 
+use url::Url;
+
 use crate::engine::search_pattern::ChannelSearchPattern;
 use crate::error::AppError;
 use crate::models::channel::{Channel, ContentType};
@@ -276,7 +278,7 @@ fn parse_header_epg_sources(header_line: &str) -> Vec<String> {
         if let Some(value) = attr_value(&attrs, key) {
             for url in value.split(',') {
                 let url = url.trim();
-                if (url.starts_with("http://") || url.starts_with("https://"))
+                if Url::parse(url).is_ok_and(|parsed| matches!(parsed.scheme(), "http" | "https"))
                     && !sources.iter().any(|existing| existing == url)
                 {
                     sources.push(url.to_string());
@@ -1072,6 +1074,10 @@ mod tests {
 
         assert!(parse_header_epg_sources("#EXTM3U").is_empty());
         assert!(parse_header_epg_sources("#EXTM3U x-tvg-url=\"not-a-url\"").is_empty());
+        assert_eq!(
+            parse_header_epg_sources("#EXTM3U x-tvg-url=\"HTTPS://epg.example.com/guide.xml\""),
+            vec!["HTTPS://epg.example.com/guide.xml".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -79,15 +79,7 @@ pub fn find_unquoted_comma(input: &str) -> Option<usize> {
     None
 }
 
-/// Parse key-value attributes from an #EXTINF line header.
-pub fn parse_extinf_attributes(extinf_line: &str) -> Vec<(String, String)> {
-    let header_end = find_unquoted_comma(extinf_line).unwrap_or(extinf_line.len());
-    let header = &extinf_line[..header_end];
-    let payload = header
-        .split_once(':')
-        .map(|(_, after_colon)| after_colon)
-        .unwrap_or(header);
-
+fn parse_attributes(payload: &str, comma_terminates_unquoted_value: bool) -> Vec<(String, String)> {
     let bytes = payload.as_bytes();
     let mut i = 0usize;
     let mut attrs = Vec::new();
@@ -171,7 +163,10 @@ pub fn parse_extinf_attributes(extinf_line: &str) -> Vec<(String, String)> {
             raw.trim().to_string()
         } else {
             let value_start = i;
-            while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b',' {
+            while i < bytes.len()
+                && !bytes[i].is_ascii_whitespace()
+                && (!comma_terminates_unquoted_value || bytes[i] != b',')
+            {
                 i += 1;
             }
             payload[value_start..i].trim().to_string()
@@ -184,6 +179,17 @@ pub fn parse_extinf_attributes(extinf_line: &str) -> Vec<(String, String)> {
     }
 
     attrs
+}
+
+/// Parse key-value attributes from an #EXTINF line header.
+pub fn parse_extinf_attributes(extinf_line: &str) -> Vec<(String, String)> {
+    let header_end = find_unquoted_comma(extinf_line).unwrap_or(extinf_line.len());
+    let header = &extinf_line[..header_end];
+    let payload = header
+        .split_once(':')
+        .map(|(_, after_colon)| after_colon)
+        .unwrap_or(header);
+    parse_attributes(payload, true)
 }
 
 /// Extract channel name from #EXTINF line (text after the last comma).
@@ -263,11 +269,8 @@ pub fn extract_tvg_metadata(
 /// Both `x-tvg-url` and `url-tvg` occur in the wild, each possibly holding a
 /// comma-separated list of URLs.
 fn parse_header_epg_sources(header_line: &str) -> Vec<String> {
-    // parse_extinf_attributes drops everything before the first ':', which in
-    // an #EXTM3U header would be the colon of the first quoted URL. Insert a
-    // separator right after the tag so the attribute payload survives intact.
-    let doctored = header_line.replacen("#EXTM3U", "#EXTM3U:", 1);
-    let attrs = parse_extinf_attributes(&doctored);
+    let payload = header_line.strip_prefix("#EXTM3U").unwrap_or(header_line);
+    let attrs = parse_attributes(payload, false);
     let mut sources = Vec::new();
     for key in ["x-tvg-url", "url-tvg"] {
         if let Some(value) = attr_value(&attrs, key) {
@@ -1053,6 +1056,17 @@ mod tests {
             vec![
                 "http://a/epg.xml".to_string(),
                 "http://b/epg.xml".to_string()
+            ]
+        );
+
+        assert_eq!(
+            parse_header_epg_sources(
+                "#EXTM3U x-tvg-url=http://a/epg.xml,http://b/epg.xml url-tvg=http://c/epg.xml"
+            ),
+            vec![
+                "http://a/epg.xml".to_string(),
+                "http://b/epg.xml".to_string(),
+                "http://c/epg.xml".to_string()
             ]
         );
 

--- a/src-tauri/src/engine/parser.rs
+++ b/src-tauri/src/engine/parser.rs
@@ -787,12 +787,17 @@ fn parse_playlist_directory(
             }
         };
         let parsed = parse_playlist_with_progress(&file, &None, &None, Some(&child_progress))?;
+        let playlist_id = Path::new(&file)
+            .strip_prefix(dir_path)
+            .unwrap_or_else(|_| Path::new(&file))
+            .to_string_lossy()
+            .replace('\\', "/");
         for source in &parsed.epg_sources {
             if !epg_sources.contains(source) {
                 epg_sources.push(source.clone());
             }
         }
-        epg_sources_by_playlist.insert(parsed.file_name.clone(), parsed.epg_sources.clone());
+        epg_sources_by_playlist.insert(playlist_id.clone(), parsed.epg_sources.clone());
         let last = last_reported.get();
         parsed_progress = ParseProgress {
             channels_found: base_progress.channels_found + last.channels_found,
@@ -801,6 +806,7 @@ fn parse_playlist_directory(
             series_found: base_progress.series_found + last.series_found,
         };
         for mut channel in parsed.channels {
+            channel.playlist.clone_from(&playlist_id);
             let playlist_group = format!("{}{}", PLAYLIST_GROUP_PREFIX, channel.playlist);
             groups.insert(channel.group.clone());
             groups.insert(playlist_group.clone());
@@ -1220,12 +1226,12 @@ http://example.com/three.m3u8
         let nested = root.join("nested");
         std::fs::create_dir_all(&nested).expect("nested fixture dir should be created");
 
-        let first = root.join("first.m3u8");
-        let second = nested.join("second.m3u");
+        let first = root.join("live.m3u8");
+        let second = nested.join("live.m3u8");
         std::fs::write(
             &first,
             "\
-#EXTM3U
+#EXTM3U x-tvg-url=\"http://provider-a.example/epg.xml\"
 #EXTINF:-1 group-title=\"Sports\",Alpha
 http://example.com/alpha.m3u8
 ",
@@ -1234,7 +1240,7 @@ http://example.com/alpha.m3u8
         std::fs::write(
             &second,
             "\
-#EXTM3U
+#EXTM3U x-tvg-url=\"http://provider-b.example/epg.xml\"
 #EXTINF:-1 group-title=\"News\",Beta
 http://example.com/beta.m3u8
 ",
@@ -1258,20 +1264,26 @@ http://example.com/beta.m3u8
                 .iter()
                 .map(|channel| channel.playlist.clone())
                 .collect::<Vec<_>>(),
-            vec!["first.m3u8".to_string(), "second.m3u".to_string()]
+            vec!["live.m3u8".to_string(), "nested/live.m3u8".to_string()]
         );
         assert!(preview.groups.contains(&"Sports".to_string()));
         assert!(preview.groups.contains(&"News".to_string()));
-        assert!(preview.groups.contains(&"Playlist: first.m3u8".to_string()));
-        assert!(preview.groups.contains(&"Playlist: second.m3u".to_string()));
+        assert!(preview.groups.contains(&"Playlist: live.m3u8".to_string()));
+        assert!(preview
+            .groups
+            .contains(&"Playlist: nested/live.m3u8".to_string()));
         assert_eq!(
-            preview.epg_sources_by_playlist.get("first.m3u8"),
-            Some(&Vec::new())
+            preview.epg_sources_by_playlist.get("live.m3u8"),
+            Some(&vec!["http://provider-a.example/epg.xml".to_string()])
+        );
+        assert_eq!(
+            preview.epg_sources_by_playlist.get("nested/live.m3u8"),
+            Some(&vec!["http://provider-b.example/epg.xml".to_string()])
         );
 
         let playlist_filtered = parse_playlist(
             &root.to_string_lossy(),
-            &Some("Playlist: second.m3u".to_string()),
+            &Some("Playlist: nested/live.m3u8".to_string()),
             &None,
         )
         .expect("playlist-filtered directory parse should succeed");

--- a/src-tauri/src/engine/stalker.rs
+++ b/src-tauri/src/engine/stalker.rs
@@ -729,6 +729,7 @@ pub(crate) fn build_stalker_preview(
         series_count,
         groups: groups.into_iter().collect(),
         epg_sources: Vec::new(),
+        epg_sources_by_playlist: std::collections::BTreeMap::new(),
         channels,
     })
 }

--- a/src-tauri/src/engine/stalker.rs
+++ b/src-tauri/src/engine/stalker.rs
@@ -728,6 +728,7 @@ pub(crate) fn build_stalker_preview(
         movie_count,
         series_count,
         groups: groups.into_iter().collect(),
+        epg_sources: Vec::new(),
         channels,
     })
 }

--- a/src-tauri/src/engine/stream_proxy.rs
+++ b/src-tauri/src/engine/stream_proxy.rs
@@ -160,29 +160,31 @@ pub(crate) fn redact_url(url: &str) -> String {
                 let _ = parsed.set_password(None);
             }
             // Xtream credentials live in path segments rather than URL userinfo:
-            // /live/{username}/{password}/{stream-id}.ts. Those URLs are the
-            // most common source of playback diagnostics, so query/userinfo
-            // redaction alone would still leak both credentials.
+            // /live/{username}/{password}/{stream-id}.ts and
+            // /timeshift/{username}/{password}/{duration}/{start}/{stream-id}.ts.
+            // Providers may also serve these paths below a prefix.
             let segments = parsed
                 .path_segments()
                 .map(|segments| segments.map(str::to_string).collect::<Vec<_>>())
                 .unwrap_or_default();
-            let credential_start = if segments.len() >= 4
-                && matches!(
-                    segments[0].to_ascii_lowercase().as_str(),
-                    "live" | "movie" | "series"
-                ) {
-                Some(1)
-            } else if segments.len() == 3
-                && segments[2]
-                    .split('.')
-                    .next()
-                    .is_some_and(|id| !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()))
-            {
-                Some(0)
-            } else {
-                None
-            };
+            let credential_start = segments
+                .iter()
+                .enumerate()
+                .find_map(|(index, segment)| {
+                    let remaining = segments.len() - index;
+                    match segment.to_ascii_lowercase().as_str() {
+                        "live" | "movie" | "series" if remaining >= 4 => Some(index + 1),
+                        "timeshift" if remaining >= 6 => Some(index + 1),
+                        _ => None,
+                    }
+                })
+                .or_else(|| {
+                    (segments.len() == 3
+                        && segments[2].split('.').next().is_some_and(|id| {
+                            !id.is_empty() && id.chars().all(|c| c.is_ascii_digit())
+                        }))
+                    .then_some(0)
+                });
             if let Some(start) = credential_start {
                 let redacted_segments = segments
                     .iter()
@@ -1534,6 +1536,12 @@ mod tests {
         assert_eq!(
             redact_url("https://provider.example/user/pass/67890?token=secret"),
             "https://provider.example/***/***/67890?***"
+        );
+        assert_eq!(
+            redact_url(
+                "https://provider.example/prefix/timeshift/user-name/pass-word/120/2026-08-29:12-00/12345.m3u8"
+            ),
+            "https://provider.example/prefix/timeshift/***/***/120/2026-08-29:12-00/12345.m3u8"
         );
     }
 

--- a/src-tauri/src/engine/xtream.rs
+++ b/src-tauri/src/engine/xtream.rs
@@ -96,6 +96,24 @@ pub(crate) fn build_xtream_download_url(server: &Url, username: &str, password: 
     playlist_url
 }
 
+pub(crate) fn build_xtream_xmltv_url(server: &Url, username: &str, password: &str) -> Url {
+    let mut xmltv_url = server.clone();
+    let mut endpoint_path = xmltv_url.path().trim_end_matches('/').to_string();
+    if endpoint_path.is_empty() || endpoint_path == "/" {
+        endpoint_path = "/xmltv.php".to_string();
+    } else {
+        endpoint_path.push_str("/xmltv.php");
+    }
+    xmltv_url.set_path(&endpoint_path);
+    xmltv_url.set_query(None);
+    xmltv_url.set_fragment(None);
+    xmltv_url
+        .query_pairs_mut()
+        .append_pair("username", username)
+        .append_pair("password", password);
+    xmltv_url
+}
+
 pub(crate) fn build_xtream_player_api_url(server: &Url, username: &str, password: &str) -> Url {
     let mut api_url = server.clone();
     let mut endpoint_path = api_url.path().trim_end_matches('/').to_string();
@@ -589,7 +607,11 @@ pub(crate) async fn fetch_xtream_playlist_via_json_api(
 
     let estimated_total = live_streams.len() + vod_streams.len();
     let mut m3u = String::with_capacity(estimated_total * 200);
-    m3u.push_str("#EXTM3U\n");
+    let xmltv_url = build_xtream_xmltv_url(server, username, password);
+    m3u.push_str(&format!(
+        "#EXTM3U x-tvg-url=\"{}\"\n",
+        crate::engine::parser::escape_extinf_value(xmltv_url.as_str())
+    ));
 
     // Live streams → .ts extension
     let live_count =
@@ -730,9 +752,11 @@ mod tests {
     use super::{
         append_xtream_streams_to_m3u, apply_xtream_archive_flags, build_xtream_download_url,
         build_xtream_player_api_action_url, build_xtream_player_api_url, build_xtream_source_key,
-        extract_xtream_account_info, extract_xtream_max_connections, normalize_xtream_server,
+        build_xtream_xmltv_url, extract_xtream_account_info, extract_xtream_max_connections,
+        normalize_xtream_server,
     };
     use std::collections::HashMap;
+    use url::Url;
 
     #[test]
     fn generated_xtream_entries_carry_catchup_attributes() {
@@ -924,6 +948,17 @@ mod tests {
         let server = normalize_xtream_server("https://demo.example.com:8080/get.php/")
             .expect("server should normalize");
         assert_eq!(server.to_string(), "https://demo.example.com:8080/");
+    }
+
+    #[test]
+    fn builds_xtream_xmltv_url_with_encoded_credentials() {
+        let server = Url::parse("https://demo.example.com/provider/").expect("server URL");
+        let url = build_xtream_xmltv_url(&server, "user@example.com", "p&ss");
+
+        assert_eq!(
+            url.as_str(),
+            "https://demo.example.com/provider/xmltv.php?username=user%40example.com&password=p%26ss"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1047,6 +1047,8 @@ pub fn run() {
             commands::scan::cancel_scan,
             commands::scan::reset_scan,
             commands::scan::quick_check_channel,
+            commands::epg::load_epg,
+            commands::epg::get_epg_programmes,
             commands::export::export_csv,
             commands::export::export_split,
             commands::export::export_renamed,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1048,6 +1048,7 @@ pub fn run() {
             commands::scan::reset_scan,
             commands::scan::quick_check_channel,
             commands::epg::load_epg,
+            commands::epg::cancel_epg_load,
             commands::epg::get_epg_programmes,
             commands::export::export_csv,
             commands::export::export_split,

--- a/src-tauri/src/models/chromecast.rs
+++ b/src-tauri/src/models/chromecast.rs
@@ -40,6 +40,8 @@ pub struct CastMediaRequest {
     pub channel_name: Option<String>,
     pub channel_logo: Option<String>,
     pub stream_kind: CastStreamKind,
+    #[serde(default)]
+    pub is_finite: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/models/playlist.rs
+++ b/src-tauri/src/models/playlist.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::channel::Channel;
@@ -44,5 +46,8 @@ pub struct PlaylistPreview {
     /// XMLTV EPG URLs advertised by the playlist header (`x-tvg-url` / `url-tvg`).
     #[serde(default)]
     pub epg_sources: Vec<String>,
+    /// XMLTV EPG sources keyed by the playlist each channel came from.
+    #[serde(default)]
+    pub epg_sources_by_playlist: BTreeMap<String, Vec<String>>,
     pub channels: Vec<Channel>,
 }

--- a/src-tauri/src/models/playlist.rs
+++ b/src-tauri/src/models/playlist.rs
@@ -41,5 +41,8 @@ pub struct PlaylistPreview {
     #[serde(default)]
     pub series_count: usize,
     pub groups: Vec<String>,
+    /// XMLTV EPG URLs advertised by the playlist header (`x-tvg-url` / `url-tvg`).
+    #[serde(default)]
+    pub epg_sources: Vec<String>,
     pub channels: Vec<Channel>,
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -81,6 +81,10 @@ pub struct AppState {
     window_scan_states: Mutex<HashMap<String, WindowScanState>>,
     backend_perf_samples: Mutex<VecDeque<BackendPerfSample>>,
     playlist_preview_cache: Mutex<HashMap<String, CachedPlaylistPreview>>,
+    /// Programme index from the most recent load_epg call.
+    pub epg: Mutex<Option<std::sync::Arc<crate::engine::epg::EpgIndex>>>,
+    /// Serializes concurrent load_epg calls so two loads never interleave.
+    pub epg_load_lock: Mutex<()>,
     /// Rejects a second install immediately instead of queueing it behind the
     /// first one on `update_checking`.
     pub update_installing: std::sync::atomic::AtomicBool,
@@ -108,6 +112,8 @@ impl AppState {
             window_scan_states: Mutex::new(HashMap::new()),
             backend_perf_samples: Mutex::new(VecDeque::new()),
             playlist_preview_cache: Mutex::new(HashMap::new()),
+            epg: Mutex::new(None),
+            epg_load_lock: Mutex::new(()),
             update_installing: std::sync::atomic::AtomicBool::new(false),
             update_checking: Mutex::new(()),
             update_available: Mutex::new(None),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -85,6 +85,8 @@ pub struct AppState {
     pub epg: Mutex<Option<std::sync::Arc<crate::engine::epg::EpgIndex>>>,
     /// Serializes concurrent load_epg calls so two loads never interleave.
     pub epg_load_lock: Mutex<()>,
+    /// Cancels the previous EPG load when the playlist or load request changes.
+    pub epg_load_cancel: Mutex<CancellationToken>,
     /// Rejects a second install immediately instead of queueing it behind the
     /// first one on `update_checking`.
     pub update_installing: std::sync::atomic::AtomicBool,
@@ -114,6 +116,7 @@ impl AppState {
             playlist_preview_cache: Mutex::new(HashMap::new()),
             epg: Mutex::new(None),
             epg_load_lock: Mutex::new(()),
+            epg_load_cancel: Mutex::new(CancellationToken::new()),
             update_installing: std::sync::atomic::AtomicBool::new(false),
             update_checking: Mutex::new(()),
             update_available: Mutex::new(None),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useSettings } from "./hooks/useSettings";
 import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import { buildArchiveUrl } from "./lib/archive";
+import { cancelArchiveProbes } from "./lib/archiveProbe";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
   checkFfmpegAvailable,
@@ -583,6 +584,18 @@ export default function App() {
   }, [chromecast]);
   const castSession = chromecast.session;
   const isCasting = isCastSessionActive(castSession);
+  const hadActiveCastRef = useRef(false);
+
+  useEffect(() => {
+    if (isCasting) {
+      hadActiveCastRef.current = true;
+      return;
+    }
+    if (hadActiveCastRef.current && streamPlayer.archiveSession) {
+      setArchiveSession(null);
+    }
+    hadActiveCastRef.current = false;
+  }, [isCasting, setArchiveSession, streamPlayer.archiveSession]);
 
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
   const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
@@ -900,6 +913,14 @@ export default function App() {
       const applyResult = await ensureSourceFilterApplied();
       if (!applyResult.ok) {
         return false;
+      }
+
+      const appliedState = getStore();
+      if (
+        appliedState.playlist?.single_provider &&
+        Object.values(appliedState.archiveProbes).some((probe) => probe.running)
+      ) {
+        await cancelArchiveProbes();
       }
 
       const refreshedState = getStore();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,7 +299,7 @@ function SelectedChannelSidebar({
         onSetVolume={streamPlayer.setVolume}
         onToggleMute={streamPlayer.toggleMute}
         onOpenExternal={onOpenExternal}
-        onRetryPlay={(result) => streamPlayer.play(result)}
+        onRetryPlay={streamPlayer.retry}
         onPip={document.pictureInPictureEnabled ? onPip : undefined}
       />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -553,6 +553,7 @@ export default function App() {
   const handlePlaybackFailedRef = useRef<((result: ChannelResult) => void) | undefined>(undefined);
   const streamPlayer = useStreamPlayer({
     onPlaybackFailed: (result) => handlePlaybackFailedRef.current?.(result),
+    onPlaybackFinished: () => getStore().setPlayIntentActive(false),
   });
   const {
     activeChannelIndex: playbackChannelIndex,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from "react";
 import { setLiquidGlassEffect } from "tauri-plugin-liquid-glass-api";
 import { AppBanners } from "./components/AppBanners";
+import type { CastStartHandler } from "./components/CastMenu";
 import { ChannelTable } from "./components/ChannelTable";
 import { FilterBar } from "./components/FilterBar";
 import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
@@ -186,7 +187,7 @@ function SelectedChannelSidebar({
   onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   onScanChannel: (indices: number[]) => void;
   onStopPlayer: () => void;
-  onCastStart: () => void;
+  onCastStart: CastStartHandler;
   onOpenExternal: (result: ChannelResult) => void;
   onPip?: () => void;
 }) {
@@ -1139,9 +1140,13 @@ export default function App() {
   }, [stopStream]);
 
   const handleCastStart = useCallback(() => {
+    const archiveHandoff = streamPlayer.archiveSession !== null;
     getStore().setPlayIntentActive(false);
     stopStream({ preserveArchiveSession: true });
-  }, [stopStream]);
+    if (archiveHandoff) {
+      return () => setArchiveSession(null);
+    }
+  }, [setArchiveSession, stopStream, streamPlayer.archiveSession]);
 
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1170,11 +1170,15 @@ export default function App() {
 
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {
-      if (isSingleConnectionPlaylist(getStore().playlist)) {
-        handleStopPlayer();
-      }
-
       try {
+        if (isSingleConnectionPlaylist(getStore().playlist)) {
+          handleStopPlayer();
+          const currentChromecast = chromecastRef.current;
+          if (isCastSessionActive(currentChromecast.session)) {
+            await currentChromecast.stop();
+          }
+        }
+
         await openChannelInPlayer({
           extinf_line: result.extinf_line,
           metadata_lines: result.metadata_lines,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -605,6 +605,10 @@ export default function App() {
   } = usePlaylistSources({ initFromPlaylist, syncFromPlaylist });
 
   useEffect(() => {
+    setPendingArchivePlayback(null);
+  }, [playlist?.file_path, playlist?.source_identity]);
+
+  useEffect(() => {
     document.documentElement.dataset.platform = platform;
     if (platform !== "macos") return;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,7 @@ export default function App() {
   const {
     activeChannelIndex: playbackChannelIndex,
     play: playStream,
+    resumeArchive,
     stop: stopStream,
     setArchiveSession,
     videoElement: playbackVideoElement,
@@ -1141,13 +1142,16 @@ export default function App() {
   }, [stopStream]);
 
   const handleCastStart = useCallback(() => {
-    const archiveHandoff = streamPlayer.archiveSession !== null;
+    const archiveSession = streamPlayer.archiveSession;
     getStore().setPlayIntentActive(false);
     stopStream({ preserveArchiveSession: true });
-    if (archiveHandoff) {
-      return () => setArchiveSession(null);
+    if (archiveSession) {
+      return () => {
+        getStore().setPlayIntentActive(true);
+        resumeArchive(archiveSession);
+      };
     }
-  }, [setArchiveSession, stopStream, streamPlayer.archiveSession]);
+  }, [resumeArchive, stopStream, streamPlayer.archiveSession]);
 
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1183,22 +1183,8 @@ export default function App() {
     [playStream, setArchiveSession],
   );
 
-  const handlePlayArchive = useCallback(
+  const startArchivePlayback = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
-      if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
-        setPendingArchivePlayback({ result, options });
-        setPendingPlaybackReason("scan");
-        return;
-      }
-      if (
-        getStore().playlist?.single_provider &&
-        Object.values(getStore().archiveProbes).some((probe) => probe.running)
-      ) {
-        setPendingArchivePlayback({ result, options });
-        setPendingPlaybackReason("archive_probe");
-        return;
-      }
-
       const nowEpochS = Math.floor(Date.now() / 1000);
       const windowEndEpochS = Math.min(options.endEpochS ?? nowEpochS, nowEpochS);
       const startEpochS = Math.min(Math.floor(options.startEpochS), windowEndEpochS - 1);
@@ -1242,6 +1228,27 @@ export default function App() {
     [setArchiveSession, streamPlayer.playArchive],
   );
 
+  const handlePlayArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
+        setPendingArchivePlayback({ result, options });
+        setPendingPlaybackReason("scan");
+        return;
+      }
+      if (
+        getStore().playlist?.single_provider &&
+        Object.values(getStore().archiveProbes).some((probe) => probe.running)
+      ) {
+        setPendingArchivePlayback({ result, options });
+        setPendingPlaybackReason("archive_probe");
+        return;
+      }
+
+      startArchivePlayback(result, options);
+    },
+    [startArchivePlayback],
+  );
+
   const handlePip = useCallback(() => {
     const video = playbackVideoElement;
     if (!video) return;
@@ -1256,8 +1263,7 @@ export default function App() {
     setPendingPlaybackReason(null);
     if (pendingArchivePlayback) {
       setPendingArchivePlayback(null);
-      getStore().setPlayIntentActive(true);
-      streamPlayer.playArchive(pendingArchivePlayback.result, pendingArchivePlayback.options);
+      startArchivePlayback(pendingArchivePlayback.result, pendingArchivePlayback.options);
       return;
     }
     if (!pendingPlaybackChannel) return;
@@ -1265,7 +1271,7 @@ export default function App() {
     getStore().setPendingPlaybackChannel(null);
     getStore().setPlayIntentActive(true);
     playStream(channel);
-  }, [pendingArchivePlayback, pendingPlaybackChannel, playStream, streamPlayer.playArchive]);
+  }, [pendingArchivePlayback, pendingPlaybackChannel, playStream, startArchivePlayback]);
 
   useEffect(() => {
     if (pendingPlaybackReason === "archive_probe" && !archiveProbeActive) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,6 +604,7 @@ export default function App() {
   const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
     useScan();
   const { checkForUpdates, installUpdate } = useUpdateCheck();
+  const invalidatePendingArchivePlayback = useCallback(() => setPendingArchivePlayback(null), []);
   const {
     handleClearRecentPlaylists,
     handleOpen,
@@ -628,7 +629,11 @@ export default function App() {
     setSavedPlaylistEditorDraft,
     savedXtreamTestEntry,
     setSavedXtreamTestEntry,
-  } = usePlaylistSources({ initFromPlaylist, syncFromPlaylist });
+  } = usePlaylistSources({
+    initFromPlaylist,
+    syncFromPlaylist,
+    invalidatePendingArchivePlayback,
+  });
 
   useEffect(() => {
     setPendingArchivePlayback(null);
@@ -1186,6 +1191,7 @@ export default function App() {
   const handlePlayInApp = useCallback(
     (result: ChannelResult) => {
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
+        setPendingArchivePlayback(null);
         getStore().setPendingPlaybackChannel(result);
         setPendingPlaybackReason("scan");
         return;
@@ -1194,6 +1200,7 @@ export default function App() {
         getStore().playlist?.single_provider &&
         Object.values(getStore().archiveProbes).some((probe) => probe.running)
       ) {
+        setPendingArchivePlayback(null);
         getStore().setPendingPlaybackChannel(result);
         setPendingPlaybackReason("archive_probe");
         return;
@@ -1272,6 +1279,7 @@ export default function App() {
   const handlePlayArchive = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
+        getStore().setPendingPlaybackChannel(null);
         setPendingArchivePlayback({ result, options });
         setPendingPlaybackReason("scan");
         return;
@@ -1280,6 +1288,7 @@ export default function App() {
         getStore().playlist?.single_provider &&
         Object.values(getStore().archiveProbes).some((probe) => probe.running)
       ) {
+        getStore().setPendingPlaybackChannel(null);
         setPendingArchivePlayback({ result, options });
         setPendingPlaybackReason("archive_probe");
         return;
@@ -1303,12 +1312,14 @@ export default function App() {
   const handleProceedPlayback = useCallback(() => {
     setPendingPlaybackReason(null);
     if (pendingArchivePlayback) {
+      getStore().setPendingPlaybackChannel(null);
       setPendingArchivePlayback(null);
       startArchivePlayback(pendingArchivePlayback.result, pendingArchivePlayback.options);
       return;
     }
     if (!pendingPlaybackChannel) return;
     const channel = pendingPlaybackChannel;
+    setPendingArchivePlayback(null);
     getStore().setPendingPlaybackChannel(null);
     getStore().setPlayIntentActive(true);
     playStream(channel);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,6 +290,10 @@ function SelectedChannelSidebar({
         volume={streamPlayer.volume}
         muted={streamPlayer.muted}
         videoElement={streamPlayer.videoElement}
+        archiveSession={streamPlayer.archiveSession}
+        onPlayArchive={streamPlayer.playArchive}
+        onSeekArchive={streamPlayer.seekArchive}
+        onGoLive={streamPlayer.goLive}
         onTogglePause={streamPlayer.togglePause}
         onStopPlayer={onStopPlayer}
         onSetVolume={streamPlayer.setVolume}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -924,10 +924,7 @@ export default function App() {
       }
 
       const appliedState = getStore();
-      if (
-        appliedState.playlist?.single_provider &&
-        Object.values(appliedState.archiveProbes).some((probe) => probe.running)
-      ) {
+      if (Object.values(appliedState.archiveProbes).some((probe) => probe.running)) {
         await cancelArchiveProbes();
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1143,6 +1143,10 @@ export default function App() {
 
   const handleCastStart = useCallback(() => {
     const archiveSession = streamPlayer.archiveSession;
+    const liveChannel =
+      archiveSession || playbackChannelIndex == null
+        ? null
+        : selectResultByIndex(getStore(), playbackChannelIndex);
     getStore().setPlayIntentActive(false);
     stopStream({ preserveArchiveSession: true });
     if (archiveSession) {
@@ -1151,7 +1155,13 @@ export default function App() {
         resumeArchive(archiveSession);
       };
     }
-  }, [resumeArchive, stopStream, streamPlayer.archiveSession]);
+    if (liveChannel) {
+      return () => {
+        getStore().setPlayIntentActive(true);
+        playStream(liveChannel);
+      };
+    }
+  }, [playStream, playbackChannelIndex, resumeArchive, stopStream, streamPlayer.archiveSession]);
 
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -527,6 +527,12 @@ export default function App() {
     result: ChannelResult;
     options: ArchivePlayOptions;
   } | null>(null);
+  const [pendingPlaybackReason, setPendingPlaybackReason] = useState<"scan" | "archive_probe" | null>(
+    null,
+  );
+  const archiveProbeActive = useAppStore((state) =>
+    Object.values(state.archiveProbes).some((probe) => probe.running),
+  );
   const liveSelectedChannel = useAppStore(selectLiveSelectedChannel);
   const showHistory = useAppStore((s) => s.showHistory);
   const historyEntries = useAppStore((s) => s.historyEntries);
@@ -1131,6 +1137,15 @@ export default function App() {
     (result: ChannelResult) => {
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
         getStore().setPendingPlaybackChannel(result);
+        setPendingPlaybackReason("scan");
+        return;
+      }
+      if (
+        getStore().playlist?.single_provider &&
+        Object.values(getStore().archiveProbes).some((probe) => probe.running)
+      ) {
+        getStore().setPendingPlaybackChannel(result);
+        setPendingPlaybackReason("archive_probe");
         return;
       }
       // While a cast session is active, redirect the cast to the new channel
@@ -1160,6 +1175,15 @@ export default function App() {
     (result: ChannelResult, options: ArchivePlayOptions) => {
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
         setPendingArchivePlayback({ result, options });
+        setPendingPlaybackReason("scan");
+        return;
+      }
+      if (
+        getStore().playlist?.single_provider &&
+        Object.values(getStore().archiveProbes).some((probe) => probe.running)
+      ) {
+        setPendingArchivePlayback({ result, options });
+        setPendingPlaybackReason("archive_probe");
         return;
       }
 
@@ -1205,6 +1229,7 @@ export default function App() {
   }, [playbackVideoElement]);
 
   const handleProceedPlayback = useCallback(() => {
+    setPendingPlaybackReason(null);
     if (pendingArchivePlayback) {
       setPendingArchivePlayback(null);
       getStore().setPlayIntentActive(true);
@@ -1217,6 +1242,12 @@ export default function App() {
     getStore().setPlayIntentActive(true);
     playStream(channel);
   }, [pendingArchivePlayback, pendingPlaybackChannel, playStream, streamPlayer.playArchive]);
+
+  useEffect(() => {
+    if (pendingPlaybackReason === "archive_probe" && !archiveProbeActive) {
+      handleProceedPlayback();
+    }
+  }, [archiveProbeActive, handleProceedPlayback, pendingPlaybackReason]);
 
   // Successful playback is itself a channel check. Keep the result row and
   // detail panel in sync with everything the active player can establish.
@@ -1366,6 +1397,7 @@ export default function App() {
         if (state.pendingPlaybackChannel || pendingArchivePlayback) {
           state.setPendingPlaybackChannel(null);
           setPendingArchivePlayback(null);
+          setPendingPlaybackReason(null);
           return;
         }
         if (state.openSourceDialogState) {
@@ -1654,29 +1686,37 @@ export default function App() {
       {(pendingPlaybackChannel || pendingArchivePlayback) && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
           <div className="w-full max-w-xl rounded-xl border border-border-app bg-overlay p-5 shadow-2xl">
-            <h2 className="text-[16px] font-semibold mb-2">Scan currently running</h2>
+            <h2 className="text-[16px] font-semibold mb-2">
+              {pendingPlaybackReason === "archive_probe"
+                ? "Catch-up test currently running"
+                : "Scan currently running"}
+            </h2>
             <p className="text-[14px] text-text-secondary leading-relaxed">
-              A scan is currently running. Playing a channel while scanning may interfere with the
-              scan or cause playback issues if the server&apos;s max connection limit is exceeded.
+              {pendingPlaybackReason === "archive_probe"
+                ? "Playback will start when the catch-up test finishes, so a single-connection server is not interrupted."
+                : "A scan is currently running. Playing a channel while scanning may interfere with the scan or cause playback issues if the server&apos;s max connection limit is exceeded."}
             </p>
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
                 onClick={() => {
                   getStore().setPendingPlaybackChannel(null);
                   setPendingArchivePlayback(null);
+                  setPendingPlaybackReason(null);
                 }}
                 className="macos-btn px-3 py-2 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                 type="button"
               >
                 Cancel
               </button>
-              <button
-                onClick={handleProceedPlayback}
-                className="macos-btn macos-btn-primary px-3 py-2 min-h-9 text-[13px] font-medium bg-blue-600 hover:bg-blue-500 rounded-md"
-                type="button"
-              >
-                Proceed
-              </button>
+              {pendingPlaybackReason !== "archive_probe" && (
+                <button
+                  onClick={handleProceedPlayback}
+                  className="macos-btn macos-btn-primary px-3 py-2 min-h-9 text-[13px] font-medium bg-blue-600 hover:bg-blue-500 rounded-md"
+                  type="button"
+                >
+                  Proceed
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,8 +36,8 @@ import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
 import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import { buildArchiveUrl } from "./lib/archive";
+import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
   checkFfmpegAvailable,
   clearScanHistory,
@@ -173,6 +173,7 @@ function SelectedChannelSidebar({
   onPlayArchive,
   onScanChannel,
   onStopPlayer,
+  onCastStart,
   onOpenExternal,
   onPip,
 }: {
@@ -184,6 +185,7 @@ function SelectedChannelSidebar({
   onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   onScanChannel: (indices: number[]) => void;
   onStopPlayer: () => void;
+  onCastStart: () => void;
   onOpenExternal: (result: ChannelResult) => void;
   onPip?: () => void;
 }) {
@@ -299,6 +301,7 @@ function SelectedChannelSidebar({
         onGoLive={streamPlayer.goLive}
         onTogglePause={streamPlayer.togglePause}
         onStopPlayer={onStopPlayer}
+        onCastStart={onCastStart}
         onSetVolume={streamPlayer.setVolume}
         onToggleMute={streamPlayer.toggleMute}
         onOpenExternal={onOpenExternal}
@@ -527,9 +530,9 @@ export default function App() {
     result: ChannelResult;
     options: ArchivePlayOptions;
   } | null>(null);
-  const [pendingPlaybackReason, setPendingPlaybackReason] = useState<"scan" | "archive_probe" | null>(
-    null,
-  );
+  const [pendingPlaybackReason, setPendingPlaybackReason] = useState<
+    "scan" | "archive_probe" | null
+  >(null);
   const archiveProbeActive = useAppStore((state) =>
     Object.values(state.archiveProbes).some((probe) => probe.running),
   );
@@ -553,6 +556,7 @@ export default function App() {
     activeChannelIndex: playbackChannelIndex,
     play: playStream,
     stop: stopStream,
+    setArchiveSession,
     videoElement: playbackVideoElement,
   } = streamPlayer;
 
@@ -1113,6 +1117,11 @@ export default function App() {
     stopStream();
   }, [stopStream]);
 
+  const handleCastStart = useCallback(() => {
+    getStore().setPlayIntentActive(false);
+    stopStream({ preserveArchiveSession: true });
+  }, [stopStream]);
+
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {
       if (isSingleConnectionPlaylist(getStore().playlist)) {
@@ -1159,7 +1168,10 @@ export default function App() {
           currentChromecast.devices.find((d) => d.id === session.deviceId) ??
           (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
         if (device) {
-          void currentChromecast.cast(device, buildCastRequest(result));
+          void currentChromecast
+            .cast(device, buildCastRequest(result))
+            .then(() => setArchiveSession(null))
+            .catch(() => {});
           return;
         }
         // Fall through to local play if we can't resolve the device — better
@@ -1168,7 +1180,7 @@ export default function App() {
       getStore().setPlayIntentActive(true);
       playStream(result);
     },
-    [playStream],
+    [playStream, setArchiveSession],
   );
 
   const handlePlayArchive = useCallback(
@@ -1204,10 +1216,22 @@ export default function App() {
           currentChromecast.devices.find((d) => d.id === session.deviceId) ??
           (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
         if (device) {
-          void currentChromecast.cast(
-            device,
-            buildCastRequest({ ...result, url, content_type: "movie", stream_url: null }),
-          );
+          void currentChromecast
+            .cast(
+              device,
+              buildCastRequest({ ...result, url, content_type: "movie", stream_url: null }),
+            )
+            .then(() => {
+              setArchiveSession({
+                baseResult: result,
+                url,
+                startEpochS,
+                windowStartEpochS: startEpochS,
+                windowEndEpochS,
+                title: options.title ?? null,
+              });
+            })
+            .catch(() => {});
           return;
         }
       }
@@ -1215,7 +1239,7 @@ export default function App() {
       getStore().setPlayIntentActive(true);
       streamPlayer.playArchive(result, options);
     },
-    [streamPlayer.playArchive],
+    [setArchiveSession, streamPlayer.playArchive],
   );
 
   const handlePip = useCallback(() => {
@@ -1253,7 +1277,8 @@ export default function App() {
   // detail panel in sync with everything the active player can establish.
   useEffect(() => {
     const idx = streamPlayer.activeChannelIndex;
-    if (idx === null || streamPlayer.playerState !== "playing" || streamPlayer.archiveSession) return;
+    if (idx === null || streamPlayer.playerState !== "playing" || streamPlayer.archiveSession)
+      return;
 
     const state = getStore();
     const existing = selectResultByIndex(state, idx);
@@ -1539,6 +1564,7 @@ export default function App() {
                 onPlayArchive={handlePlayArchive}
                 onScanChannel={handleScanSelected}
                 onStopPlayer={handleStopPlayer}
+                onCastStart={handleCastStart}
                 onOpenExternal={handleOpenExternal}
                 onPip={handlePip}
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1301,6 +1301,11 @@ export default function App() {
 
   useEffect(() => {
     if (pendingPlaybackReason === "archive_probe" && !archiveProbeActive) {
+      const state = getStore();
+      if (isScanActive(state.scanState) && state.playlist?.single_provider) {
+        setPendingPlaybackReason("scan");
+        return;
+      }
       handleProceedPlayback();
     }
   }, [archiveProbeActive, handleProceedPlayback, pendingPlaybackReason]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,9 +34,10 @@ import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
 import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
-import { useStreamPlayer } from "./hooks/useStreamPlayer";
+import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
+import { buildArchiveUrl } from "./lib/archive";
 import {
   checkFfmpegAvailable,
   clearScanHistory,
@@ -169,6 +170,7 @@ function SelectedChannelSidebar({
   streamPlayer,
   chromecast,
   onPlayChannel,
+  onPlayArchive,
   onScanChannel,
   onStopPlayer,
   onOpenExternal,
@@ -179,6 +181,7 @@ function SelectedChannelSidebar({
   streamPlayer: StreamPlayerController;
   chromecast: UseChromecastResult;
   onPlayChannel: (result: ChannelResult) => void;
+  onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   onScanChannel: (indices: number[]) => void;
   onStopPlayer: () => void;
   onOpenExternal: (result: ChannelResult) => void;
@@ -291,7 +294,7 @@ function SelectedChannelSidebar({
         muted={streamPlayer.muted}
         videoElement={streamPlayer.videoElement}
         archiveSession={streamPlayer.archiveSession}
-        onPlayArchive={streamPlayer.playArchive}
+        onPlayArchive={onPlayArchive}
         onSeekArchive={streamPlayer.seekArchive}
         onGoLive={streamPlayer.goLive}
         onTogglePause={streamPlayer.togglePause}
@@ -520,6 +523,10 @@ export default function App() {
   const ffmpegWarning = useAppStore((s) => s.ffmpegWarning);
   const openSourceDialogState = useAppStore((s) => s.openSourceDialogState);
   const pendingPlaybackChannel = useAppStore((s) => s.pendingPlaybackChannel);
+  const [pendingArchivePlayback, setPendingArchivePlayback] = useState<{
+    result: ChannelResult;
+    options: ArchivePlayOptions;
+  } | null>(null);
   const liveSelectedChannel = useAppStore(selectLiveSelectedChannel);
   const showHistory = useAppStore((s) => s.showHistory);
   const historyEntries = useAppStore((s) => s.historyEntries);
@@ -1145,6 +1152,44 @@ export default function App() {
     [playStream],
   );
 
+  const handlePlayArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
+        setPendingArchivePlayback({ result, options });
+        return;
+      }
+
+      const nowEpochS = Math.floor(Date.now() / 1000);
+      const windowEndEpochS = Math.min(options.endEpochS ?? nowEpochS, nowEpochS);
+      const startEpochS = Math.min(Math.floor(options.startEpochS), windowEndEpochS - 1);
+      const url = buildArchiveUrl(result, {
+        startEpochS,
+        durationS: Math.max(60, windowEndEpochS - startEpochS),
+        nowEpochS,
+      });
+      if (!url) return;
+
+      const currentChromecast = chromecastRef.current;
+      if (isCastSessionActive(currentChromecast.session)) {
+        const session = currentChromecast.session;
+        const device =
+          currentChromecast.devices.find((d) => d.id === session.deviceId) ??
+          (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
+        if (device) {
+          void currentChromecast.cast(
+            device,
+            buildCastRequest({ ...result, url, content_type: "movie", stream_url: null }),
+          );
+          return;
+        }
+      }
+
+      getStore().setPlayIntentActive(true);
+      streamPlayer.playArchive(result, options);
+    },
+    [streamPlayer.playArchive],
+  );
+
   const handlePip = useCallback(() => {
     const video = playbackVideoElement;
     if (!video) return;
@@ -1156,18 +1201,24 @@ export default function App() {
   }, [playbackVideoElement]);
 
   const handleProceedPlayback = useCallback(() => {
+    if (pendingArchivePlayback) {
+      setPendingArchivePlayback(null);
+      getStore().setPlayIntentActive(true);
+      streamPlayer.playArchive(pendingArchivePlayback.result, pendingArchivePlayback.options);
+      return;
+    }
     if (!pendingPlaybackChannel) return;
     const channel = pendingPlaybackChannel;
     getStore().setPendingPlaybackChannel(null);
     getStore().setPlayIntentActive(true);
     playStream(channel);
-  }, [pendingPlaybackChannel, playStream]);
+  }, [pendingArchivePlayback, pendingPlaybackChannel, playStream, streamPlayer.playArchive]);
 
   // Successful playback is itself a channel check. Keep the result row and
   // detail panel in sync with everything the active player can establish.
   useEffect(() => {
     const idx = streamPlayer.activeChannelIndex;
-    if (idx === null || streamPlayer.playerState !== "playing") return;
+    if (idx === null || streamPlayer.playerState !== "playing" || streamPlayer.archiveSession) return;
 
     const state = getStore();
     const existing = selectResultByIndex(state, idx);
@@ -1187,6 +1238,7 @@ export default function App() {
   }, [
     settings.low_fps_threshold,
     streamPlayer.activeChannelIndex,
+    streamPlayer.archiveSession,
     streamPlayer.playerState,
     streamPlayer.streamMetadata,
     updateResult,
@@ -1307,8 +1359,9 @@ export default function App() {
           state.setLightboxOpen(false);
           return;
         }
-        if (state.pendingPlaybackChannel) {
+        if (state.pendingPlaybackChannel || pendingArchivePlayback) {
           state.setPendingPlaybackChannel(null);
+          setPendingArchivePlayback(null);
           return;
         }
         if (state.openSourceDialogState) {
@@ -1327,7 +1380,7 @@ export default function App() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isMac]);
+  }, [isMac, pendingArchivePlayback]);
 
   const handleTableProfilerRender = useCallback<ProfilerOnRenderCallback>(
     (id, phase, actualDuration, baseDuration) => {
@@ -1447,6 +1500,7 @@ export default function App() {
                 streamPlayer={streamPlayer}
                 chromecast={chromecast}
                 onPlayChannel={handlePlayInApp}
+                onPlayArchive={handlePlayArchive}
                 onScanChannel={handleScanSelected}
                 onStopPlayer={handleStopPlayer}
                 onOpenExternal={handleOpenExternal}
@@ -1593,7 +1647,7 @@ export default function App() {
         </div>
       )}
 
-      {pendingPlaybackChannel && (
+      {(pendingPlaybackChannel || pendingArchivePlayback) && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
           <div className="w-full max-w-xl rounded-xl border border-border-app bg-overlay p-5 shadow-2xl">
             <h2 className="text-[16px] font-semibold mb-2">Scan currently running</h2>
@@ -1603,7 +1657,10 @@ export default function App() {
             </p>
             <div className="mt-5 flex items-center justify-end gap-2">
               <button
-                onClick={() => getStore().setPendingPlaybackChannel(null)}
+                onClick={() => {
+                  getStore().setPendingPlaybackChannel(null);
+                  setPendingArchivePlayback(null);
+                }}
                 className="macos-btn px-3 py-2 min-h-9 text-[13px] bg-btn hover:bg-btn-hover rounded-md"
                 type="button"
               >

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -38,6 +38,7 @@ function ensureEpgLoaded(): Promise<void> {
   ];
   const promise = loadEpg(sources, tvgIds).then(
     (summary) => {
+      useAppStore.getState().setEpgLoadSummary(summary);
       logger.info(
         "[EPG] Loaded",
         summary.programme_count,

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -240,6 +240,7 @@ export function ArchiveCard({
   onPlayArchive,
 }: ArchiveCardProps) {
   const [programmes, setProgrammes] = useState<EpgProgramme[] | null>(null);
+  const depthDays = Math.min(MAX_CATCHUP_DAYS, Math.max(1, result.catchup_days ?? 7));
 
   useEffect(() => {
     if (!hasArchive(result)) {
@@ -254,7 +255,6 @@ export function ArchiveCard({
       }
       await ensureEpgLoaded();
       const now = Math.floor(Date.now() / 1000);
-      const depthDays = Math.min(MAX_CATCHUP_DAYS, result.catchup_days ?? 7);
       const list = await getEpgProgrammes(
         epgSourcesFor(result),
         result.tvg_id,
@@ -267,15 +267,18 @@ export function ArchiveCard({
     return () => {
       stale = true;
     };
-  }, [result]);
+  }, [depthDays, result]);
 
   const dayGroups = useMemo(() => {
     if (!programmes || programmes.length === 0) return [];
     const now = new Date();
     const nowEpochS = Math.floor(now.getTime() / 1000);
+    const retentionStartEpochS = nowEpochS - depthDays * 86_400;
     const groups: Array<{ label: string; entries: EpgProgramme[] }> = [];
     const visibleProgrammes = programmes
-      .filter((programme) => programme.start <= nowEpochS)
+      .filter(
+        (programme) => programme.start >= retentionStartEpochS && programme.start <= nowEpochS,
+      )
       .slice(-MAX_RENDERED_PROGRAMMES);
     // Newest day first, programmes within a day in airing order.
     for (const programme of visibleProgrammes) {
@@ -289,7 +292,7 @@ export function ArchiveCard({
     }
     groups.reverse();
     return groups;
-  }, [programmes]);
+  }, [depthDays, programmes]);
 
   if (!hasArchive(result)) {
     return null;

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,9 +1,10 @@
 import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
 import { archiveTitle, hasArchive } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { logger } from "../lib/logger";
+import { isScanActive } from "../lib/scanState";
 import { getEpgProgrammes, loadEpg } from "../lib/tauri";
 import type { ChannelResult, EpgProgramme } from "../lib/types";
 import { useAppStore } from "../store";
@@ -11,6 +12,7 @@ import { useAppStore } from "../store";
 interface ArchiveCardProps {
   result: ChannelResult;
   archiveSession: ArchiveSession | null;
+  isCasting: boolean;
   onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
 }
 
@@ -68,21 +70,52 @@ function timeLabel(epochS: number): string {
   return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function ArchiveProbe({ result }: { result: ChannelResult }) {
+function ArchiveProbe({ result, isCasting }: Pick<ArchiveCardProps, "result" | "isCasting">) {
   const entry = useAppStore((state) => state.archiveProbes[result.index]);
   const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
+  const scanState = useAppStore((state) => state.scanState);
+  const singleProvider = useAppStore((state) => state.playlist?.single_provider ?? false);
+  const isPlaying = useAppStore((state) => state.playIntentActive);
   const running = entry?.running ?? false;
+  const scanActive = isScanActive(scanState);
+  const streamActive = singleProvider && (isPlaying || isCasting);
   const outcomes = entry?.outcomes ?? [];
+  const isCastingRef = useRef(isCasting);
+  isCastingRef.current = isCasting;
 
   const runProbe = () => {
-    void probeChannelArchive(result, (update) => setArchiveProbe(result.index, update));
+    const initialState = useAppStore.getState();
+    if (
+      isScanActive(initialState.scanState) ||
+      (initialState.playlist?.single_provider &&
+        (initialState.playIntentActive || isCastingRef.current))
+    ) {
+      return;
+    }
+    const playlist = initialState.playlist;
+    void probeChannelArchive(
+      result,
+      (update) => {
+        if (useAppStore.getState().playlist === playlist) {
+          setArchiveProbe(result.index, update);
+        }
+      },
+      () => {
+        const state = useAppStore.getState();
+        return (
+          state.playlist === playlist &&
+          !isScanActive(state.scanState) &&
+          !(state.playlist?.single_provider && (state.playIntentActive || isCastingRef.current))
+        );
+      },
+    );
   };
 
   return (
     <div className="mt-2 border-t border-violet-500/15 pt-2">
       <button
         type="button"
-        disabled={running}
+        disabled={running || scanActive || streamActive}
         onClick={runProbe}
         className="flex w-full items-center justify-center gap-1.5 rounded-md bg-btn px-3 py-1.5 text-[12px] font-medium text-text-primary border border-border-app shadow-sm hover:bg-btn-hover transition-colors disabled:opacity-40"
       >
@@ -171,7 +204,12 @@ function ArchivePicker({
   );
 }
 
-export function ArchiveCard({ result, archiveSession, onPlayArchive }: ArchiveCardProps) {
+export function ArchiveCard({
+  result,
+  archiveSession,
+  isCasting,
+  onPlayArchive,
+}: ArchiveCardProps) {
   const [programmes, setProgrammes] = useState<EpgProgramme[] | null>(null);
 
   useEffect(() => {
@@ -287,7 +325,7 @@ export function ArchiveCard({ result, archiveSession, onPlayArchive }: ArchiveCa
         <ArchivePicker result={result} onPlayArchive={onPlayArchive} />
       )}
 
-      <ArchiveProbe result={result} />
+      <ArchiveProbe result={result} isCasting={isCasting} />
     </div>
   );
 }

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,9 +1,10 @@
 import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
-import { archiveTitle, buildArchiveUrl, hasArchive } from "../lib/archive";
+import { archiveTitle, hasArchive } from "../lib/archive";
+import { probeChannelArchive } from "../lib/archiveProbe";
 import { logger } from "../lib/logger";
-import { getEpgProgrammes, loadEpg, quickCheckChannel } from "../lib/tauri";
+import { getEpgProgrammes, loadEpg } from "../lib/tauri";
 import type { ChannelResult, EpgProgramme } from "../lib/types";
 import { useAppStore } from "../store";
 
@@ -66,65 +67,14 @@ function timeLabel(epochS: number): string {
   return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-interface ProbeOutcome {
-  label: string;
-  ok: boolean;
-  latencyMs: number | null;
-  error: string | null;
-}
-
 function ArchiveProbe({ result }: { result: ChannelResult }) {
-  const [running, setRunning] = useState(false);
-  const [outcomes, setOutcomes] = useState<ProbeOutcome[]>([]);
+  const entry = useAppStore((state) => state.archiveProbes[result.index]);
+  const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
+  const running = entry?.running ?? false;
+  const outcomes = entry?.outcomes ?? [];
 
-  const runProbe = async () => {
-    setRunning(true);
-    setOutcomes([]);
-    const now = Math.floor(Date.now() / 1000);
-    const depthDays = result.catchup_days;
-    const points: Array<{ label: string; startEpochS: number }> = [
-      { label: "Archive −1 h", startEpochS: now - 3600 },
-    ];
-    if (depthDays != null && depthDays > 0) {
-      points.push({
-        label: `Archive −${depthDays} d`,
-        startEpochS: now - depthDays * 86_400 + 1800,
-      });
-    }
-
-    const results: ProbeOutcome[] = [];
-    for (const point of points) {
-      const url = buildArchiveUrl(result, {
-        startEpochS: point.startEpochS,
-        durationS: 300,
-        nowEpochS: now,
-      });
-      if (!url) continue;
-      try {
-        const checked = await quickCheckChannel({
-          ...result,
-          url,
-          content_type: "movie",
-          stream_url: null,
-          status: "pending",
-        });
-        results.push({
-          label: point.label,
-          ok: checked.status === "alive",
-          latencyMs: checked.latency_ms,
-          error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
-        });
-      } catch (error) {
-        results.push({
-          label: point.label,
-          ok: false,
-          latencyMs: null,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      setOutcomes([...results]);
-    }
-    setRunning(false);
+  const runProbe = () => {
+    void probeChannelArchive(result, (update) => setArchiveProbe(result.index, update));
   };
 
   return (
@@ -147,7 +97,7 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
           {outcome.ok ? (
             <span className="flex items-center gap-1 font-medium text-green-400">
               <CircleCheck className="h-3 w-3" />
-              OK{outcome.latencyMs != null ? ` · ${outcome.latencyMs} ms` : ""}
+              OK{outcome.latencyMs != null ? ` \u00b7 ${outcome.latencyMs} ms` : ""}
             </span>
           ) : (
             <span
@@ -336,8 +286,7 @@ export function ArchiveCard({ result, archiveSession, onPlayArchive }: ArchiveCa
         <ArchivePicker result={result} onPlayArchive={onPlayArchive} />
       )}
 
-      {/* Keyed by channel so probe results never survive a selection change. */}
-      <ArchiveProbe key={result.index} result={result} />
+      <ArchiveProbe result={result} />
     </div>
   );
 }

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -108,7 +108,9 @@ function ArchiveProbe({ result, isCasting }: Pick<ArchiveCardProps, "result" | "
   const streamActive = singleProvider && (isPlaying || isCasting);
   const outcomes = entry?.outcomes ?? [];
   const isCastingRef = useRef(isCasting);
-  isCastingRef.current = isCasting;
+  useEffect(() => {
+    isCastingRef.current = isCasting;
+  }, [isCasting]);
 
   const runProbe = () => {
     const initialState = useAppStore.getState();

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -17,19 +17,12 @@ interface ArchiveCardProps {
 }
 
 // The EPG download can be hundreds of MB, so it loads lazily the first time a
-// catch-up channel's card opens, once per playlist+sources combination.
+// catch-up channel's card opens, once per playlist, sources, and indexed IDs.
 let epgLoad: { key: string; promise: Promise<void> } | null = null;
 
 function ensureEpgLoaded(): Promise<void> {
   const state = useAppStore.getState();
   const sources = state.playlist?.epg_sources ?? [];
-  if (sources.length === 0) {
-    return Promise.resolve();
-  }
-  const key = `${state.playlist?.source_identity ?? state.playlist?.file_path ?? ""}|${sources.join(",")}`;
-  if (epgLoad?.key === key) {
-    return epgLoad.promise;
-  }
   const tvgIds = [
     ...new Set(
       state.flatResults
@@ -37,7 +30,15 @@ function ensureEpgLoaded(): Promise<void> {
         .map((result) => result.tvg_id)
         .filter((id): id is string => !!id),
     ),
-  ];
+  ].sort();
+  const key = JSON.stringify([
+    state.playlist?.source_identity ?? state.playlist?.file_path ?? "",
+    sources,
+    tvgIds,
+  ]);
+  if (epgLoad?.key === key) {
+    return epgLoad.promise;
+  }
   const promise = loadEpg(sources, tvgIds).then(
     (summary) => {
       useAppStore.getState().setEpgLoadSummary(summary);
@@ -161,9 +162,10 @@ function ArchivePicker({
     const [hours, minutes] = time.split(":").map((part) => Number.parseInt(part, 10));
     const date = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack);
     date.setHours(hours || 0, minutes || 0, 0, 0);
-    const startEpochS = Math.min(
-      Math.floor(date.getTime() / 1000),
-      Math.floor(Date.now() / 1000) - 60,
+    const nowEpochS = Math.floor(Date.now() / 1000);
+    const startEpochS = Math.max(
+      nowEpochS - depthDays * 86_400,
+      Math.min(Math.floor(date.getTime() / 1000), nowEpochS - 60),
     );
     onPlayArchive(result, { startEpochS });
   };

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -20,6 +20,7 @@ interface ArchiveCardProps {
 // catch-up channel's card opens, once per playlist, sources, and indexed IDs.
 let epgLoad: { key: string; promise: Promise<void> } | null = null;
 const MAX_CATCHUP_DAYS = 31;
+const MAX_RENDERED_PROGRAMMES = 2_000;
 
 function epgSourcesFor(result: ChannelResult): string[] {
   const playlist = useAppStore.getState().playlist;
@@ -249,9 +250,7 @@ export function ArchiveCard({
         result.tvg_id,
         now - depthDays * 86_400,
         now,
-      ).catch(
-        () => [] as EpgProgramme[],
-      );
+      ).catch(() => [] as EpgProgramme[]);
       if (!stale) setProgrammes(list);
     };
     void load();
@@ -265,9 +264,11 @@ export function ArchiveCard({
     const now = new Date();
     const nowEpochS = Math.floor(now.getTime() / 1000);
     const groups: Array<{ label: string; entries: EpgProgramme[] }> = [];
+    const visibleProgrammes = programmes
+      .filter((programme) => programme.start <= nowEpochS)
+      .slice(-MAX_RENDERED_PROGRAMMES);
     // Newest day first, programmes within a day in airing order.
-    for (const programme of programmes) {
-      if (programme.start > nowEpochS) continue;
+    for (const programme of visibleProgrammes) {
       const label = dayLabel(programme.start, now);
       const group = groups.find((candidate) => candidate.label === label);
       if (group) {

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -18,7 +18,13 @@ interface ArchiveCardProps {
 
 // The EPG download can be hundreds of MB, so it loads lazily the first time a
 // catch-up channel's card opens, once per playlist, sources, and indexed IDs.
-let epgLoad: { key: string; promise: Promise<void>; summary: EpgLoadSummary | null } | null = null;
+let epgLoad: {
+  key: string;
+  promise: Promise<void>;
+  summary: EpgLoadSummary | null;
+  loadedAt: number | null;
+} | null = null;
+const EPG_LOAD_TTL_MS = 6 * 60 * 60 * 1_000;
 const MAX_RENDERED_PROGRAMMES = 2_000;
 
 function epgSourcesFor(result: ChannelResult): string[] {
@@ -44,7 +50,10 @@ function epgLoadRequest() {
 
 function ensureEpgLoaded(): Promise<void> {
   const { key, sources, tvgIds } = epgLoadRequest();
-  if (epgLoad?.key === key) {
+  if (
+    epgLoad?.key === key &&
+    (epgLoad.loadedAt == null || Date.now() - epgLoad.loadedAt < EPG_LOAD_TTL_MS)
+  ) {
     if (epgLoad.summary) {
       useAppStore.getState().setEpgLoadSummary(epgLoad.summary);
     }
@@ -56,6 +65,7 @@ function ensureEpgLoaded(): Promise<void> {
         return;
       }
       epgLoad.summary = summary;
+      epgLoad.loadedAt = Date.now();
       useAppStore.getState().setEpgLoadSummary(summary);
       logger.info(
         "[EPG] Loaded",
@@ -81,7 +91,7 @@ function ensureEpgLoaded(): Promise<void> {
       }
     },
   );
-  epgLoad = { key, promise, summary: null };
+  epgLoad = { key, promise, summary: null, loadedAt: null };
   return promise;
 }
 

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -348,7 +348,7 @@ export function ArchiveCard({
                 const playing = playingStart === programme.start;
                 return (
                   <button
-                    key={`${programme.start}-${programme.title}`}
+                    key={`${programme.start}-${programme.stop}-${programme.title}`}
                     type="button"
                     onClick={() =>
                       onPlayArchive(result, {

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -19,6 +19,12 @@ interface ArchiveCardProps {
 // The EPG download can be hundreds of MB, so it loads lazily the first time a
 // catch-up channel's card opens, once per playlist, sources, and indexed IDs.
 let epgLoad: { key: string; promise: Promise<void> } | null = null;
+const MAX_CATCHUP_DAYS = 31;
+
+function epgSourcesFor(result: ChannelResult): string[] {
+  const playlist = useAppStore.getState().playlist;
+  return playlist?.epg_sources_by_playlist[result.playlist] ?? playlist?.epg_sources ?? [];
+}
 
 function ensureEpgLoaded(): Promise<void> {
   const state = useAppStore.getState();
@@ -49,9 +55,15 @@ function ensureEpgLoaded(): Promise<void> {
         summary.channels_matched,
         "channels",
       );
+      if (summary.failed_sources.length > 0 && epgLoad?.key === key) {
+        epgLoad = null;
+      }
     },
     (error) => {
       logger.warn("[EPG] Load failed:", error);
+      if (epgLoad?.key === key) {
+        epgLoad = null;
+      }
     },
   );
   epgLoad = { key, promise };
@@ -157,7 +169,7 @@ function ArchivePicker({
   result,
   onPlayArchive,
 }: Pick<ArchiveCardProps, "result" | "onPlayArchive">) {
-  const depthDays = Math.max(1, result.catchup_days ?? 1);
+  const depthDays = Math.min(MAX_CATCHUP_DAYS, Math.max(1, result.catchup_days ?? 1));
   const [daysBack, setDaysBack] = useState(0);
   const [time, setTime] = useState("20:00");
   const now = new Date();
@@ -231,8 +243,13 @@ export function ArchiveCard({
       }
       await ensureEpgLoaded();
       const now = Math.floor(Date.now() / 1000);
-      const depthDays = result.catchup_days ?? 7;
-      const list = await getEpgProgrammes(result.tvg_id, now - depthDays * 86_400, now).catch(
+      const depthDays = Math.min(MAX_CATCHUP_DAYS, result.catchup_days ?? 7);
+      const list = await getEpgProgrammes(
+        epgSourcesFor(result),
+        result.tvg_id,
+        now - depthDays * 86_400,
+        now,
+      ).catch(
         () => [] as EpgProgramme[],
       );
       if (!stale) setProgrammes(list);

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -6,7 +6,7 @@ import { probeChannelArchive } from "../lib/archiveProbe";
 import { logger } from "../lib/logger";
 import { isScanActive } from "../lib/scanState";
 import { getEpgProgrammes, loadEpg } from "../lib/tauri";
-import type { ChannelResult, EpgProgramme } from "../lib/types";
+import type { ChannelResult, EpgLoadSummary, EpgProgramme } from "../lib/types";
 import { useAppStore } from "../store";
 
 interface ArchiveCardProps {
@@ -18,7 +18,7 @@ interface ArchiveCardProps {
 
 // The EPG download can be hundreds of MB, so it loads lazily the first time a
 // catch-up channel's card opens, once per playlist, sources, and indexed IDs.
-let epgLoad: { key: string; promise: Promise<void> } | null = null;
+let epgLoad: { key: string; promise: Promise<void>; summary: EpgLoadSummary | null } | null = null;
 const MAX_RENDERED_PROGRAMMES = 2_000;
 
 function epgSourcesFor(result: ChannelResult): string[] {
@@ -45,6 +45,9 @@ function epgLoadRequest() {
 function ensureEpgLoaded(): Promise<void> {
   const { key, sources, tvgIds } = epgLoadRequest();
   if (epgLoad?.key === key) {
+    if (epgLoad.summary) {
+      useAppStore.getState().setEpgLoadSummary(epgLoad.summary);
+    }
     return epgLoad.promise;
   }
   const promise = loadEpg(sources, tvgIds).then(
@@ -52,6 +55,7 @@ function ensureEpgLoaded(): Promise<void> {
       if (epgLoad?.key !== key || epgLoadRequest().key !== key) {
         return;
       }
+      epgLoad.summary = summary;
       useAppStore.getState().setEpgLoadSummary(summary);
       logger.info(
         "[EPG] Loaded",
@@ -77,7 +81,7 @@ function ensureEpgLoaded(): Promise<void> {
       }
     },
   );
-  epgLoad = { key, promise };
+  epgLoad = { key, promise, summary: null };
   return promise;
 }
 

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,7 +1,7 @@
 import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
-import { archiveTitle, hasArchive } from "../lib/archive";
+import { archiveTitle, hasArchive, MAX_CATCHUP_DAYS } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { logger } from "../lib/logger";
 import { isScanActive } from "../lib/scanState";
@@ -19,7 +19,6 @@ interface ArchiveCardProps {
 // The EPG download can be hundreds of MB, so it loads lazily the first time a
 // catch-up channel's card opens, once per playlist, sources, and indexed IDs.
 let epgLoad: { key: string; promise: Promise<void> } | null = null;
-const MAX_CATCHUP_DAYS = 31;
 const MAX_RENDERED_PROGRAMMES = 2_000;
 
 function epgSourcesFor(result: ChannelResult): string[] {
@@ -27,7 +26,7 @@ function epgSourcesFor(result: ChannelResult): string[] {
   return playlist?.epg_sources_by_playlist[result.playlist] ?? playlist?.epg_sources ?? [];
 }
 
-function ensureEpgLoaded(): Promise<void> {
+function epgLoadRequest() {
   const state = useAppStore.getState();
   const sources = state.playlist?.epg_sources ?? [];
   const tvgIds = [
@@ -43,11 +42,19 @@ function ensureEpgLoaded(): Promise<void> {
     sources,
     tvgIds,
   ]);
+  return { key, sources, tvgIds };
+}
+
+function ensureEpgLoaded(): Promise<void> {
+  const { key, sources, tvgIds } = epgLoadRequest();
   if (epgLoad?.key === key) {
     return epgLoad.promise;
   }
   const promise = loadEpg(sources, tvgIds).then(
     (summary) => {
+      if (epgLoad?.key !== key || epgLoadRequest().key !== key) {
+        return;
+      }
       useAppStore.getState().setEpgLoadSummary(summary);
       logger.info(
         "[EPG] Loaded",

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -73,6 +73,9 @@ function timeLabel(epochS: number): string {
 
 function ArchiveProbe({ result, isCasting }: Pick<ArchiveCardProps, "result" | "isCasting">) {
   const entry = useAppStore((state) => state.archiveProbes[result.index]);
+  const probeActive = useAppStore((state) =>
+    Object.values(state.archiveProbes).some((probe) => probe.running),
+  );
   const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
   const scanState = useAppStore((state) => state.scanState);
   const singleProvider = useAppStore((state) => state.playlist?.single_provider ?? false);
@@ -88,6 +91,7 @@ function ArchiveProbe({ result, isCasting }: Pick<ArchiveCardProps, "result" | "
     const initialState = useAppStore.getState();
     if (
       isScanActive(initialState.scanState) ||
+      Object.values(initialState.archiveProbes).some((probe) => probe.running) ||
       (initialState.playlist?.single_provider &&
         (initialState.playIntentActive || isCastingRef.current))
     ) {
@@ -116,7 +120,7 @@ function ArchiveProbe({ result, isCasting }: Pick<ArchiveCardProps, "result" | "
     <div className="mt-2 border-t border-violet-500/15 pt-2">
       <button
         type="button"
-        disabled={running || scanActive || streamActive}
+        disabled={probeActive || scanActive || streamActive}
         onClick={runProbe}
         className="flex w-full items-center justify-center gap-1.5 rounded-md bg-btn px-3 py-1.5 text-[12px] font-medium text-text-primary border border-border-app shadow-sm hover:bg-btn-hover transition-colors disabled:opacity-40"
       >

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,0 +1,343 @@
+import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
+import { archiveTitle, buildArchiveUrl, hasArchive } from "../lib/archive";
+import { logger } from "../lib/logger";
+import { getEpgProgrammes, loadEpg, quickCheckChannel } from "../lib/tauri";
+import type { ChannelResult, EpgProgramme } from "../lib/types";
+import { useAppStore } from "../store";
+
+interface ArchiveCardProps {
+  result: ChannelResult;
+  archiveSession: ArchiveSession | null;
+  onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
+}
+
+// The EPG download can be hundreds of MB, so it loads lazily the first time a
+// catch-up channel's card opens, once per playlist+sources combination.
+let epgLoad: { key: string; promise: Promise<void> } | null = null;
+
+function ensureEpgLoaded(): Promise<void> {
+  const state = useAppStore.getState();
+  const sources = state.playlist?.epg_sources ?? [];
+  if (sources.length === 0) {
+    return Promise.resolve();
+  }
+  const key = `${state.playlist?.source_identity ?? state.playlist?.file_path ?? ""}|${sources.join(",")}`;
+  if (epgLoad?.key === key) {
+    return epgLoad.promise;
+  }
+  const tvgIds = [
+    ...new Set(
+      state.flatResults
+        .filter(hasArchive)
+        .map((result) => result.tvg_id)
+        .filter((id): id is string => !!id),
+    ),
+  ];
+  const promise = loadEpg(sources, tvgIds).then(
+    (summary) => {
+      logger.info(
+        "[EPG] Loaded",
+        summary.programme_count,
+        "programmes for",
+        summary.channels_matched,
+        "channels",
+      );
+    },
+    (error) => {
+      logger.warn("[EPG] Load failed:", error);
+    },
+  );
+  epgLoad = { key, promise };
+  return promise;
+}
+
+function dayLabel(epochS: number, now: Date): string {
+  const date = new Date(epochS * 1000);
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const dayDiff = Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000);
+  if (dayDiff === 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  return date.toLocaleDateString([], { weekday: "short", day: "numeric", month: "short" });
+}
+
+function timeLabel(epochS: number): string {
+  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+interface ProbeOutcome {
+  label: string;
+  ok: boolean;
+  latencyMs: number | null;
+  error: string | null;
+}
+
+function ArchiveProbe({ result }: { result: ChannelResult }) {
+  const [running, setRunning] = useState(false);
+  const [outcomes, setOutcomes] = useState<ProbeOutcome[]>([]);
+
+  const runProbe = async () => {
+    setRunning(true);
+    setOutcomes([]);
+    const now = Math.floor(Date.now() / 1000);
+    const depthDays = result.catchup_days;
+    const points: Array<{ label: string; startEpochS: number }> = [
+      { label: "Archive −1 h", startEpochS: now - 3600 },
+    ];
+    if (depthDays != null && depthDays > 0) {
+      points.push({
+        label: `Archive −${depthDays} d`,
+        startEpochS: now - depthDays * 86_400 + 1800,
+      });
+    }
+
+    const results: ProbeOutcome[] = [];
+    for (const point of points) {
+      const url = buildArchiveUrl(result, {
+        startEpochS: point.startEpochS,
+        durationS: 300,
+        nowEpochS: now,
+      });
+      if (!url) continue;
+      try {
+        const checked = await quickCheckChannel({
+          ...result,
+          url,
+          content_type: "movie",
+          stream_url: null,
+          status: "pending",
+        });
+        results.push({
+          label: point.label,
+          ok: checked.status === "alive",
+          latencyMs: checked.latency_ms,
+          error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
+        });
+      } catch (error) {
+        results.push({
+          label: point.label,
+          ok: false,
+          latencyMs: null,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      setOutcomes([...results]);
+    }
+    setRunning(false);
+  };
+
+  return (
+    <div className="mt-2 border-t border-violet-500/15 pt-2">
+      <button
+        type="button"
+        disabled={running}
+        onClick={runProbe}
+        className="flex w-full items-center justify-center gap-1.5 rounded-md bg-btn px-3 py-1.5 text-[12px] font-medium text-text-primary border border-border-app shadow-sm hover:bg-btn-hover transition-colors disabled:opacity-40"
+      >
+        {running && <LoaderCircle className="h-3 w-3 animate-spin" />}
+        {running ? "Testing catch-up..." : "Test catch-up"}
+      </button>
+      {outcomes.map((outcome) => (
+        <div
+          key={outcome.label}
+          className="mt-1.5 flex items-center justify-between gap-2 text-[11px]"
+        >
+          <span className="text-text-secondary">{outcome.label}</span>
+          {outcome.ok ? (
+            <span className="flex items-center gap-1 font-medium text-green-400">
+              <CircleCheck className="h-3 w-3" />
+              OK{outcome.latencyMs != null ? ` · ${outcome.latencyMs} ms` : ""}
+            </span>
+          ) : (
+            <span
+              className="flex min-w-0 items-center gap-1 font-medium text-red-400"
+              title={outcome.error ?? undefined}
+            >
+              <CircleX className="h-3 w-3 shrink-0" />
+              <span className="truncate">{outcome.error ?? "Failed"}</span>
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ArchivePicker({
+  result,
+  onPlayArchive,
+}: Pick<ArchiveCardProps, "result" | "onPlayArchive">) {
+  const depthDays = Math.max(1, result.catchup_days ?? 1);
+  const [daysBack, setDaysBack] = useState(0);
+  const [time, setTime] = useState("20:00");
+  const now = new Date();
+
+  const watchFrom = () => {
+    const [hours, minutes] = time.split(":").map((part) => Number.parseInt(part, 10));
+    const date = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysBack);
+    date.setHours(hours || 0, minutes || 0, 0, 0);
+    const startEpochS = Math.min(
+      Math.floor(date.getTime() / 1000),
+      Math.floor(Date.now() / 1000) - 60,
+    );
+    onPlayArchive(result, { startEpochS });
+  };
+
+  return (
+    <div className="mt-1">
+      <div className="flex items-center gap-1.5">
+        <select
+          value={daysBack}
+          onChange={(e) => setDaysBack(Number.parseInt(e.target.value, 10))}
+          className="native-field h-7 flex-1 min-w-0 rounded-md border border-border-app bg-input pl-2 pr-6 text-[12px] text-text-primary focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          {Array.from({ length: depthDays + 1 }, (_, daysAgo) => {
+            const label = dayLabel(Date.now() / 1000 - daysAgo * 86_400, now);
+            return (
+              <option key={label} value={daysAgo}>
+                {label}
+              </option>
+            );
+          })}
+        </select>
+        <input
+          type="time"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+          className="native-field h-7 w-[5.5rem] rounded-md border border-border-app bg-input px-1.5 text-[12px] text-text-primary focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={watchFrom}
+        className="mt-1.5 flex w-full items-center justify-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-[12px] font-medium text-white shadow-sm hover:bg-blue-500 transition-colors"
+      >
+        <Play className="h-3 w-3" />
+        Watch from here
+      </button>
+    </div>
+  );
+}
+
+export function ArchiveCard({ result, archiveSession, onPlayArchive }: ArchiveCardProps) {
+  const [programmes, setProgrammes] = useState<EpgProgramme[] | null>(null);
+
+  useEffect(() => {
+    if (!hasArchive(result)) {
+      return;
+    }
+    let stale = false;
+    setProgrammes(null);
+    const load = async () => {
+      if (!result.tvg_id) {
+        if (!stale) setProgrammes([]);
+        return;
+      }
+      await ensureEpgLoaded();
+      const now = Math.floor(Date.now() / 1000);
+      const depthDays = result.catchup_days ?? 7;
+      const list = await getEpgProgrammes(result.tvg_id, now - depthDays * 86_400, now).catch(
+        () => [] as EpgProgramme[],
+      );
+      if (!stale) setProgrammes(list);
+    };
+    void load();
+    return () => {
+      stale = true;
+    };
+  }, [result]);
+
+  const dayGroups = useMemo(() => {
+    if (!programmes || programmes.length === 0) return [];
+    const now = new Date();
+    const nowEpochS = Math.floor(now.getTime() / 1000);
+    const groups: Array<{ label: string; entries: EpgProgramme[] }> = [];
+    // Newest day first, programmes within a day in airing order.
+    for (const programme of programmes) {
+      if (programme.start > nowEpochS) continue;
+      const label = dayLabel(programme.start, now);
+      const group = groups.find((candidate) => candidate.label === label);
+      if (group) {
+        group.entries.push(programme);
+      } else {
+        groups.push({ label, entries: [programme] });
+      }
+    }
+    groups.reverse();
+    return groups;
+  }, [programmes]);
+
+  if (!hasArchive(result)) {
+    return null;
+  }
+
+  const playingStart =
+    archiveSession && archiveSession.baseResult.index === result.index
+      ? archiveSession.windowStartEpochS
+      : null;
+
+  return (
+    <div className="p-2 rounded bg-violet-500/10 border border-violet-500/20">
+      <p
+        className="text-[12px] font-medium text-violet-300"
+        title={archiveTitle(result) ?? undefined}
+      >
+        Archive
+        <span className="ml-1.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-violet-300/80">
+          {result.catchup ?? "default"}
+          {result.catchup_days != null ? ` · ${result.catchup_days} d` : ""}
+        </span>
+      </p>
+
+      {programmes === null ? (
+        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-text-tertiary">
+          <LoaderCircle className="h-3 w-3 animate-spin" />
+          Loading guide...
+        </div>
+      ) : dayGroups.length > 0 ? (
+        <div className="mt-1">
+          {dayGroups.map((group) => (
+            <div key={group.label}>
+              <p className="mt-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-text-tertiary">
+                {group.label}
+              </p>
+              {group.entries.map((programme) => {
+                const playing = playingStart === programme.start;
+                return (
+                  <button
+                    key={`${programme.start}-${programme.title}`}
+                    type="button"
+                    onClick={() =>
+                      onPlayArchive(result, {
+                        startEpochS: programme.start,
+                        endEpochS: programme.stop,
+                        title: programme.title,
+                      })
+                    }
+                    className={`flex w-full items-center gap-2 rounded px-1.5 py-0.5 text-left text-[11px] transition-colors ${
+                      playing
+                        ? "bg-violet-500/20 text-violet-200"
+                        : "text-text-secondary hover:bg-panel-subtle hover:text-text-primary"
+                    }`}
+                  >
+                    <span className="shrink-0 tabular-nums text-text-tertiary">
+                      {timeLabel(programme.start)}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{programme.title}</span>
+                    <Play className="h-2.5 w-2.5 shrink-0 opacity-60" />
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <ArchivePicker result={result} onPlayArchive={onPlayArchive} />
+      )}
+
+      {/* Keyed by channel so probe results never survive a selection change. */}
+      <ArchiveProbe key={result.index} result={result} />
+    </div>
+  );
+}

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -68,6 +68,9 @@ function ensureEpgLoaded(): Promise<void> {
       }
     },
     (error) => {
+      if (epgLoad?.key !== key || epgLoadRequest().key !== key) {
+        return;
+      }
       logger.warn("[EPG] Load failed:", error);
       if (epgLoad?.key === key) {
         epgLoad = null;

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,7 +1,7 @@
 import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
-import { archiveTitle, hasArchive, MAX_CATCHUP_DAYS } from "../lib/archive";
+import { archivePickerDefault, archiveTitle, hasArchive, MAX_CATCHUP_DAYS } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { logger } from "../lib/logger";
 import { isScanActive } from "../lib/scanState";
@@ -197,8 +197,8 @@ function ArchivePicker({
   onPlayArchive,
 }: Pick<ArchiveCardProps, "result" | "onPlayArchive">) {
   const depthDays = Math.min(MAX_CATCHUP_DAYS, Math.max(1, result.catchup_days ?? 1));
-  const [daysBack, setDaysBack] = useState(0);
-  const [time, setTime] = useState("20:00");
+  const [daysBack, setDaysBack] = useState(() => archivePickerDefault().daysBack);
+  const [time, setTime] = useState(() => archivePickerDefault().time);
   const now = new Date();
 
   const watchFrom = () => {

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -29,14 +29,11 @@ function epgSourcesFor(result: ChannelResult): string[] {
 function epgLoadRequest() {
   const state = useAppStore.getState();
   const sources = state.playlist?.epg_sources ?? [];
-  const tvgIds = [
-    ...new Set(
-      state.flatResults
-        .filter(hasArchive)
-        .map((result) => result.tvg_id)
-        .filter((id): id is string => !!id),
-    ),
-  ].sort();
+  const tvgIds = state.flatResults
+    .filter(hasArchive)
+    .map((result) => result.tvg_id)
+    .filter((id): id is string => !!id)
+    .sort();
   const key = JSON.stringify([
     state.playlist?.source_identity ?? state.playlist?.file_path ?? "",
     sources,
@@ -63,8 +60,11 @@ function ensureEpgLoaded(): Promise<void> {
         summary.channels_matched,
         "channels",
       );
-      if (summary.failed_sources.length > 0 && epgLoad?.key === key) {
-        epgLoad = null;
+      if (summary.failed_sources.length > 0) {
+        logger.warn("[EPG] Some sources failed to load:", summary.failed_sources.length);
+        if (summary.sources_loaded === 0 && epgLoad?.key === key) {
+          epgLoad = null;
+        }
       }
     },
     (error) => {

--- a/src/components/CastMenu.tsx
+++ b/src/components/CastMenu.tsx
@@ -13,12 +13,17 @@ interface UseChromecastShape {
   stop: () => Promise<void>;
 }
 
+export type CastStartHandler = () => (() => void) | undefined;
+
 interface CastMenuProps {
   chromecast: UseChromecastShape;
   castRequest: CastMediaRequest;
   mode: "popover" | "inline";
-  /** Fired after a cast successfully starts — e.g. to pause the local player. */
-  onCastStart?: () => void;
+  /**
+   * Fired before cast startup so the local stream can release its upstream
+   * connection. May return a rollback to run if startup fails.
+   */
+  onCastStart?: CastStartHandler;
   /**
    * Popover-mode only: fired when the menu opens or closes so the parent can
    * suppress auto-hide of surrounding chrome while the picker is visible.
@@ -92,11 +97,12 @@ function CastMenuPopover({
       // ffmpeg), and it also flips playIntentActive=false so arrow-key
       // navigation in the channel table won't auto-start a new local stream
       // mid-handshake.
-      onCastStart?.();
+      const rollBackCastStart = onCastStart?.();
       try {
         await chromecast.cast(device, castRequest);
         setOpen(false);
       } catch {
+        rollBackCastStart?.();
         // error surfaces via chromecast.error; keep menu open so the user sees it
       } finally {
         setStarting(false);
@@ -221,10 +227,11 @@ function CastMenuInline({ chromecast, castRequest, onCastStart }: Omit<CastMenuP
       // Fire onCastStart BEFORE the network round-trip — see CastMenuPopover
       // for the rationale (release upstream slot + suppress arrow-key
       // auto-play during the cast handshake).
-      onCastStart?.();
+      const rollBackCastStart = onCastStart?.();
       try {
         await chromecast.cast(device, castRequest);
       } catch {
+        rollBackCastStart?.();
         // error surfaces via chromecast.error; row stays expanded
       } finally {
         setStarting(false);

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -675,7 +675,9 @@ export function ChannelTable({
   // backend cast_to_device call instead of one per keystroke.
   const castRedirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isCastingRef = useRef(isCasting);
-  isCastingRef.current = isCasting;
+  useEffect(() => {
+    isCastingRef.current = isCasting;
+  }, [isCasting]);
   useEffect(() => {
     return () => {
       if (castRedirectTimerRef.current) {

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -144,6 +144,7 @@ export function ChannelTable({
   const isMac = useAppStore((s) => s.isMac);
   const channelLogoSize = useAppStore((s) => s.settings.channel_logo_size);
   const isPlaying = useAppStore((s) => s.playIntentActive);
+  const singleProvider = useAppStore((s) => s.playlist?.single_provider ?? false);
   const separatePlaceholder = useAppStore((s) => s.settings.separate_placeholder_status);
   const onSelectionChange = useAppStore((s) => s.setSelectedChannelIndices);
   const rawSearch = useAppStore((s) => s.search);
@@ -670,6 +671,8 @@ export function ChannelTable({
   // timer and schedules a new one, so a key burst coalesces into a single
   // backend cast_to_device call instead of one per keystroke.
   const castRedirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isCastingRef = useRef(isCasting);
+  isCastingRef.current = isCasting;
   useEffect(() => {
     return () => {
       if (castRedirectTimerRef.current) {
@@ -923,17 +926,43 @@ export function ChannelTable({
   }, [selectedIndices, contextMenuState, completedResults]);
 
   const handleTestCatchup = useCallback(() => {
+    const initialState = useAppStore.getState();
+    if (
+      isScanActive(initialState.scanState) ||
+      (initialState.playlist?.single_provider &&
+        (initialState.playIntentActive || isCastingRef.current))
+    ) {
+      setContextMenuState(null);
+      return;
+    }
     const targets = getSelectedChannels().filter(hasArchive);
+    const playlist = initialState.playlist;
     setContextMenuState(null);
     if (targets.length === 0) {
       return;
     }
+    const shouldContinue = () => {
+      const state = useAppStore.getState();
+      return (
+        state.playlist === playlist &&
+        !isScanActive(state.scanState) &&
+        !(state.playlist?.single_provider && (state.playIntentActive || isCastingRef.current))
+      );
+    };
     void (async () => {
       // Sequential on purpose: IPTV providers commonly cap concurrent
       // connections, and each probe already opens up to two archive URLs.
       for (const target of targets) {
-        await probeChannelArchive(target, (entry) =>
-          useAppStore.getState().setArchiveProbe(target.index, entry),
+        if (!shouldContinue()) break;
+        await probeChannelArchive(
+          target,
+          (entry) => {
+            const state = useAppStore.getState();
+            if (state.playlist === playlist) {
+              state.setArchiveProbe(target.index, entry);
+            }
+          },
+          shouldContinue,
         );
       }
     })();
@@ -1458,7 +1487,8 @@ export function ChannelTable({
             return (
               <button
                 onClick={handleTestCatchup}
-                className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
+                disabled={isScanActive(scanState) || (singleProvider && (isPlaying || isCasting))}
+                className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover disabled:opacity-50 disabled:pointer-events-none"
                 type="button"
               >
                 Test Catch-up ({archiveCount})

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -12,7 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { resultAtIndex } from "../hooks/useScan.helpers";
 import { hasArchive } from "../lib/archive";
-import { probeChannelArchive } from "../lib/archiveProbe";
+import { createArchiveProbeSequenceGuard, probeChannelArchive } from "../lib/archiveProbe";
 import { channelRowHeightPixels } from "../lib/channelLogoSize";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { getChannelTableLayout } from "../lib/channelTableLayout";
@@ -945,9 +945,11 @@ export function ChannelTable({
     if (targets.length === 0) {
       return;
     }
+    const sequenceIsCurrent = createArchiveProbeSequenceGuard();
     const shouldContinue = () => {
       const state = useAppStore.getState();
       return (
+        sequenceIsCurrent() &&
         state.playlist === playlist &&
         !isScanActive(state.scanState) &&
         !(state.playlist?.single_provider && (state.playIntentActive || isCastingRef.current))

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -144,6 +144,9 @@ export function ChannelTable({
   const isMac = useAppStore((s) => s.isMac);
   const channelLogoSize = useAppStore((s) => s.settings.channel_logo_size);
   const isPlaying = useAppStore((s) => s.playIntentActive);
+  const archiveProbeActive = useAppStore((state) =>
+    Object.values(state.archiveProbes).some((probe) => probe.running),
+  );
   const singleProvider = useAppStore((s) => s.playlist?.single_provider ?? false);
   const separatePlaceholder = useAppStore((s) => s.settings.separate_placeholder_status);
   const onSelectionChange = useAppStore((s) => s.setSelectedChannelIndices);
@@ -929,6 +932,7 @@ export function ChannelTable({
     const initialState = useAppStore.getState();
     if (
       isScanActive(initialState.scanState) ||
+      Object.values(initialState.archiveProbes).some((probe) => probe.running) ||
       (initialState.playlist?.single_provider &&
         (initialState.playIntentActive || isCastingRef.current))
     ) {
@@ -1487,7 +1491,11 @@ export function ChannelTable({
             return (
               <button
                 onClick={handleTestCatchup}
-                disabled={isScanActive(scanState) || (singleProvider && (isPlaying || isCasting))}
+                disabled={
+                  archiveProbeActive ||
+                  isScanActive(scanState) ||
+                  (singleProvider && (isPlaying || isCasting))
+                }
                 className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover disabled:opacity-50 disabled:pointer-events-none"
                 type="button"
               >

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -11,6 +11,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { resultAtIndex } from "../hooks/useScan.helpers";
+import { hasArchive } from "../lib/archive";
+import { probeChannelArchive } from "../lib/archiveProbe";
 import { channelRowHeightPixels } from "../lib/channelLogoSize";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { getChannelTableLayout } from "../lib/channelTableLayout";
@@ -920,6 +922,23 @@ export function ChannelTable({
     return completedResults.filter((r) => indexSet.has(r.index)).sort((a, b) => a.index - b.index);
   }, [selectedIndices, contextMenuState, completedResults]);
 
+  const handleTestCatchup = useCallback(() => {
+    const targets = getSelectedChannels().filter(hasArchive);
+    setContextMenuState(null);
+    if (targets.length === 0) {
+      return;
+    }
+    void (async () => {
+      // Sequential on purpose: IPTV providers commonly cap concurrent
+      // connections, and each probe already opens up to two archive URLs.
+      for (const target of targets) {
+        await probeChannelArchive(target, (entry) =>
+          useAppStore.getState().setArchiveProbe(target.index, entry),
+        );
+      }
+    })();
+  }, [getSelectedChannels]);
+
   const handleCopyChannelName = useCallback(async () => {
     if (!contextMenuState) return;
     const channels = getSelectedChannels();
@@ -1433,6 +1452,19 @@ export function ChannelTable({
               : "Scan"}{" "}
             Selected ({selectedIndices.size})
           </button>
+          {(() => {
+            const archiveCount = getSelectedChannels().filter(hasArchive).length;
+            if (archiveCount === 0) return null;
+            return (
+              <button
+                onClick={handleTestCatchup}
+                className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
+                type="button"
+              >
+                Test Catch-up ({archiveCount})
+              </button>
+            );
+          })()}
           <div className="h-px my-1 bg-border-subtle" />
           <button
             onClick={handlePreviewChannel}

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -158,6 +158,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const playlist = useAppStore((s) => s.playlist);
   const results = useAppStore((s) => s.flatResults);
   const progress = useAppStore((s) => s.progress);
+  const epgLoadSummary = useAppStore((s) => s.epgLoadSummary);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
   // Every hook below must run unconditionally: the "no playlist" early return
@@ -480,6 +481,12 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                 {epgSummary.channelsWithEpg} / {epgSummary.totalChannels} channels
               </p>
               <p className="text-text-secondary">Unique EPG IDs: {epgSummary.uniqueEpgSources}</p>
+              {epgLoadSummary && (
+                <p className="text-text-secondary">
+                  Programme data: {epgLoadSummary.channels_matched} channels ·{" "}
+                  {epgLoadSummary.programme_count.toLocaleString()} programmes
+                </p>
+              )}
             </div>
           </div>
         </section>

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -60,6 +60,7 @@ interface StreamPlayerProps {
   onGoLive?: () => void;
   onTogglePause: () => void;
   onStop: () => void;
+  onCastStart?: () => void;
   onSetVolume: (v: number) => void;
   onToggleMute: () => void;
   onOpenExternal: () => void;
@@ -87,6 +88,7 @@ export function StreamPlayer({
   onGoLive,
   onTogglePause,
   onStop,
+  onCastStart,
   onSetVolume,
   onToggleMute,
   onOpenExternal,
@@ -164,8 +166,8 @@ export function StreamPlayer({
     // ffmpeg every few seconds. Each reconnect introduces a DTS jump that
     // the Chromecast HLS player can't recover from cleanly, so the cast
     // session goes idle/error within seconds.
-    onStop();
-  }, [onStop]);
+    (onCastStart ?? onStop)();
+  }, [onCastStart, onStop]);
 
   return (
     <div

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   Cast,
+  History,
   LoaderCircle,
   Maximize,
   Pause,
@@ -12,10 +13,21 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { UseChromecastResult } from "../hooks/useChromecast";
-import { MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../hooks/useStreamPlayer";
+import { type ArchiveSession, MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../hooks/useStreamPlayer";
 import { isCastSessionActive } from "../lib/cast";
 import type { CastMediaRequest } from "../lib/types";
 import { CastMenu } from "./CastMenu";
+
+function formatArchiveClock(epochS: number): string {
+  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatBehindLive(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  return hours > 0 ? `−${hours} h ${minutes} m` : `−${minutes} m`;
+}
 
 interface StreamPlayerProps {
   playerState: "idle" | "loading" | "playing" | "error";
@@ -40,6 +52,12 @@ interface StreamPlayerProps {
    * UI is shown regardless of `castRequest`.
    */
   chromecast?: UseChromecastResult;
+  /** Active catch-up session; enables the archive badge, seek bar, GO LIVE. */
+  archiveSession?: ArchiveSession | null;
+  /** Needed to poll the playback position for the archive seek bar. */
+  videoElement?: HTMLVideoElement;
+  onSeekArchive?: (epochS: number) => void;
+  onGoLive?: () => void;
   onTogglePause: () => void;
   onStop: () => void;
   onSetVolume: (v: number) => void;
@@ -63,6 +81,10 @@ export function StreamPlayer({
   castRequest,
   compact = false,
   chromecast,
+  archiveSession,
+  videoElement,
+  onSeekArchive,
+  onGoLive,
   onTogglePause,
   onStop,
   onSetVolume,
@@ -74,10 +96,28 @@ export function StreamPlayer({
 }: StreamPlayerProps) {
   const [controlsVisible, setControlsVisible] = useState(true);
   const [castMenuPinned, setCastMenuPinned] = useState(false);
+  const [archivePositionS, setArchivePositionS] = useState(0);
+  const [archiveScrubEpochS, setArchiveScrubEpochS] = useState<number | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const showCastUi = !compact && !!castRequest && !!chromecast;
   const isCasting = isCastSessionActive(chromecast?.session ?? null);
+
+  useEffect(() => {
+    setArchivePositionS(0);
+    setArchiveScrubEpochS(null);
+    if (!archiveSession || !videoElement || playerState !== "playing") {
+      return;
+    }
+    const tick = () => setArchivePositionS(videoElement.currentTime);
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [archiveSession, videoElement, playerState]);
+
+  const archiveCurrentEpochS = archiveSession
+    ? archiveSession.startEpochS + archivePositionS
+    : null;
 
   const scheduleHide = useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
@@ -135,6 +175,28 @@ export function StreamPlayer({
       onMouseEnter={showControls}
     >
       {/* Video element is appended here by ThumbnailPanel */}
+
+      {archiveSession && playerState !== "error" && archiveCurrentEpochS != null && (
+        <div className="absolute top-2 left-2 flex items-center gap-1.5 px-2 py-1 rounded-md bg-violet-600/85 text-white text-[11px] font-medium shadow-md backdrop-blur-sm">
+          <History className="w-3 h-3" />
+          <span className="truncate max-w-[200px]">
+            {archiveSession.title ?? formatArchiveClock(archiveCurrentEpochS)}
+            {archiveSession.title
+              ? ""
+              : ` · ${formatBehindLive(Date.now() / 1000 - archiveCurrentEpochS)}`}
+          </span>
+        </div>
+      )}
+
+      {archiveSession && playerState !== "error" && onGoLive && (
+        <button
+          type="button"
+          onClick={onGoLive}
+          className="absolute top-2 right-2 px-2 py-0.5 rounded border border-white/40 bg-black/45 text-[10px] font-semibold text-white hover:bg-black/70 transition-colors"
+        >
+          GO LIVE
+        </button>
+      )}
 
       {showCastUi && isCasting && chromecast?.session && (
         <div className="absolute top-2 left-2 flex items-center gap-1.5 px-2 py-1 rounded-md bg-blue-600/85 text-white text-[11px] font-medium shadow-md backdrop-blur-sm">
@@ -194,76 +256,105 @@ export function StreamPlayer({
       {/* Controls overlay */}
       {playerState === "playing" && (
         <div
-          className={`absolute inset-x-0 bottom-0 flex items-center gap-2 px-2.5 py-2 bg-gradient-to-t from-black/70 to-transparent transition-opacity duration-200 ${
+          className={`absolute inset-x-0 bottom-0 flex flex-col gap-1 px-2.5 py-2 bg-gradient-to-t from-black/70 to-transparent transition-opacity duration-200 ${
             controlsVisible ? "opacity-100" : "opacity-0 pointer-events-none"
           }`}
         >
-          <button
-            type="button"
-            onClick={onTogglePause}
-            className="p-1 text-white hover:text-white/80 transition-colors"
-            title={isPaused ? "Play" : "Pause"}
-          >
-            {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
-          </button>
-          <button
-            type="button"
-            onClick={onStop}
-            className="p-1 text-white hover:text-white/80 transition-colors"
-            title="Stop"
-          >
-            <Square className="w-3.5 h-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={onToggleMute}
-            className="p-1 text-white hover:text-white/80 transition-colors ml-auto"
-            title={muted ? "Unmute" : "Mute"}
-          >
-            {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
-          </button>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={muted ? 0 : volume}
-            onChange={(e) => {
-              onSetVolume(Number.parseFloat(e.target.value));
-              if (muted) onToggleMute();
-            }}
-            className="w-16 h-1 accent-white cursor-pointer"
-            title={`Volume: ${Math.round((muted ? 0 : volume) * 100)}%`}
-          />
-          {showCastUi && castRequest && chromecast && (
-            <CastMenu
-              chromecast={chromecast}
-              castRequest={castRequest}
-              mode="popover"
-              onCastStart={handleCastStart}
-              onOpenChange={setCastMenuPinned}
+          {archiveSession && onSeekArchive && archiveCurrentEpochS != null && (
+            <input
+              type="range"
+              min={archiveSession.windowStartEpochS}
+              max={archiveSession.windowEndEpochS}
+              step={10}
+              value={Math.round(archiveScrubEpochS ?? archiveCurrentEpochS)}
+              onChange={(e) => setArchiveScrubEpochS(Number.parseInt(e.target.value, 10))}
+              onPointerUp={() => {
+                if (archiveScrubEpochS != null) {
+                  onSeekArchive(archiveScrubEpochS);
+                  setArchiveScrubEpochS(null);
+                }
+              }}
+              onKeyUp={(e) => {
+                if (
+                  (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
+                  archiveScrubEpochS != null
+                ) {
+                  onSeekArchive(archiveScrubEpochS);
+                  setArchiveScrubEpochS(null);
+                }
+              }}
+              className="w-full h-1 accent-violet-400 cursor-pointer"
+              title={formatArchiveClock(archiveScrubEpochS ?? archiveCurrentEpochS)}
             />
           )}
-          {onPip && (
+          <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={onPip}
-              className="p-1 text-white hover:text-white/80 transition-colors ml-1"
-              title="Picture-in-Picture"
+              onClick={onTogglePause}
+              className="p-1 text-white hover:text-white/80 transition-colors"
+              title={isPaused ? "Play" : "Pause"}
             >
-              <PictureInPicture2 className="w-4 h-4" />
+              {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
             </button>
-          )}
-          {onFullscreen && (
             <button
               type="button"
-              onClick={onFullscreen}
-              className="p-1 text-white hover:text-white/80 transition-colors ml-1"
-              title="Fullscreen"
+              onClick={onStop}
+              className="p-1 text-white hover:text-white/80 transition-colors"
+              title="Stop"
             >
-              <Maximize className="w-4 h-4" />
+              <Square className="w-3.5 h-3.5" />
             </button>
-          )}
+            <button
+              type="button"
+              onClick={onToggleMute}
+              className="p-1 text-white hover:text-white/80 transition-colors ml-auto"
+              title={muted ? "Unmute" : "Mute"}
+            >
+              {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={muted ? 0 : volume}
+              onChange={(e) => {
+                onSetVolume(Number.parseFloat(e.target.value));
+                if (muted) onToggleMute();
+              }}
+              className="w-16 h-1 accent-white cursor-pointer"
+              title={`Volume: ${Math.round((muted ? 0 : volume) * 100)}%`}
+            />
+            {showCastUi && castRequest && chromecast && (
+              <CastMenu
+                chromecast={chromecast}
+                castRequest={castRequest}
+                mode="popover"
+                onCastStart={handleCastStart}
+                onOpenChange={setCastMenuPinned}
+              />
+            )}
+            {onPip && (
+              <button
+                type="button"
+                onClick={onPip}
+                className="p-1 text-white hover:text-white/80 transition-colors ml-1"
+                title="Picture-in-Picture"
+              >
+                <PictureInPicture2 className="w-4 h-4" />
+              </button>
+            )}
+            {onFullscreen && (
+              <button
+                type="button"
+                onClick={onFullscreen}
+                className="p-1 text-white hover:text-white/80 transition-colors ml-1"
+                title="Fullscreen"
+              >
+                <Maximize className="w-4 h-4" />
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -282,7 +282,16 @@ export function StreamPlayer({
               }}
               onKeyUp={(e) => {
                 if (
-                  (e.key === "ArrowLeft" || e.key === "ArrowRight") &&
+                  [
+                    "ArrowDown",
+                    "ArrowLeft",
+                    "ArrowRight",
+                    "ArrowUp",
+                    "End",
+                    "Home",
+                    "PageDown",
+                    "PageUp",
+                  ].includes(e.key) &&
                   archiveScrubEpochS != null
                 ) {
                   onSeekArchive(archiveScrubEpochS);

--- a/src/components/StreamPlayer.tsx
+++ b/src/components/StreamPlayer.tsx
@@ -16,7 +16,7 @@ import type { UseChromecastResult } from "../hooks/useChromecast";
 import { type ArchiveSession, MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../hooks/useStreamPlayer";
 import { isCastSessionActive } from "../lib/cast";
 import type { CastMediaRequest } from "../lib/types";
-import { CastMenu } from "./CastMenu";
+import { CastMenu, type CastStartHandler } from "./CastMenu";
 
 function formatArchiveClock(epochS: number): string {
   return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -60,7 +60,7 @@ interface StreamPlayerProps {
   onGoLive?: () => void;
   onTogglePause: () => void;
   onStop: () => void;
-  onCastStart?: () => void;
+  onCastStart?: CastStartHandler;
   onSetVolume: (v: number) => void;
   onToggleMute: () => void;
   onOpenExternal: () => void;
@@ -166,7 +166,11 @@ export function StreamPlayer({
     // ffmpeg every few seconds. Each reconnect introduces a DTS jump that
     // the Chromecast HLS player can't recover from cleanly, so the cast
     // session goes idle/error within seconds.
-    (onCastStart ?? onStop)();
+    if (onCastStart) {
+      return onCastStart();
+    }
+    onStop();
+    return undefined;
   }, [onCastStart, onStop]);
 
   return (

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -218,30 +218,32 @@ export function ThumbnailPanel({
   // return lives after them — bailing out first would change the hook count
   // between renders as soon as a channel is selected.
   const resolvedUrl = result?.stream_url?.trim() || null;
+  const activeArchiveSession =
+    archiveSession && archiveSession.baseResult.index === result?.index ? archiveSession : null;
 
   // Memoized so the prop identity is stable across renders — without this, any
   // useEffect downstream of `castRequest` would tear down and re-fire on every
   // parent re-render even when none of its inputs actually changed.
   const castRequest = useMemo(() => {
     if (!result) return null;
-    if (!archiveSession) return buildCastRequest(result);
+    if (!activeArchiveSession) return buildCastRequest(result);
     return buildCastRequest({
-      ...archiveSession.baseResult,
-      url: archiveSession.url,
+      ...activeArchiveSession.baseResult,
+      url: activeArchiveSession.url,
       content_type: "movie",
       stream_url: null,
     });
-  }, [archiveSession, result]);
+  }, [activeArchiveSession, result]);
 
   const externalPlaybackResult = useMemo(() => {
-    if (!archiveSession) return result;
+    if (!activeArchiveSession) return result;
     return {
-      ...archiveSession.baseResult,
-      url: archiveSession.url,
+      ...activeArchiveSession.baseResult,
+      url: activeArchiveSession.url,
       content_type: "movie" as const,
       stream_url: null,
     };
-  }, [archiveSession, result]);
+  }, [activeArchiveSession, result]);
 
   const handleCopyResolvedUrl = useCallback(async () => {
     if (!resolvedUrl) return;
@@ -327,7 +329,7 @@ export function ThumbnailPanel({
           castRequest={castRequest}
           compact
           chromecast={chromecast}
-          archiveSession={archiveSession}
+          archiveSession={activeArchiveSession}
           videoElement={videoElement}
           onSeekArchive={onSeekArchive}
           onGoLive={onGoLive}
@@ -531,7 +533,7 @@ export function ThumbnailPanel({
       {onPlayArchive && (
         <ArchiveCard
           result={result}
-          archiveSession={archiveSession ?? null}
+          archiveSession={activeArchiveSession}
           isCasting={isCastSessionActive(chromecast.session)}
           onPlayArchive={onPlayArchive}
         />
@@ -676,7 +678,7 @@ export function ThumbnailPanel({
                     }
                     castRequest={castRequest}
                     chromecast={chromecast}
-                    archiveSession={archiveSession}
+                    archiveSession={activeArchiveSession}
                     videoElement={videoElement}
                     onSeekArchive={onSeekArchive}
                     onGoLive={onGoLive}

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -504,6 +504,7 @@ export function ThumbnailPanel({
         <ArchiveCard
           result={result}
           archiveSession={archiveSession ?? null}
+          isCasting={isCastSessionActive(chromecast.session)}
           onPlayArchive={onPlayArchive}
         />
       )}

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -14,12 +14,14 @@ import {
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { UseChromecastResult } from "../hooks/useChromecast";
+import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
 import { buildCastRequest, isCastSessionActive } from "../lib/cast";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { formatAudioInfo, formatVideoInfo, statusLabel } from "../lib/format";
 import { isScanActive, type ScanState } from "../lib/scanState";
 import { getThumbnailDisplayState } from "../lib/thumbnailState";
 import type { ChannelResult } from "../lib/types";
+import { ArchiveCard } from "./ArchiveCard";
 import { CastMenu } from "./CastMenu";
 import { StatusBadge } from "./StatusBadge";
 import { StreamPlayer } from "./StreamPlayer";
@@ -59,6 +61,10 @@ interface ThumbnailPanelProps {
   onOpenExternal?: (result: ChannelResult) => void;
   onRetryPlay?: (result: ChannelResult) => void;
   onPip?: () => void;
+  archiveSession?: ArchiveSession | null;
+  onPlayArchive?: (result: ChannelResult, options: ArchivePlayOptions) => void;
+  onSeekArchive?: (epochS: number) => void;
+  onGoLive?: () => void;
 }
 
 export function ThumbnailPanel({
@@ -90,6 +96,10 @@ export function ThumbnailPanel({
   onOpenExternal,
   onRetryPlay,
   onPip,
+  archiveSession,
+  onPlayArchive,
+  onSeekArchive,
+  onGoLive,
 }: ThumbnailPanelProps) {
   const [lightboxRendered, setLightboxRendered] = useState(false);
   const [lightboxVisible, setLightboxVisible] = useState(false);
@@ -295,6 +305,10 @@ export function ThumbnailPanel({
           castRequest={castRequest}
           compact
           chromecast={chromecast}
+          archiveSession={archiveSession}
+          videoElement={videoElement}
+          onSeekArchive={onSeekArchive}
+          onGoLive={onGoLive}
         />
       ) : screenshotUrl ? (
         <button
@@ -486,6 +500,14 @@ export function ThumbnailPanel({
         )}
       </div>
 
+      {onPlayArchive && (
+        <ArchiveCard
+          result={result}
+          archiveSession={archiveSession ?? null}
+          onPlayArchive={onPlayArchive}
+        />
+      )}
+
       {result.status === "drm" && (
         <div className="p-2 rounded bg-cyan-500/10 border border-cyan-500/20">
           <p className="text-[12px] font-medium text-cyan-300">DRM Detection</p>
@@ -622,6 +644,10 @@ export function ThumbnailPanel({
                     }
                     castRequest={castRequest}
                     chromecast={chromecast}
+                    archiveSession={archiveSession}
+                    videoElement={videoElement}
+                    onSeekArchive={onSeekArchive}
+                    onGoLive={onGoLive}
                   />
                   <button
                     type="button"

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -15,7 +15,6 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from "react-dom";
 import type { UseChromecastResult } from "../hooks/useChromecast";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
-import { buildArchiveUrl } from "../lib/archive";
 import { buildCastRequest, isCastSessionActive } from "../lib/cast";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { formatAudioInfo, formatVideoInfo, statusLabel } from "../lib/format";
@@ -224,18 +223,22 @@ export function ThumbnailPanel({
   const castRequest = useMemo(() => {
     if (!result) return null;
     if (!archiveSession) return buildCastRequest(result);
-
-    const nowEpochS = Math.floor(Date.now() / 1000);
-    const url = buildArchiveUrl(archiveSession.baseResult, {
-      startEpochS: archiveSession.startEpochS,
-      durationS: Math.max(60, archiveSession.windowEndEpochS - archiveSession.startEpochS),
-      nowEpochS,
+    return buildCastRequest({
+      ...archiveSession.baseResult,
+      url: archiveSession.url,
+      content_type: "movie",
+      stream_url: null,
     });
-    return buildCastRequest(
-      url
-        ? { ...archiveSession.baseResult, url, content_type: "movie", stream_url: null }
-        : result,
-    );
+  }, [archiveSession, result]);
+
+  const externalPlaybackResult = useMemo(() => {
+    if (!archiveSession) return result;
+    return {
+      ...archiveSession.baseResult,
+      url: archiveSession.url,
+      content_type: "movie" as const,
+      stream_url: null,
+    };
   }, [archiveSession, result]);
 
   const handleCopyResolvedUrl = useCallback(async () => {
@@ -314,7 +317,7 @@ export function ThumbnailPanel({
           onStop={onStopPlayer}
           onSetVolume={onSetVolume}
           onToggleMute={onToggleMute}
-          onOpenExternal={() => onOpenExternal?.(result)}
+          onOpenExternal={() => externalPlaybackResult && onOpenExternal?.(externalPlaybackResult)}
           onRetry={() => onRetryPlay?.(result)}
           onFullscreen={() => onLightboxChange(true)}
           onPip={onPip}
@@ -649,7 +652,9 @@ export function ThumbnailPanel({
                     onStop={onStopPlayer}
                     onSetVolume={onSetVolume}
                     onToggleMute={onToggleMute}
-                    onOpenExternal={() => onOpenExternal?.(result)}
+                    onOpenExternal={() =>
+                      externalPlaybackResult && onOpenExternal?.(externalPlaybackResult)
+                    }
                     onRetry={() => onRetryPlay?.(result)}
                     onPip={
                       onPip

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -56,6 +56,7 @@ interface ThumbnailPanelProps {
   videoElement?: HTMLVideoElement;
   onTogglePause?: () => void;
   onStopPlayer?: () => void;
+  onCastStart?: () => void;
   onSetVolume?: (v: number) => void;
   onToggleMute?: () => void;
   onOpenExternal?: (result: ChannelResult) => void;
@@ -91,6 +92,7 @@ export function ThumbnailPanel({
   videoElement,
   onTogglePause,
   onStopPlayer,
+  onCastStart,
   onSetVolume,
   onToggleMute,
   onOpenExternal,
@@ -317,6 +319,7 @@ export function ThumbnailPanel({
           onStop={onStopPlayer}
           onSetVolume={onSetVolume}
           onToggleMute={onToggleMute}
+          onCastStart={onCastStart}
           onOpenExternal={() => externalPlaybackResult && onOpenExternal?.(externalPlaybackResult)}
           onRetry={() => onRetryPlay?.(result)}
           onFullscreen={() => onLightboxChange(true)}
@@ -477,7 +480,7 @@ export function ThumbnailPanel({
             chromecast={chromecast}
             castRequest={castRequest}
             mode="inline"
-            onCastStart={() => onStopPlayer?.()}
+            onCastStart={onCastStart ?? onStopPlayer}
           />
         );
       })()}
@@ -652,6 +655,7 @@ export function ThumbnailPanel({
                     onStop={onStopPlayer}
                     onSetVolume={onSetVolume}
                     onToggleMute={onToggleMute}
+                    onCastStart={onCastStart}
                     onOpenExternal={() =>
                       externalPlaybackResult && onOpenExternal?.(externalPlaybackResult)
                     }

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from "react-dom";
 import type { UseChromecastResult } from "../hooks/useChromecast";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
+import { buildArchiveUrl } from "../lib/archive";
 import { buildCastRequest, isCastSessionActive } from "../lib/cast";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { formatAudioInfo, formatVideoInfo, statusLabel } from "../lib/format";
@@ -220,7 +221,22 @@ export function ThumbnailPanel({
   // Memoized so the prop identity is stable across renders — without this, any
   // useEffect downstream of `castRequest` would tear down and re-fire on every
   // parent re-render even when none of its inputs actually changed.
-  const castRequest = useMemo(() => (result ? buildCastRequest(result) : null), [result]);
+  const castRequest = useMemo(() => {
+    if (!result) return null;
+    if (!archiveSession) return buildCastRequest(result);
+
+    const nowEpochS = Math.floor(Date.now() / 1000);
+    const url = buildArchiveUrl(archiveSession.baseResult, {
+      startEpochS: archiveSession.startEpochS,
+      durationS: Math.max(60, archiveSession.windowEndEpochS - archiveSession.startEpochS),
+      nowEpochS,
+    });
+    return buildCastRequest(
+      url
+        ? { ...archiveSession.baseResult, url, content_type: "movie", stream_url: null }
+        : result,
+    );
+  }, [archiveSession, result]);
 
   const handleCopyResolvedUrl = useCallback(async () => {
     if (!resolvedUrl) return;

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -436,7 +436,7 @@ export function ThumbnailPanel({
           {onOpenExternal && (
             <button
               type="button"
-              onClick={() => onOpenExternal(result)}
+              onClick={() => externalPlaybackResult && onOpenExternal(externalPlaybackResult)}
               className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium rounded-md bg-btn hover:bg-btn-hover text-text-primary border border-border-app shadow-sm transition-colors"
               title="Open in external player"
             >

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -22,7 +22,7 @@ import { isScanActive, type ScanState } from "../lib/scanState";
 import { getThumbnailDisplayState } from "../lib/thumbnailState";
 import type { ChannelResult } from "../lib/types";
 import { ArchiveCard } from "./ArchiveCard";
-import { CastMenu } from "./CastMenu";
+import { CastMenu, type CastStartHandler } from "./CastMenu";
 import { StatusBadge } from "./StatusBadge";
 import { StreamPlayer } from "./StreamPlayer";
 
@@ -56,7 +56,7 @@ interface ThumbnailPanelProps {
   videoElement?: HTMLVideoElement;
   onTogglePause?: () => void;
   onStopPlayer?: () => void;
-  onCastStart?: () => void;
+  onCastStart?: CastStartHandler;
   onSetVolume?: (v: number) => void;
   onToggleMute?: () => void;
   onOpenExternal?: (result: ChannelResult) => void;
@@ -480,7 +480,13 @@ export function ThumbnailPanel({
             chromecast={chromecast}
             castRequest={castRequest}
             mode="inline"
-            onCastStart={onCastStart ?? onStopPlayer}
+            onCastStart={
+              onCastStart ??
+              (() => {
+                onStopPlayer?.();
+                return undefined;
+              })
+            }
           />
         );
       })()}

--- a/src/hooks/useChromecast.ts
+++ b/src/hooks/useChromecast.ts
@@ -41,7 +41,14 @@ export function useChromecast(): UseChromecastResult {
     } catch (err) {
       if (!cancelledRef.current) {
         setError(String(err));
-        setSession(null);
+        // A same-device redirect may fail after the backend has restored the
+        // previous cast. Reconcile instead of assuming the receiver stopped.
+        try {
+          const current = await getCastStatus();
+          if (!cancelledRef.current) setSession(current);
+        } catch {
+          // Keep the last known session when status cannot be refreshed.
+        }
       }
       throw err;
     }

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -1,5 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { cancelArchiveProbes } from "../lib/archiveProbe";
 import { errorToString, formatPlaylistOpenError, formatSourceReloadError } from "../lib/errors";
 import { logger } from "../lib/logger";
 import { parseXtreamRecent, serializeXtreamRecent } from "../lib/recentPlaylists";
@@ -203,6 +204,10 @@ export function usePlaylistSources({
       }
       logger.info(`[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`);
 
+      await cancelArchiveProbes();
+      if (!shouldApply()) {
+        return false;
+      }
       await cancelEpgLoad().catch(() => {});
       if (!shouldApply()) {
         return false;

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -220,6 +220,7 @@ export function usePlaylistSources({
 
       state.setSelectedChannel(null);
       state.setSelectedChannelIndices([]);
+      state.clearArchiveProbes();
       state.setPendingPlaybackChannel(null);
 
       return true;
@@ -401,6 +402,7 @@ export function usePlaylistSources({
           // Keep app interaction predictable after a failed fresh open attempt.
           getStore().setSelectedChannel(null);
           getStore().setSelectedChannelIndices([]);
+          getStore().clearArchiveProbes();
           getStore().setPendingPlaybackChannel(null);
           getStore().setShowHistory(false);
           void refreshRecentPlaylists();

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -18,6 +18,7 @@ import {
 } from "../lib/sourceFilter";
 import {
   addRecentPlaylist,
+  cancelEpgLoad,
   clearRecentPlaylists,
   deleteSavedPlaylist,
   getRecentPlaylists,
@@ -203,6 +204,7 @@ export function usePlaylistSources({
       logger.info(`[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`);
 
       const state = getStore();
+      await cancelEpgLoad().catch(() => {});
       state.setPlaylist(preview);
       state.setCachedSourcePreview(cachedPreview);
       state.setCurrentSourceDescriptor(descriptor);

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -203,8 +203,11 @@ export function usePlaylistSources({
       }
       logger.info(`[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`);
 
-      const state = getStore();
       await cancelEpgLoad().catch(() => {});
+      if (!shouldApply()) {
+        return false;
+      }
+      const state = getStore();
       state.setPlaylist(preview);
       state.setCachedSourcePreview(cachedPreview);
       state.setCurrentSourceDescriptor(descriptor);

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -131,6 +131,7 @@ export interface UsePlaylistSourcesParams {
     preserveExistingResults?: boolean,
     shouldApply?: () => boolean,
   ) => Promise<boolean>;
+  invalidatePendingArchivePlayback: () => void;
 }
 
 /** Playlist source management: opening file/URL/Xtream/Stalker sources,
@@ -138,6 +139,7 @@ export interface UsePlaylistSourcesParams {
 export function usePlaylistSources({
   initFromPlaylist,
   syncFromPlaylist,
+  invalidatePendingArchivePlayback,
 }: UsePlaylistSourcesParams) {
   const channelSearch = useAppStore((s) => s.channelSearch);
   const settingsHydrated = useAppStore((s) => s.settingsHydrated);
@@ -196,6 +198,7 @@ export function usePlaylistSources({
       appliedSourceFilter: string,
       shouldApply: () => boolean,
     ): Promise<boolean> => {
+      invalidatePendingArchivePlayback();
       await cancelArchiveProbes();
       if (!shouldApply()) {
         return false;
@@ -236,7 +239,7 @@ export function usePlaylistSources({
 
       return true;
     },
-    [initFromPlaylist],
+    [initFromPlaylist, invalidatePendingArchivePlayback],
   );
 
   const loadFullSourcePreview = useCallback(
@@ -410,6 +413,7 @@ export function usePlaylistSources({
         getStore().setPlaylistOpenError(message);
 
         if (mode === "freshOpen") {
+          invalidatePendingArchivePlayback();
           await cancelArchiveProbes();
           if (!isCurrentLoad()) {
             return supersededResult();
@@ -435,6 +439,7 @@ export function usePlaylistSources({
       buildVisiblePreview,
       channelSearch,
       commitLoadedPlaylist,
+      invalidatePendingArchivePlayback,
       loadFullSourcePreview,
       refreshRecentPlaylists,
     ],

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -458,42 +458,53 @@ export function usePlaylistSources({
     }
     previousHideVodContentRef.current = hideVodContent;
 
-    const state = getStore();
-    if (!state.cachedSourcePreview) {
+    const initialState = getStore();
+    const cachedSourcePreview = initialState.cachedSourcePreview;
+    const playlist = initialState.playlist;
+    if (!cachedSourcePreview) {
       return;
     }
 
-    const nextPreview = buildVisiblePreview(
-      state.cachedSourcePreview,
-      state.lastAppliedSourceFilter,
-    );
-    const visibleIndices = new Set(nextPreview.channels.map((channel) => channel.index));
-    const selectedIndex = state.selectedChannel?.index ?? null;
-    const pendingPlaybackIndex = state.pendingPlaybackChannel?.index ?? null;
-    const nextSelectedIndices = state.selectedChannelIndices.filter((index) =>
-      visibleIndices.has(index),
-    );
-
-    state.setPlaylist(nextPreview);
-    state.setGroupFilter(resolvePreservedGroupFilter(state.groupFilter, nextPreview.groups));
-    state.setSelectedChannelIndices(nextSelectedIndices);
-
-    if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
-      state.setSelectedChannel(null);
-    }
-    if (pendingPlaybackIndex == null || !visibleIndices.has(pendingPlaybackIndex)) {
-      state.setPendingPlaybackChannel(null);
-    }
-
-    void syncFromPlaylist(nextPreview.channels, true).then(() => {
-      if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
+    void cancelArchiveProbes().then(() => {
+      const state = getStore();
+      if (
+        previousHideVodContentRef.current !== hideVodContent ||
+        state.cachedSourcePreview !== cachedSourcePreview ||
+        state.playlist !== playlist
+      ) {
         return;
       }
 
-      const refreshed = selectResultByIndex(getStore(), selectedIndex);
-      if (refreshed) {
-        getStore().setSelectedChannel(refreshed);
+      const nextPreview = buildVisiblePreview(cachedSourcePreview, state.lastAppliedSourceFilter);
+      const visibleIndices = new Set(nextPreview.channels.map((channel) => channel.index));
+      const selectedIndex = state.selectedChannel?.index ?? null;
+      const pendingPlaybackIndex = state.pendingPlaybackChannel?.index ?? null;
+      const nextSelectedIndices = state.selectedChannelIndices.filter((index) =>
+        visibleIndices.has(index),
+      );
+
+      state.clearArchiveProbes();
+      state.setPlaylist(nextPreview);
+      state.setGroupFilter(resolvePreservedGroupFilter(state.groupFilter, nextPreview.groups));
+      state.setSelectedChannelIndices(nextSelectedIndices);
+
+      if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
+        state.setSelectedChannel(null);
       }
+      if (pendingPlaybackIndex == null || !visibleIndices.has(pendingPlaybackIndex)) {
+        state.setPendingPlaybackChannel(null);
+      }
+
+      void syncFromPlaylist(nextPreview.channels, true).then(() => {
+        if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
+          return;
+        }
+
+        const refreshed = selectResultByIndex(getStore(), selectedIndex);
+        if (refreshed) {
+          getStore().setSelectedChannel(refreshed);
+        }
+      });
     });
   }, [buildVisiblePreview, hideVodContent, settingsHydrated, syncFromPlaylist]);
 

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -196,6 +196,11 @@ export function usePlaylistSources({
       appliedSourceFilter: string,
       shouldApply: () => boolean,
     ): Promise<boolean> => {
+      await cancelArchiveProbes();
+      if (!shouldApply()) {
+        return false;
+      }
+
       const initStartedAt = performance.now();
       logger.info(`[App] Preparing scan cache for ${preview.channels.length} visible channels`);
       const initialized = await initFromPlaylist(preview.channels, shouldApply);
@@ -204,10 +209,6 @@ export function usePlaylistSources({
       }
       logger.info(`[App] Scan cache ready in ${(performance.now() - initStartedAt).toFixed(1)}ms`);
 
-      await cancelArchiveProbes();
-      if (!shouldApply()) {
-        return false;
-      }
       await cancelEpgLoad().catch(() => {});
       if (!shouldApply()) {
         return false;
@@ -409,6 +410,10 @@ export function usePlaylistSources({
         getStore().setPlaylistOpenError(message);
 
         if (mode === "freshOpen") {
+          await cancelArchiveProbes();
+          if (!isCurrentLoad()) {
+            return supersededResult();
+          }
           // Keep app interaction predictable after a failed fresh open attempt.
           getStore().setSelectedChannel(null);
           getStore().setSelectedChannelIndices([]);

--- a/src/hooks/usePlaylistSources.ts
+++ b/src/hooks/usePlaylistSources.ts
@@ -495,8 +495,22 @@ export function usePlaylistSources({
         state.setPendingPlaybackChannel(null);
       }
 
-      void syncFromPlaylist(nextPreview.channels, true).then(() => {
-        if (selectedIndex == null || !visibleIndices.has(selectedIndex)) {
+      const shouldApply = () => {
+        const latest = getStore();
+        return (
+          previousHideVodContentRef.current === hideVodContent &&
+          latest.cachedSourcePreview === cachedSourcePreview &&
+          latest.playlist === nextPreview
+        );
+      };
+
+      void syncFromPlaylist(nextPreview.channels, true, shouldApply).then((synced) => {
+        if (
+          !synced ||
+          !shouldApply() ||
+          selectedIndex == null ||
+          !visibleIndices.has(selectedIndex)
+        ) {
           return;
         }
 

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -66,6 +66,7 @@ export interface UseStreamPlayerReturn {
   streamMetadata: StreamMetadata | null;
   archiveSession: ArchiveSession | null;
   play: (result: ChannelResult) => void;
+  retry: (result: ChannelResult) => void;
   playArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   seekArchive: (toEpochS: number) => void;
   goLive: () => void;
@@ -417,7 +418,6 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       if (notifyBackend && !archiveSessionRef.current) {
         onPlaybackFailedRef.current?.(result);
       }
-      setArchiveSession(null);
     },
     [cleanup, clearRecoveryTimer, resetRecoveryUi],
   );
@@ -977,6 +977,20 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     [beginPlayback],
   );
 
+  const retry = useCallback(
+    (result: ChannelResult) => {
+      const session = archiveSessionRef.current;
+      const currentChannel = currentChannelRef.current;
+      if (session && currentChannel && session.baseResult.index === result.index) {
+        beginPlayback(currentChannel);
+        return;
+      }
+      setArchiveSession(null);
+      beginPlayback(result);
+    },
+    [beginPlayback],
+  );
+
   const playArchive = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
       const now = Math.floor(Date.now() / 1000);
@@ -1095,6 +1109,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     streamMetadata,
     archiveSession,
     play,
+    retry,
     playArchive,
     seekArchive,
     goLive,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -67,12 +67,13 @@ export interface UseStreamPlayerReturn {
   videoElement: HTMLVideoElement;
   streamMetadata: StreamMetadata | null;
   archiveSession: ArchiveSession | null;
+  setArchiveSession: (session: ArchiveSession | null) => void;
   play: (result: ChannelResult) => void;
   retry: (result: ChannelResult) => void;
   playArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   seekArchive: (toEpochS: number) => void;
   goLive: () => void;
-  stop: () => void;
+  stop: (options?: { preserveArchiveSession?: boolean }) => void;
   togglePause: () => void;
   setVolume: (v: number) => void;
   toggleMute: () => void;
@@ -1059,23 +1060,28 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     beginPlayback(session.baseResult);
   }, [beginPlayback]);
 
-  const stop = useCallback(() => {
-    playbackSessionIdRef.current += 1;
-    isPausedRef.current = false;
-    clearRecoveryTimer();
-    currentChannelRef.current = null;
-    recoveryTimestampsRef.current = [];
-    hasStartedPlayingRef.current = false;
-    playbackStartedAtRef.current = null;
-    startupLatencyMsRef.current = null;
-    resetRecoveryUi();
-    cleanup();
-    setPlayerState("idle");
-    setErrorMessage(null);
-    setIsPaused(false);
-    setActiveChannelIndex(null);
-    setArchiveSession(null);
-  }, [cleanup, clearRecoveryTimer, resetRecoveryUi]);
+  const stop = useCallback(
+    (options?: { preserveArchiveSession?: boolean }) => {
+      playbackSessionIdRef.current += 1;
+      isPausedRef.current = false;
+      clearRecoveryTimer();
+      currentChannelRef.current = null;
+      recoveryTimestampsRef.current = [];
+      hasStartedPlayingRef.current = false;
+      playbackStartedAtRef.current = null;
+      startupLatencyMsRef.current = null;
+      resetRecoveryUi();
+      cleanup();
+      setPlayerState("idle");
+      setErrorMessage(null);
+      setIsPaused(false);
+      setActiveChannelIndex(null);
+      if (!options?.preserveArchiveSession) {
+        setArchiveSession(null);
+      }
+    },
+    [cleanup, clearRecoveryTimer, resetRecoveryUi],
+  );
 
   const togglePause = useCallback(() => {
     if (videoElement.paused) {
@@ -1111,6 +1117,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     videoElement,
     streamMetadata,
     archiveSession,
+    setArchiveSession,
     play,
     retry,
     playArchive,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -81,6 +81,7 @@ export interface UseStreamPlayerReturn {
 
 interface UseStreamPlayerOptions {
   onPlaybackFailed?: (result: ChannelResult) => void;
+  onPlaybackFinished?: (result: ChannelResult) => void;
 }
 
 function readStoredVolume(): number {
@@ -135,6 +136,8 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
   const onPlaybackFailedRef = useRef(options?.onPlaybackFailed);
   onPlaybackFailedRef.current = options?.onPlaybackFailed;
+  const onPlaybackFinishedRef = useRef(options?.onPlaybackFinished);
+  onPlaybackFinishedRef.current = options?.onPlaybackFinished;
 
   const [playerState, setPlayerState] = useState<PlayerState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -466,6 +469,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
       if (decision.kind === "finish") {
         logger.info("[Player] Playback finished for", result.name);
+        onPlaybackFinishedRef.current?.(result);
         stop();
         return;
       }

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { buildArchiveUrl } from "../lib/archive";
 import { normalizeCodecName, resolveResolutionLabel } from "../lib/format";
 import { logger } from "../lib/logger";
 import {
@@ -31,6 +32,26 @@ import { canUseBlobWorkers } from "../lib/workerSupport";
 // alongside the hook. The implementation lives in lib/playback.
 export { MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../lib/playback";
 
+/** Active catch-up playback: which channel, where in its archive, and the
+ * seekable window. Present only while playing an archive URL. */
+export interface ArchiveSession {
+  baseResult: ChannelResult;
+  /** Where the current archive URL starts, epoch seconds. */
+  startEpochS: number;
+  /** Earliest seekable point (programme start or the picked time). */
+  windowStartEpochS: number;
+  /** Latest seekable point (programme end, clamped to launch time). */
+  windowEndEpochS: number;
+  title: string | null;
+}
+
+export interface ArchivePlayOptions {
+  startEpochS: number;
+  /** Programme end; defaults to now (watch from start up to live edge). */
+  endEpochS?: number;
+  title?: string;
+}
+
 export interface UseStreamPlayerReturn {
   playerState: PlayerState;
   errorMessage: string | null;
@@ -43,7 +64,11 @@ export interface UseStreamPlayerReturn {
   activeChannelIndex: number | null;
   videoElement: HTMLVideoElement;
   streamMetadata: StreamMetadata | null;
+  archiveSession: ArchiveSession | null;
   play: (result: ChannelResult) => void;
+  playArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
+  seekArchive: (toEpochS: number) => void;
+  goLive: () => void;
   stop: () => void;
   togglePause: () => void;
   setVolume: (v: number) => void;
@@ -117,6 +142,9 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
   const [activeChannelIndex, setActiveChannelIndex] = useState<number | null>(null);
   const [streamMetadata, setStreamMetadata] = useState<StreamMetadata | null>(null);
+  const [archiveSession, setArchiveSession] = useState<ArchiveSession | null>(null);
+  const archiveSessionRef = useRef<ArchiveSession | null>(null);
+  archiveSessionRef.current = archiveSession;
 
   const lastErrorRef = useRef<string | null>(null);
   const playerStateRef = useRef<PlayerState>("idle");
@@ -384,9 +412,12 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       setErrorMessage(reason);
       setIsPaused(false);
       setActiveChannelIndex(null);
-      if (notifyBackend) {
+      // A failed archive URL says nothing about the live channel's health, so
+      // never report it to the backend as a channel failure.
+      if (notifyBackend && !archiveSessionRef.current) {
         onPlaybackFailedRef.current?.(result);
       }
+      setArchiveSession(null);
     },
     [cleanup, clearRecoveryTimer, resetRecoveryUi],
   );
@@ -921,7 +952,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     };
   }, [cleanup, clearRecoveryTimer]);
 
-  const play = useCallback(
+  const beginPlayback = useCallback(
     (result: ChannelResult) => {
       playbackSessionIdRef.current += 1;
       isPausedRef.current = false;
@@ -938,6 +969,79 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     [clearRecoveryTimer, resetRecoveryUi, startPlaybackAttempt],
   );
 
+  const play = useCallback(
+    (result: ChannelResult) => {
+      setArchiveSession(null);
+      beginPlayback(result);
+    },
+    [beginPlayback],
+  );
+
+  const playArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      const now = Math.floor(Date.now() / 1000);
+      const windowEnd = Math.min(options.endEpochS ?? now, now);
+      const start = Math.min(Math.floor(options.startEpochS), windowEnd - 1);
+      const durationS = Math.max(60, windowEnd - start);
+      const url = buildArchiveUrl(result, { startEpochS: start, durationS, nowEpochS: now });
+      if (!url) {
+        return;
+      }
+      setArchiveSession({
+        baseResult: result,
+        startEpochS: start,
+        windowStartEpochS: start,
+        windowEndEpochS: windowEnd,
+        title: options.title ?? null,
+      });
+      // The archive URL rides through the normal route/recovery pipeline as a
+      // synthetic channel; it is not live, so MPEG-TS routes get a VOD hint.
+      beginPlayback({ ...result, url, content_type: "movie", stream_url: null });
+    },
+    [beginPlayback],
+  );
+
+  const seekArchive = useCallback(
+    (toEpochS: number) => {
+      const session = archiveSessionRef.current;
+      if (!session) {
+        return;
+      }
+      const now = Math.floor(Date.now() / 1000);
+      const latestSeekable = Math.min(session.windowEndEpochS, now) - 10;
+      const clamped = Math.max(
+        session.windowStartEpochS,
+        Math.min(Math.floor(toEpochS), latestSeekable),
+      );
+      const durationS = Math.max(60, session.windowEndEpochS - clamped);
+      const url = buildArchiveUrl(session.baseResult, {
+        startEpochS: clamped,
+        durationS,
+        nowEpochS: now,
+      });
+      if (!url) {
+        return;
+      }
+      setArchiveSession({ ...session, startEpochS: clamped });
+      beginPlayback({
+        ...session.baseResult,
+        url,
+        content_type: "movie",
+        stream_url: null,
+      });
+    },
+    [beginPlayback],
+  );
+
+  const goLive = useCallback(() => {
+    const session = archiveSessionRef.current;
+    if (!session) {
+      return;
+    }
+    setArchiveSession(null);
+    beginPlayback(session.baseResult);
+  }, [beginPlayback]);
+
   const stop = useCallback(() => {
     playbackSessionIdRef.current += 1;
     isPausedRef.current = false;
@@ -953,6 +1057,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     setErrorMessage(null);
     setIsPaused(false);
     setActiveChannelIndex(null);
+    setArchiveSession(null);
   }, [cleanup, clearRecoveryTimer, resetRecoveryUi]);
 
   const togglePause = useCallback(() => {
@@ -988,7 +1093,11 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     activeChannelIndex,
     videoElement,
     streamMetadata,
+    archiveSession,
     play,
+    playArchive,
+    seekArchive,
+    goLive,
     stop,
     togglePause,
     setVolume,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -148,8 +148,12 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
   const [activeChannelIndex, setActiveChannelIndex] = useState<number | null>(null);
   const [streamMetadata, setStreamMetadata] = useState<StreamMetadata | null>(null);
-  const [archiveSession, setArchiveSession] = useState<ArchiveSession | null>(null);
+  const [archiveSession, setArchiveSessionState] = useState<ArchiveSession | null>(null);
   const archiveSessionRef = useRef<ArchiveSession | null>(null);
+  const setArchiveSession = useCallback((session: ArchiveSession | null) => {
+    archiveSessionRef.current = session;
+    setArchiveSessionState(session);
+  }, []);
 
   const lastErrorRef = useRef<string | null>(null);
   const playerStateRef = useRef<PlayerState>("idle");
@@ -173,10 +177,6 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     onPlaybackFailedRef.current = options?.onPlaybackFailed;
     onPlaybackFinishedRef.current = options?.onPlaybackFinished;
   }, [options?.onPlaybackFailed, options?.onPlaybackFinished]);
-
-  useEffect(() => {
-    archiveSessionRef.current = archiveSession;
-  }, [archiveSession]);
 
   useEffect(() => {
     playerStateRef.current = playerState;

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -68,6 +68,7 @@ export interface UseStreamPlayerReturn {
   streamMetadata: StreamMetadata | null;
   archiveSession: ArchiveSession | null;
   setArchiveSession: (session: ArchiveSession | null) => void;
+  resumeArchive: (session: ArchiveSession) => void;
   play: (result: ChannelResult) => void;
   retry: (result: ChannelResult) => void;
   playArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
@@ -135,9 +136,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   const videoElement = videoElRef.current;
 
   const onPlaybackFailedRef = useRef(options?.onPlaybackFailed);
-  onPlaybackFailedRef.current = options?.onPlaybackFailed;
   const onPlaybackFinishedRef = useRef(options?.onPlaybackFinished);
-  onPlaybackFinishedRef.current = options?.onPlaybackFinished;
 
   const [playerState, setPlayerState] = useState<PlayerState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -151,7 +150,6 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   const [streamMetadata, setStreamMetadata] = useState<StreamMetadata | null>(null);
   const [archiveSession, setArchiveSession] = useState<ArchiveSession | null>(null);
   const archiveSessionRef = useRef<ArchiveSession | null>(null);
-  archiveSessionRef.current = archiveSession;
 
   const lastErrorRef = useRef<string | null>(null);
   const playerStateRef = useRef<PlayerState>("idle");
@@ -170,6 +168,15 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
   const startupLatencyMsRef = useRef<number | null>(null);
   const playbackSessionIdRef = useRef(0);
   const startPlaybackAttemptRef = useRef<StartPlaybackAttempt | null>(null);
+
+  useEffect(() => {
+    onPlaybackFailedRef.current = options?.onPlaybackFailed;
+    onPlaybackFinishedRef.current = options?.onPlaybackFinished;
+  }, [options?.onPlaybackFailed, options?.onPlaybackFinished]);
+
+  useEffect(() => {
+    archiveSessionRef.current = archiveSession;
+  }, [archiveSession]);
 
   useEffect(() => {
     playerStateRef.current = playerState;
@@ -1052,6 +1059,19 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     [beginPlayback],
   );
 
+  const resumeArchive = useCallback(
+    (session: ArchiveSession) => {
+      setArchiveSession(session);
+      beginPlayback({
+        ...session.baseResult,
+        url: session.url,
+        content_type: "movie",
+        stream_url: null,
+      });
+    },
+    [beginPlayback],
+  );
+
   const seekArchive = useCallback(
     (toEpochS: number) => {
       const session = archiveSessionRef.current;
@@ -1128,6 +1148,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     streamMetadata,
     archiveSession,
     setArchiveSession,
+    resumeArchive,
     play,
     retry,
     playArchive,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -36,6 +36,8 @@ export { MAX_PLAYBACK_RECOVERY_ATTEMPTS } from "../lib/playback";
  * seekable window. Present only while playing an archive URL. */
 export interface ArchiveSession {
   baseResult: ChannelResult;
+  /** Exact synthetic URL currently loaded by the player. */
+  url: string;
   /** Where the current archive URL starts, epoch seconds. */
   startEpochS: number;
   /** Earliest seekable point (programme start or the picked time). */
@@ -1003,6 +1005,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       }
       setArchiveSession({
         baseResult: result,
+        url,
         startEpochS: start,
         windowStartEpochS: start,
         windowEndEpochS: windowEnd,
@@ -1036,7 +1039,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       if (!url) {
         return;
       }
-      setArchiveSession({ ...session, startEpochS: clamped });
+      setArchiveSession({ ...session, url, startEpochS: clamped });
       beginPlayback({
         ...session.baseResult,
         url,

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -383,6 +383,29 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     videoElement.load();
   }, [clearLoadingTimer, cleanupRuntimeMonitor, cleanupMetadataListeners, videoElement]);
 
+  const stop = useCallback(
+    (options?: { preserveArchiveSession?: boolean }) => {
+      playbackSessionIdRef.current += 1;
+      isPausedRef.current = false;
+      clearRecoveryTimer();
+      currentChannelRef.current = null;
+      recoveryTimestampsRef.current = [];
+      hasStartedPlayingRef.current = false;
+      playbackStartedAtRef.current = null;
+      startupLatencyMsRef.current = null;
+      resetRecoveryUi();
+      cleanup();
+      setPlayerState("idle");
+      setErrorMessage(null);
+      setIsPaused(false);
+      setActiveChannelIndex(null);
+      if (!options?.preserveArchiveSession) {
+        setArchiveSession(null);
+      }
+    },
+    [cleanup, clearRecoveryTimer, resetRecoveryUi],
+  );
+
   const applyVolume = useCallback(() => {
     videoElement.volume = volume;
     videoElement.muted = muted;
@@ -441,6 +464,12 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         return;
       }
 
+      if (decision.kind === "finish") {
+        logger.info("[Player] Playback finished for", result.name);
+        stop();
+        return;
+      }
+
       if (decision.kind === "fail") {
         finalizePlaybackFailure(result, reason, true);
         return;
@@ -479,7 +508,7 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
         void startAttempt(result, sessionId, "recovery", decision.nextAttempt);
       }, PLAYBACK_RECOVERY_DELAY_MS);
     },
-    [cleanup, clearRecoveryTimer, finalizePlaybackFailure, showRecoveryUi],
+    [cleanup, clearRecoveryTimer, finalizePlaybackFailure, showRecoveryUi, stop],
   );
 
   const setupRuntimeMonitor = useCallback(
@@ -1059,29 +1088,6 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
     setArchiveSession(null);
     beginPlayback(session.baseResult);
   }, [beginPlayback]);
-
-  const stop = useCallback(
-    (options?: { preserveArchiveSession?: boolean }) => {
-      playbackSessionIdRef.current += 1;
-      isPausedRef.current = false;
-      clearRecoveryTimer();
-      currentChannelRef.current = null;
-      recoveryTimestampsRef.current = [];
-      hasStartedPlayingRef.current = false;
-      playbackStartedAtRef.current = null;
-      startupLatencyMsRef.current = null;
-      resetRecoveryUi();
-      cleanup();
-      setPlayerState("idle");
-      setErrorMessage(null);
-      setIsPaused(false);
-      setActiveChannelIndex(null);
-      if (!options?.preserveArchiveSession) {
-        setArchiveSession(null);
-      }
-    },
-    [cleanup, clearRecoveryTimer, resetRecoveryUi],
-  );
 
   const togglePause = useCallback(() => {
     if (videoElement.paused) {

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -33,3 +33,113 @@ export function archiveSortValue(result: ArchiveFields): number | null {
   if (!hasArchive(result)) return null;
   return result.catchup_days ?? 0;
 }
+
+// ---------------------------------------------------------------------------
+// Archive URL construction
+// ---------------------------------------------------------------------------
+
+export interface ArchiveWindow {
+  /** Where playback should start, unix epoch seconds. */
+  startEpochS: number;
+  /** Window length in seconds (a programme's runtime, or start→now). */
+  durationS: number;
+  /** Current time; offset-style templates need it. */
+  nowEpochS: number;
+}
+
+type ArchiveUrlFields = Pick<ChannelResult, "url" | "catchup" | "catchup_days" | "catchup_source">;
+
+/**
+ * Fill catch-up placeholder variables. Both `${var}` and `{var}` forms occur
+ * in the wild; supported names follow the common catchup-source conventions.
+ */
+export function substituteArchiveTemplate(template: string, window: ArchiveWindow): string {
+  const start = Math.floor(window.startEpochS);
+  const now = Math.floor(window.nowEpochS);
+  const duration = Math.max(0, Math.floor(window.durationS));
+  const values: Record<string, number> = {
+    start,
+    utc: start,
+    timestamp: start,
+    lutc: now,
+    now,
+    end: start + duration,
+    utcend: start + duration,
+    duration,
+    offset: Math.max(0, now - start),
+  };
+  return template.replace(
+    /\$?\{(start|utc|timestamp|lutc|now|end|utcend|duration|offset)\}/g,
+    (_match, name: string) => String(values[name]),
+  );
+}
+
+function appendQuery(url: string, query: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}${query}`;
+}
+
+/** "YYYY-MM-DD:HH-MM" in UTC, the start format Xtream timeshift URLs expect. */
+function formatXtreamStart(epochS: number): string {
+  const date = new Date(epochS * 1000);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}:${pad(
+    date.getUTCHours(),
+  )}-${pad(date.getUTCMinutes())}`;
+}
+
+/** `http(s)://host[/live]/user/pass/id[.ext]` — the Xtream live URL shape. */
+const XTREAM_LIVE_URL = /^(https?:\/\/[^/]+)(?:\/live)?\/([^/]+)\/([^/]+)\/(\d+)(?:\.\w+)?$/;
+
+function defaultArchiveUrl(url: string, window: ArchiveWindow): string {
+  return appendQuery(url, substituteArchiveTemplate("utc=${start}&lutc=${now}", window));
+}
+
+/**
+ * Build a playable archive URL for a catch-up channel, or null when the
+ * channel does not advertise catch-up. Falls back to the standard
+ * `utc`/`lutc` query form whenever a more specific scheme cannot apply.
+ */
+export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow): string | null {
+  if (!hasArchive(channel)) return null;
+
+  const source = channel.catchup_source?.trim();
+  if (source) {
+    const resolved = substituteArchiveTemplate(source, window);
+    if (/^https?:\/\//.test(resolved)) return resolved;
+    if (resolved.startsWith("?") || resolved.startsWith("&")) {
+      return appendQuery(channel.url, resolved.slice(1));
+    }
+    // Relative templates (catchup="append" and friends) attach to the URL.
+    return `${channel.url}${resolved}`;
+  }
+
+  switch (channel.catchup) {
+    case "xc": {
+      const match = channel.url.match(XTREAM_LIVE_URL);
+      if (!match) return defaultArchiveUrl(channel.url, window);
+      const [, base, user, pass, id] = match;
+      const durationMinutes = Math.max(1, Math.round(window.durationS / 60));
+      return `${base}/timeshift/${user}/${pass}/${durationMinutes}/${formatXtreamStart(
+        window.startEpochS,
+      )}/${id}.m3u8`;
+    }
+    case "flussonic": {
+      const start = Math.floor(window.startEpochS);
+      const duration = Math.max(1, Math.floor(window.durationS));
+      if (/\.m3u8(\?|$)/.test(channel.url)) {
+        return channel.url.replace(
+          /\/[^/?]+\.m3u8(\?|$)/,
+          `/archive-${start}-${duration}.m3u8$1`,
+        );
+      }
+      if (/\.ts(\?|$)/.test(channel.url)) {
+        return channel.url.replace(/\/[^/?]+\.ts(\?|$)/, `/timeshift_abs-${start}.ts$1`);
+      }
+      return defaultArchiveUrl(channel.url, window);
+    }
+    default:
+      // "default", "shift", "append"-without-source, and unknown types all
+      // use the standard utc/lutc query convention.
+      return defaultArchiveUrl(channel.url, window);
+  }
+}

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -94,7 +94,7 @@ function formatXtreamStart(epochS: number): string {
 
 /** `http(s)://host[/prefix][/live]/user/pass/id[.ext]` — Xtream live URL shape. */
 const XTREAM_LIVE_URL =
-  /^(https?:\/\/[^/]+)((?:\/[^/]+)*?)(?:\/live)?\/([^/]+)\/([^/]+)\/(\d+)(?:\.\w+)?$/;
+  /^(https?:\/\/[^/]+)((?:\/[^/]+)*?)(?:\/live)?\/([^/]+)\/([^/]+)\/(\d+)(?:\.\w+)?$/i;
 
 function defaultArchiveUrl(url: string, window: ArchiveWindow): string {
   return appendQuery(url, substituteArchiveTemplate("utc=${start}&lutc=${now}", window));
@@ -110,7 +110,7 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
 
   const source = channel.catchup_source?.trim();
   if (source) {
-    const resolved = substituteArchiveTemplate(source, window);
+    const resolved = substituteArchiveTemplate(source, window).replace(/&amp;/g, "&");
     if (/^https?:\/\//i.test(resolved)) return resolved;
     if (resolved.startsWith("?") || resolved.startsWith("&")) {
       return appendQuery(channel.url, resolved.slice(1));

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -135,11 +135,14 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
     case "flussonic": {
       const start = Math.floor(window.startEpochS);
       const duration = Math.max(1, Math.floor(window.durationS));
-      if (/\.m3u8(\?|$)/.test(channel.url)) {
-        return channel.url.replace(/\/[^/?]+\.m3u8(\?|$)/, `/archive-${start}-${duration}.m3u8$1`);
+      if (/\.m3u8([?#]|$)/.test(channel.url)) {
+        return channel.url.replace(
+          /\/[^/?#]+\.m3u8([?#]|$)/,
+          `/archive-${start}-${duration}.m3u8$1`,
+        );
       }
-      if (/\.ts(\?|$)/.test(channel.url)) {
-        return channel.url.replace(/\/[^/?]+\.ts(\?|$)/, `/timeshift_abs-${start}.ts$1`);
+      if (/\.ts([?#]|$)/.test(channel.url)) {
+        return channel.url.replace(/\/[^/?#]+\.ts([?#]|$)/, `/timeshift_abs-${start}.ts$1`);
       }
       return defaultArchiveUrl(channel.url, window);
     }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -117,9 +117,13 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
     }
     // Relative templates (catchup="append" and friends) attach to the URL.
     const fragmentStart = channel.url.indexOf("#");
-    return fragmentStart === -1
-      ? `${channel.url}${resolved}`
-      : `${channel.url.slice(0, fragmentStart)}${resolved}${channel.url.slice(fragmentStart)}`;
+    const withoutFragment =
+      fragmentStart === -1 ? channel.url : channel.url.slice(0, fragmentStart);
+    const fragment = fragmentStart === -1 ? "" : channel.url.slice(fragmentStart);
+    const queryStart = withoutFragment.indexOf("?");
+    const path = queryStart === -1 ? withoutFragment : withoutFragment.slice(0, queryStart);
+    const query = queryStart === -1 ? "" : withoutFragment.slice(queryStart);
+    return `${path}${resolved}${query}${fragment}`;
   }
 
   switch (channel.catchup) {

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -116,7 +116,10 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       return appendQuery(channel.url, resolved.slice(1));
     }
     // Relative templates (catchup="append" and friends) attach to the URL.
-    return `${channel.url}${resolved}`;
+    const fragmentStart = channel.url.indexOf("#");
+    return fragmentStart === -1
+      ? `${channel.url}${resolved}`
+      : `${channel.url.slice(0, fragmentStart)}${resolved}${channel.url.slice(fragmentStart)}`;
   }
 
   switch (channel.catchup) {

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -75,7 +75,10 @@ export function substituteArchiveTemplate(template: string, window: ArchiveWindo
 }
 
 function appendQuery(url: string, query: string): string {
-  return `${url}${url.includes("?") ? "&" : "?"}${query}`;
+  const fragmentStart = url.indexOf("#");
+  const requestUrl = fragmentStart === -1 ? url : url.slice(0, fragmentStart);
+  const fragment = fragmentStart === -1 ? "" : url.slice(fragmentStart);
+  return `${requestUrl}${requestUrl.includes("?") ? "&" : "?"}${query}${fragment}`;
 }
 
 /** "YYYY-MM-DD:HH-MM" in UTC, the start format Xtream timeshift URLs expect. */

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -145,7 +145,7 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
         );
       }
       if (/\.ts([?#]|$)/.test(channel.url)) {
-        return channel.url.replace(/\/[^/?#]+\.ts([?#]|$)/, `/timeshift_abs-${start}.ts$1`);
+        return channel.url.replace(/\/[^/?#]+\.ts([?#]|$)/, `/archive-${start}-${duration}.ts$1`);
       }
       return defaultArchiveUrl(channel.url, window);
     }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -6,6 +6,8 @@ import type { ChannelResult } from "./types";
 
 type ArchiveFields = Pick<ChannelResult, "catchup" | "catchup_days" | "catchup_source">;
 
+export const MAX_CATCHUP_DAYS = 31;
+
 export function hasArchive(result: ArchiveFields): boolean {
   return result.catchup != null || result.catchup_days != null;
 }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -159,3 +159,19 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       return defaultArchiveUrl(channel.url, window);
   }
 }
+
+/** How far back the sidebar picker starts: just under an hour ago. */
+export const ARCHIVE_PICKER_DEFAULT_BACK_S = 59 * 60 + 30;
+
+/**
+ * Default picker position: 59:30 before `now`, expressed as the day offset
+ * and local HH:MM the picker's controls use. A start in the future can never
+ * play, so the default always lands inside the archive.
+ */
+export function archivePickerDefault(now: Date = new Date()): { daysBack: number; time: string } {
+  const start = new Date(now.getTime() - ARCHIVE_PICKER_DEFAULT_BACK_S * 1000);
+  const dayOf = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const daysBack = Math.round((dayOf(now).getTime() - dayOf(start).getTime()) / 86_400_000);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return { daysBack, time: `${pad(start.getHours())}:${pad(start.getMinutes())}` };
+}

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -60,7 +60,7 @@ export function substituteArchiveTemplate(template: string, window: ArchiveWindo
   const values: Record<string, number> = {
     start,
     utc: start,
-    timestamp: start,
+    timestamp: now,
     lutc: now,
     now,
     end: start + duration,
@@ -90,8 +90,9 @@ function formatXtreamStart(epochS: number): string {
   )}-${pad(date.getUTCMinutes())}`;
 }
 
-/** `http(s)://host[/live]/user/pass/id[.ext]` — the Xtream live URL shape. */
-const XTREAM_LIVE_URL = /^(https?:\/\/[^/]+)(?:\/live)?\/([^/]+)\/([^/]+)\/(\d+)(?:\.\w+)?$/;
+/** `http(s)://host[/prefix][/live]/user/pass/id[.ext]` — Xtream live URL shape. */
+const XTREAM_LIVE_URL =
+  /^(https?:\/\/[^/]+)((?:\/[^/]+)*?)(?:\/live)?\/([^/]+)\/([^/]+)\/(\d+)(?:\.\w+)?$/;
 
 function defaultArchiveUrl(url: string, window: ArchiveWindow): string {
   return appendQuery(url, substituteArchiveTemplate("utc=${start}&lutc=${now}", window));
@@ -123,9 +124,9 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       const suffix = suffixStart === -1 ? "" : channel.url.slice(suffixStart);
       const match = streamUrl.match(XTREAM_LIVE_URL);
       if (!match) return defaultArchiveUrl(channel.url, window);
-      const [, base, user, pass, id] = match;
-      const durationMinutes = Math.max(1, Math.round(window.durationS / 60));
-      return `${base}/timeshift/${user}/${pass}/${durationMinutes}/${formatXtreamStart(
+      const [, base, prefix, user, pass, id] = match;
+      const durationMinutes = Math.max(1, Math.ceil(window.durationS / 60));
+      return `${base}${prefix}/timeshift/${user}/${pass}/${durationMinutes}/${formatXtreamStart(
         window.startEpochS,
       )}/${id}.m3u8${suffix}`;
     }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -111,7 +111,7 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
   const source = channel.catchup_source?.trim();
   if (source) {
     const resolved = substituteArchiveTemplate(source, window);
-    if (/^https?:\/\//.test(resolved)) return resolved;
+    if (/^https?:\/\//i.test(resolved)) return resolved;
     if (resolved.startsWith("?") || resolved.startsWith("&")) {
       return appendQuery(channel.url, resolved.slice(1));
     }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -115,22 +115,22 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
 
   switch (channel.catchup) {
     case "xc": {
-      const match = channel.url.match(XTREAM_LIVE_URL);
+      const suffixStart = channel.url.search(/[?#]/);
+      const streamUrl = suffixStart === -1 ? channel.url : channel.url.slice(0, suffixStart);
+      const suffix = suffixStart === -1 ? "" : channel.url.slice(suffixStart);
+      const match = streamUrl.match(XTREAM_LIVE_URL);
       if (!match) return defaultArchiveUrl(channel.url, window);
       const [, base, user, pass, id] = match;
       const durationMinutes = Math.max(1, Math.round(window.durationS / 60));
       return `${base}/timeshift/${user}/${pass}/${durationMinutes}/${formatXtreamStart(
         window.startEpochS,
-      )}/${id}.m3u8`;
+      )}/${id}.m3u8${suffix}`;
     }
     case "flussonic": {
       const start = Math.floor(window.startEpochS);
       const duration = Math.max(1, Math.floor(window.durationS));
       if (/\.m3u8(\?|$)/.test(channel.url)) {
-        return channel.url.replace(
-          /\/[^/?]+\.m3u8(\?|$)/,
-          `/archive-${start}-${duration}.m3u8$1`,
-        );
+        return channel.url.replace(/\/[^/?]+\.m3u8(\?|$)/, `/archive-${start}-${duration}.m3u8$1`);
       }
       if (/\.ts(\?|$)/.test(channel.url)) {
         return channel.url.replace(/\/[^/?]+\.ts(\?|$)/, `/timeshift_abs-${start}.ts$1`);

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -1,0 +1,95 @@
+import { buildArchiveUrl } from "./archive";
+import { quickCheckChannel } from "./tauri";
+import type { ChannelResult } from "./types";
+
+export interface ArchiveProbeOutcome {
+  label: string;
+  ok: boolean;
+  latencyMs: number | null;
+  error: string | null;
+}
+
+export interface ArchiveProbeEntry {
+  running: boolean;
+  outcomes: ArchiveProbeOutcome[];
+  checkedAt: number | null;
+}
+
+export interface ArchiveProbePoint {
+  label: string;
+  startEpochS: number;
+}
+
+/** One hour back, plus a point just inside the advertised depth when known. */
+export function archiveProbePoints(result: ChannelResult, nowEpochS: number): ArchiveProbePoint[] {
+  const points: ArchiveProbePoint[] = [{ label: "Archive −1 h", startEpochS: nowEpochS - 3600 }];
+  const depthDays = result.catchup_days;
+  if (depthDays != null && depthDays > 0) {
+    points.push({
+      label: `Archive −${depthDays} d`,
+      startEpochS: nowEpochS - depthDays * 86_400 + 1800,
+    });
+  }
+  return points;
+}
+
+export async function probeArchivePoint(
+  result: ChannelResult,
+  point: ArchiveProbePoint,
+  nowEpochS: number,
+): Promise<ArchiveProbeOutcome | null> {
+  const url = buildArchiveUrl(result, {
+    startEpochS: point.startEpochS,
+    durationS: 300,
+    nowEpochS,
+  });
+  if (!url) {
+    return null;
+  }
+  try {
+    const checked = await quickCheckChannel({
+      ...result,
+      url,
+      content_type: "movie",
+      stream_url: null,
+      status: "pending",
+    });
+    return {
+      label: point.label,
+      ok: checked.status === "alive",
+      latencyMs: checked.latency_ms,
+      error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
+    };
+  } catch (error) {
+    return {
+      label: point.label,
+      ok: false,
+      latencyMs: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Probe a channel's archive, streaming partial outcomes through `onUpdate` so
+ * UIs can render as each point completes. Points run sequentially — IPTV
+ * providers commonly enforce single-connection limits.
+ */
+export async function probeChannelArchive(
+  result: ChannelResult,
+  onUpdate: (entry: ArchiveProbeEntry) => void,
+): Promise<ArchiveProbeEntry> {
+  const nowEpochS = Math.floor(Date.now() / 1000);
+  const outcomes: ArchiveProbeOutcome[] = [];
+  onUpdate({ running: true, outcomes: [], checkedAt: null });
+  for (const point of archiveProbePoints(result, nowEpochS)) {
+    const outcome = await probeArchivePoint(result, point, nowEpochS);
+    if (outcome) {
+      outcomes.push(outcome);
+      onUpdate({ running: true, outcomes: [...outcomes], checkedAt: null });
+    }
+  }
+  const entry: ArchiveProbeEntry = { running: false, outcomes, checkedAt: nowEpochS };
+  onUpdate(entry);
+  return entry;
+}

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -78,18 +78,35 @@ export async function probeArchivePoint(
 export async function probeChannelArchive(
   result: ChannelResult,
   onUpdate: (entry: ArchiveProbeEntry) => void,
+  shouldContinue: () => boolean = () => true,
 ): Promise<ArchiveProbeEntry> {
+  if (!shouldContinue()) {
+    return { running: false, outcomes: [], checkedAt: null };
+  }
   const nowEpochS = Math.floor(Date.now() / 1000);
   const outcomes: ArchiveProbeOutcome[] = [];
+  let cancelled = false;
   onUpdate({ running: true, outcomes: [], checkedAt: null });
   for (const point of archiveProbePoints(result, nowEpochS)) {
+    if (!shouldContinue()) {
+      cancelled = true;
+      break;
+    }
     const outcome = await probeArchivePoint(result, point, nowEpochS);
+    if (!shouldContinue()) {
+      cancelled = true;
+      break;
+    }
     if (outcome) {
       outcomes.push(outcome);
       onUpdate({ running: true, outcomes: [...outcomes], checkedAt: null });
     }
   }
-  const entry: ArchiveProbeEntry = { running: false, outcomes, checkedAt: nowEpochS };
+  const entry: ArchiveProbeEntry = {
+    running: false,
+    outcomes,
+    checkedAt: cancelled ? null : nowEpochS,
+  };
   onUpdate(entry);
   return entry;
 }

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -56,9 +56,12 @@ export async function probeArchivePoint(
     });
     return {
       label: point.label,
-      ok: checked.status === "alive",
+      ok: checked.status === "alive" || checked.status === "drm",
       latencyMs: checked.latency_ms,
-      error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
+      error:
+        checked.status === "alive" || checked.status === "drm"
+          ? null
+          : (checked.error_reason ?? checked.status),
     };
   } catch (error) {
     return {

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -23,6 +23,12 @@ export interface ArchiveProbePoint {
 let archiveProbeGeneration = 0;
 const inFlightArchiveChecks = new Set<Promise<void>>();
 
+/** Keep a multi-channel sequence tied to the generation in which it started. */
+export function createArchiveProbeSequenceGuard(): () => boolean {
+  const generation = archiveProbeGeneration;
+  return () => generation === archiveProbeGeneration;
+}
+
 /** Stop probe sequences and wait for their current backend checks to release the provider. */
 export async function cancelArchiveProbes(): Promise<void> {
   archiveProbeGeneration += 1;

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -1,4 +1,4 @@
-import { buildArchiveUrl } from "./archive";
+import { buildArchiveUrl, MAX_CATCHUP_DAYS } from "./archive";
 import { quickCheckChannel } from "./tauri";
 import type { ChannelResult } from "./types";
 
@@ -20,10 +20,23 @@ export interface ArchiveProbePoint {
   startEpochS: number;
 }
 
+let archiveProbeGeneration = 0;
+const inFlightArchiveChecks = new Set<Promise<void>>();
+
+/** Stop probe sequences and wait for their current backend checks to release the provider. */
+export async function cancelArchiveProbes(): Promise<void> {
+  archiveProbeGeneration += 1;
+  await Promise.all(inFlightArchiveChecks);
+}
+
 /** One hour back, plus a point just inside the advertised depth when known. */
-export function archiveProbePoints(result: ChannelResult, nowEpochS: number): ArchiveProbePoint[] {
+export function archiveProbePoints(
+  result: Pick<ChannelResult, "catchup_days">,
+  nowEpochS: number,
+): ArchiveProbePoint[] {
   const points: ArchiveProbePoint[] = [{ label: "Archive −1 h", startEpochS: nowEpochS - 3600 }];
-  const depthDays = result.catchup_days;
+  const depthDays =
+    result.catchup_days == null ? null : Math.min(MAX_CATCHUP_DAYS, result.catchup_days);
   if (depthDays != null && depthDays > 0) {
     points.push({
       label: `Archive −${depthDays} d`,
@@ -83,7 +96,9 @@ export async function probeChannelArchive(
   onUpdate: (entry: ArchiveProbeEntry) => void,
   shouldContinue: () => boolean = () => true,
 ): Promise<ArchiveProbeEntry> {
-  if (!shouldContinue()) {
+  const generation = archiveProbeGeneration;
+  const canContinue = () => generation === archiveProbeGeneration && shouldContinue();
+  if (!canContinue()) {
     return { running: false, outcomes: [], checkedAt: null };
   }
   const nowEpochS = Math.floor(Date.now() / 1000);
@@ -91,12 +106,18 @@ export async function probeChannelArchive(
   let cancelled = false;
   onUpdate({ running: true, outcomes: [], checkedAt: null });
   for (const point of archiveProbePoints(result, nowEpochS)) {
-    if (!shouldContinue()) {
+    if (!canContinue()) {
       cancelled = true;
       break;
     }
-    const outcome = await probeArchivePoint(result, point, nowEpochS);
-    if (!shouldContinue()) {
+    const pendingCheck = probeArchivePoint(result, point, nowEpochS);
+    const completion = pendingCheck.then(
+      () => undefined,
+      () => undefined,
+    );
+    inFlightArchiveChecks.add(completion);
+    const outcome = await pendingCheck.finally(() => inFlightArchiveChecks.delete(completion));
+    if (!canContinue()) {
       cancelled = true;
       break;
     }

--- a/src/lib/cast.ts
+++ b/src/lib/cast.ts
@@ -25,6 +25,7 @@ export function buildCastRequest(channel: ChannelResult): CastMediaRequest {
     channelName: channel.name || null,
     channelLogo: channel.tvg_logo || null,
     streamKind: detectStreamKind(url),
+    isFinite: channel.content_type !== "live",
   };
 }
 

--- a/src/lib/playback.ts
+++ b/src/lib/playback.ts
@@ -27,9 +27,14 @@ interface PlaybackRecoveryDecisionIgnore {
   kind: "ignore";
 }
 
+interface PlaybackRecoveryDecisionFinish {
+  kind: "finish";
+}
+
 export type PlaybackRecoveryDecision =
   | PlaybackRecoveryDecisionRetry
   | PlaybackRecoveryDecisionFail
+  | PlaybackRecoveryDecisionFinish
   | PlaybackRecoveryDecisionIgnore;
 
 export interface StreamMetadata {
@@ -393,7 +398,7 @@ export function decidePlaybackRecovery(
     return { kind: "ignore" };
   }
   if (input.issue === "ended" && input.contentType !== "live") {
-    return { kind: "ignore" };
+    return { kind: "finish" };
   }
   const nextAttempt = getNextPlaybackRecoveryAttempt(
     input.recoveryTimestamps,

--- a/src/lib/runtimeMonitor.ts
+++ b/src/lib/runtimeMonitor.ts
@@ -262,10 +262,10 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     triggerRuntimeIssue("media_error", reason);
   });
   addHandler(videoElement, "ended", () => {
-    if (result.content_type !== "live") {
-      return;
-    }
-    triggerRuntimeIssue("ended", "Live stream ended unexpectedly");
+    triggerRuntimeIssue(
+      "ended",
+      result.content_type === "live" ? "Live stream ended unexpectedly" : "Playback ended",
+    );
   });
 
   const libCleanups: Array<() => void> = [];

--- a/src/lib/runtimeMonitor.ts
+++ b/src/lib/runtimeMonitor.ts
@@ -86,6 +86,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
     hasStartedPlayingRef,
     onRuntimeIssue,
   } = params;
+  const isLive = result.content_type === "live";
 
   let closed = false;
   const monitor = {
@@ -125,6 +126,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
 
   const tryLiveBufferResync = () => {
     if (
+      !isLive ||
       closed ||
       !mpegtsPlayerRef.current ||
       isPausedRef.current ||
@@ -158,7 +160,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
   };
 
   const adjustLiveBufferPlaybackRate = () => {
-    if (!mpegtsPlayerRef.current) return;
+    if (!isLive || !mpegtsPlayerRef.current) return;
     const ranges: BufferedTimeRange[] = [];
     for (let index = 0; index < videoElement.buffered.length; index += 1) {
       ranges.push({
@@ -180,7 +182,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
   };
 
   const trimExcessiveLiveLatency = () => {
-    if (!mpegtsPlayerRef.current || videoElement.buffered.length === 0) return false;
+    if (!isLive || !mpegtsPlayerRef.current || videoElement.buffered.length === 0) return false;
     const ranges: BufferedTimeRange[] = [];
     for (let index = 0; index < videoElement.buffered.length; index += 1) {
       ranges.push({
@@ -210,6 +212,7 @@ export function createRuntimeMonitor(params: RuntimeMonitorParams): () => void {
   };
 
   const scheduleLiveBufferResync = () => {
+    if (!isLive) return;
     markPotentialStall();
     if (resyncTimer) return;
     resyncTimer = setTimeout(() => {

--- a/src/lib/sourceFilter.ts
+++ b/src/lib/sourceFilter.ts
@@ -75,6 +75,19 @@ export function applySourceFilterToPreview(
 
   const channels = preview.channels.filter((channel) => matcher.test(channel.name));
   const totals = contentTypeTotals(channels);
+  const representedPlaylists = new Set(channels.map((channel) => channel.playlist));
+  const everyRepresentedPlaylistMapped = [...representedPlaylists].every((playlist) =>
+    Object.hasOwn(preview.epg_sources_by_playlist, playlist),
+  );
+  const filteredEpgSourcesByPlaylist = Object.fromEntries(
+    Object.entries(preview.epg_sources_by_playlist).filter(([playlist]) =>
+      representedPlaylists.has(playlist),
+    ),
+  );
+  const representedEpgSources = new Set(Object.values(filteredEpgSourcesByPlaylist).flat());
+  const shouldFilterEpgSources =
+    Object.keys(preview.epg_sources_by_playlist).length > 0 &&
+    (channels.length === 0 || everyRepresentedPlaylistMapped);
 
   return {
     ...preview,
@@ -85,6 +98,12 @@ export function applySourceFilterToPreview(
     channels,
     // Keep the full group list to mirror backend source-filter semantics.
     groups: [...preview.groups],
+    epg_sources: shouldFilterEpgSources
+      ? preview.epg_sources.filter((source) => representedEpgSources.has(source))
+      : preview.epg_sources,
+    epg_sources_by_playlist: shouldFilterEpgSources
+      ? filteredEpgSourcesByPlaylist
+      : preview.epg_sources_by_playlist,
   };
 }
 

--- a/src/lib/sourceFilter.ts
+++ b/src/lib/sourceFilter.ts
@@ -42,6 +42,35 @@ function visibleGroups(channels: Channel[]): string[] {
     .sort((left, right) => left.localeCompare(right));
 }
 
+function filterEpgSourcesToChannels(
+  preview: PlaylistPreview,
+  channels: Channel[],
+): Pick<PlaylistPreview, "epg_sources" | "epg_sources_by_playlist"> {
+  const representedPlaylists = new Set(channels.map((channel) => channel.playlist));
+  const everyRepresentedPlaylistMapped = [...representedPlaylists].every((playlist) =>
+    Object.hasOwn(preview.epg_sources_by_playlist, playlist),
+  );
+  const epg_sources_by_playlist = Object.fromEntries(
+    Object.entries(preview.epg_sources_by_playlist).filter(([playlist]) =>
+      representedPlaylists.has(playlist),
+    ),
+  );
+  const representedEpgSources = new Set(Object.values(epg_sources_by_playlist).flat());
+  const shouldFilterEpgSources =
+    Object.keys(preview.epg_sources_by_playlist).length > 0 &&
+    (channels.length === 0 || everyRepresentedPlaylistMapped);
+
+  return shouldFilterEpgSources
+    ? {
+        epg_sources: preview.epg_sources.filter((source) => representedEpgSources.has(source)),
+        epg_sources_by_playlist,
+      }
+    : {
+        epg_sources: preview.epg_sources,
+        epg_sources_by_playlist: preview.epg_sources_by_playlist,
+      };
+}
+
 export function normalizeSourceFilter(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
@@ -75,19 +104,7 @@ export function applySourceFilterToPreview(
 
   const channels = preview.channels.filter((channel) => matcher.test(channel.name));
   const totals = contentTypeTotals(channels);
-  const representedPlaylists = new Set(channels.map((channel) => channel.playlist));
-  const everyRepresentedPlaylistMapped = [...representedPlaylists].every((playlist) =>
-    Object.hasOwn(preview.epg_sources_by_playlist, playlist),
-  );
-  const filteredEpgSourcesByPlaylist = Object.fromEntries(
-    Object.entries(preview.epg_sources_by_playlist).filter(([playlist]) =>
-      representedPlaylists.has(playlist),
-    ),
-  );
-  const representedEpgSources = new Set(Object.values(filteredEpgSourcesByPlaylist).flat());
-  const shouldFilterEpgSources =
-    Object.keys(preview.epg_sources_by_playlist).length > 0 &&
-    (channels.length === 0 || everyRepresentedPlaylistMapped);
+  const epgSources = filterEpgSourcesToChannels(preview, channels);
 
   return {
     ...preview,
@@ -98,12 +115,7 @@ export function applySourceFilterToPreview(
     channels,
     // Keep the full group list to mirror backend source-filter semantics.
     groups: [...preview.groups],
-    epg_sources: shouldFilterEpgSources
-      ? preview.epg_sources.filter((source) => representedEpgSources.has(source))
-      : preview.epg_sources,
-    epg_sources_by_playlist: shouldFilterEpgSources
-      ? filteredEpgSourcesByPlaylist
-      : preview.epg_sources_by_playlist,
+    ...epgSources,
   };
 }
 
@@ -117,6 +129,7 @@ export function applyContentVisibilityToPreview(
 
   const channels = preview.channels.filter((channel) => channel.content_type === "live");
   const totals = contentTypeTotals(channels);
+  const epgSources = filterEpgSourcesToChannels(preview, channels);
 
   return {
     ...preview,
@@ -126,6 +139,7 @@ export function applyContentVisibilityToPreview(
     series_count: totals.series_count,
     groups: visibleGroups(channels),
     channels,
+    ...epgSources,
   };
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -6,6 +6,8 @@ import type {
   CastSession,
   ChannelResult,
   ChromecastDevice,
+  EpgLoadSummary,
+  EpgProgramme,
   PlaylistPreview,
   RecentPlaylistEntry,
   RecentPlaylistKind,
@@ -99,6 +101,22 @@ export async function resetScan(): Promise<void> {
 
 export async function quickCheckChannel(channel: ChannelResult): Promise<ChannelResult> {
   return invoke("quick_check_channel", { channel: toCommandChannelResult(channel) });
+}
+
+export async function loadEpg(
+  sources: string[],
+  tvgIds: string[],
+  forceRefresh = false,
+): Promise<EpgLoadSummary> {
+  return invoke("load_epg", { sources, tvgIds, forceRefresh });
+}
+
+export async function getEpgProgrammes(
+  tvgId: string,
+  from: number,
+  to: number,
+): Promise<EpgProgramme[]> {
+  return invoke("get_epg_programmes", { tvgId, from, to });
 }
 
 export async function exportCsv(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -112,11 +112,12 @@ export async function loadEpg(
 }
 
 export async function getEpgProgrammes(
+  sources: string[],
   tvgId: string,
   from: number,
   to: number,
 ): Promise<EpgProgramme[]> {
-  return invoke("get_epg_programmes", { tvgId, from, to });
+  return invoke("get_epg_programmes", { sources, tvgId, from, to });
 }
 
 export async function exportCsv(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -111,6 +111,10 @@ export async function loadEpg(
   return invoke("load_epg", { sources, tvgIds, forceRefresh });
 }
 
+export async function cancelEpgLoad(): Promise<void> {
+  return invoke("cancel_epg_load");
+}
+
 export async function getEpgProgrammes(
   sources: string[],
   tvgId: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,7 @@ export interface PlaylistPreview {
   series_count: number;
   groups: string[];
   epg_sources: string[];
+  epg_sources_by_playlist: Record<string, string[]>;
   channels: Channel[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -486,6 +486,7 @@ export interface CastMediaRequest {
   channelName: string | null;
   channelLogo: string | null;
   streamKind: CastStreamKind;
+  isFinite: boolean;
 }
 
 export type UpdateInstallKind = "built-in" | "manual";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,7 +86,22 @@ export interface PlaylistPreview {
   movie_count: number;
   series_count: number;
   groups: string[];
+  epg_sources: string[];
   channels: Channel[];
+}
+
+export interface EpgProgramme {
+  start: number;
+  stop: number;
+  title: string;
+}
+
+export interface EpgLoadSummary {
+  sources_requested: number;
+  sources_loaded: number;
+  failed_sources: string[];
+  channels_matched: number;
+  programme_count: number;
 }
 
 export interface XtreamAccountInfo {

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -3,8 +3,10 @@ import type { AppStore, ArchiveSlice } from "../types";
 
 export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = (set) => ({
   archiveProbes: {},
+  epgLoadSummary: null,
 
   setArchiveProbe: (index, entry) =>
     set((state) => ({ archiveProbes: { ...state.archiveProbes, [index]: entry } })),
-  clearArchiveProbes: () => set({ archiveProbes: {} }),
+  setEpgLoadSummary: (epgLoadSummary) => set({ epgLoadSummary }),
+  clearArchiveProbes: () => set({ archiveProbes: {}, epgLoadSummary: null }),
 });

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -1,0 +1,10 @@
+import type { StateCreator } from "zustand";
+import type { AppStore, ArchiveSlice } from "../types";
+
+export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = (set) => ({
+  archiveProbes: {},
+
+  setArchiveProbe: (index, entry) =>
+    set((state) => ({ archiveProbes: { ...state.archiveProbes, [index]: entry } })),
+  clearArchiveProbes: () => set({ archiveProbes: {} }),
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createArchiveSlice } from "./slices/archiveSlice";
 import { createFilterSlice } from "./slices/filterSlice";
 import { createHistorySlice } from "./slices/historySlice";
 import { createPlayerSlice } from "./slices/playerSlice";
@@ -18,4 +19,5 @@ export const useAppStore = create<AppStore>()((...a) => ({
   ...createPlayerSlice(...a),
   ...createHistorySlice(...a),
   ...createSettingsSlice(...a),
+  ...createArchiveSlice(...a),
 }));

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,8 +5,8 @@ import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
-  EpgLoadSummary,
   CurrentSourceDescriptor,
+  EpgLoadSummary,
   PlaylistLoadProgress,
   PlaylistPreview,
   RecentPlaylistEntry,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,6 +5,7 @@ import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
+  EpgLoadSummary,
   CurrentSourceDescriptor,
   PlaylistLoadProgress,
   PlaylistPreview,
@@ -113,8 +114,12 @@ export interface FilterSlice {
 export interface ArchiveSlice {
   /** Spot-probe results for catch-up channels, keyed by channel index. */
   archiveProbes: Record<number, ArchiveProbeEntry>;
+  /** Result of the most recent XMLTV load for the current playlist. */
+  epgLoadSummary: EpgLoadSummary | null;
 
   setArchiveProbe: (index: number, entry: ArchiveProbeEntry) => void;
+  setEpgLoadSummary: (summary: EpgLoadSummary | null) => void;
+  /** Reset all per-playlist archive state (probes and EPG summary). */
   clearArchiveProbes: () => void;
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,4 +1,5 @@
 import type { ScanUiMetrics } from "../hooks/useScan.helpers";
+import type { ArchiveProbeEntry } from "../lib/archiveProbe";
 import type { Platform } from "../lib/platform";
 import type { ScanState } from "../lib/scanState";
 import type {
@@ -108,6 +109,14 @@ export interface FilterSlice {
 // ---------------------------------------------------------------------------
 // Selection
 // ---------------------------------------------------------------------------
+
+export interface ArchiveSlice {
+  /** Spot-probe results for catch-up channels, keyed by channel index. */
+  archiveProbes: Record<number, ArchiveProbeEntry>;
+
+  setArchiveProbe: (index: number, entry: ArchiveProbeEntry) => void;
+  clearArchiveProbes: () => void;
+}
 
 export interface SelectionSlice {
   selectedChannel: ChannelResult | null;
@@ -249,4 +258,5 @@ export type AppStore = PlaylistSlice &
   UiSlice &
   PlayerSlice &
   HistorySlice &
-  SettingsSlice;
+  SettingsSlice &
+  ArchiveSlice;

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -137,10 +137,10 @@ describe("buildArchiveUrl", () => {
       buildArchiveUrl(urlFields("https://host/provider/live/alice/secret/42.ts", "xc"), WINDOW),
     ).toBe("https://host/provider/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8");
     expect(
-      buildArchiveUrl(
-        urlFields("https://host/provider/alice/secret/42.ts", "xc"),
-        { ...WINDOW, durationS: 3629 },
-      ),
+      buildArchiveUrl(urlFields("https://host/provider/alice/secret/42.ts", "xc"), {
+        ...WINDOW,
+        durationS: 3629,
+      }),
     ).toBe("https://host/provider/timeshift/alice/secret/61/2026-08-28:20-00/42.m3u8");
     // Non-xtream shapes fall back to the utc query convention.
     expect(buildArchiveUrl(urlFields("http://host/odd/path.m3u8", "xc"), WINDOW)).toBe(

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -94,6 +94,12 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW)).toBe(
       `http://h/s.m3u8?start=${START}`,
     );
+    expect(
+      buildArchiveUrl(
+        urlFields("http://h/s.m3u8?token=x#player", "shift", "?utc=${start}"),
+        WINDOW,
+      ),
+    ).toBe(`http://h/s.m3u8?token=x&utc=${START}#player`);
     // Non-query relative templates concatenate verbatim.
     expect(
       buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
@@ -135,6 +141,9 @@ describe("buildArchiveUrl", () => {
     );
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8?a=1", "shift"), WINDOW)).toBe(
       `http://h/s.m3u8?a=1&utc=${START}&lutc=${START + 8000}`,
+    );
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8#player", "default"), WINDOW)).toBe(
+      `http://h/s.m3u8?utc=${START}&lutc=${START + 8000}#player`,
     );
   });
 });

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -71,6 +71,9 @@ describe("substituteArchiveTemplate", () => {
     expect(substituteArchiveTemplate("?offset=${offset}&end=${utcend}", WINDOW)).toBe(
       `?offset=8000&end=${START + 3600}`,
     );
+    expect(substituteArchiveTemplate("?utc=${start}&lutc=${timestamp}", WINDOW)).toBe(
+      `?utc=${START}&lutc=${START + 8000}`,
+    );
   });
 });
 
@@ -120,6 +123,15 @@ describe("buildArchiveUrl", () => {
         WINDOW,
       ),
     ).toBe("https://host/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8?token=x#playback");
+    expect(
+      buildArchiveUrl(urlFields("https://host/provider/live/alice/secret/42.ts", "xc"), WINDOW),
+    ).toBe("https://host/provider/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8");
+    expect(
+      buildArchiveUrl(
+        urlFields("https://host/provider/alice/secret/42.ts", "xc"),
+        { ...WINDOW, durationS: 3629 },
+      ),
+    ).toBe("https://host/provider/timeshift/alice/secret/61/2026-08-28:20-00/42.m3u8");
     // Non-xtream shapes fall back to the utc query convention.
     expect(buildArchiveUrl(urlFields("http://host/odd/path.m3u8", "xc"), WINDOW)).toBe(
       `http://host/odd/path.m3u8?utc=${START}&lutc=${START + 8000}`,

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   archiveBadgeText,
+  archivePickerDefault,
   archiveSortValue,
   archiveTitle,
   buildArchiveUrl,
@@ -207,5 +208,17 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8#player", "default"), WINDOW)).toBe(
       `http://h/s.m3u8?utc=${START}&lutc=${START + 8000}#player`,
     );
+  });
+});
+
+describe("archivePickerDefault", () => {
+  it("starts 59:30 before now on the same day", () => {
+    const now = new Date(2026, 7, 29, 14, 7, 0);
+    expect(archivePickerDefault(now)).toEqual({ daysBack: 0, time: "13:07" });
+  });
+
+  it("rolls to yesterday when 59:30 back crosses midnight", () => {
+    const now = new Date(2026, 7, 29, 0, 20, 0);
+    expect(archivePickerDefault(now)).toEqual({ daysBack: 1, time: "23:20" });
   });
 });

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -105,6 +105,16 @@ describe("buildArchiveUrl", () => {
         WINDOW,
       ),
     ).toBe(`HTTPS://h/replay/${START}.m3u8`);
+    expect(
+      buildArchiveUrl(
+        urlFields(
+          "http://h/live/s.m3u8",
+          "default",
+          "http://h/replay?start=${start}&amp;duration=${duration}",
+        ),
+        WINDOW,
+      ),
+    ).toBe(`http://h/replay?start=${START}&duration=3600`);
     // Query templates attach to the stream URL, respecting existing queries.
     expect(
       buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),
@@ -113,6 +123,9 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW)).toBe(
       `http://h/s.m3u8?start=${START}`,
     );
+    expect(
+      buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&amp;start=${start}"), WINDOW),
+    ).toBe(`http://h/s.m3u8?start=${START}`);
     expect(
       buildArchiveUrl(
         urlFields("http://h/s.m3u8?token=x#player", "shift", "?utc=${start}"),
@@ -148,6 +161,9 @@ describe("buildArchiveUrl", () => {
     expect(
       buildArchiveUrl(urlFields("https://host/provider/live/alice/secret/42.ts", "xc"), WINDOW),
     ).toBe("https://host/provider/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8");
+    expect(buildArchiveUrl(urlFields("HTTPS://host/live/alice/secret/42.ts", "xc"), WINDOW)).toBe(
+      "HTTPS://host/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8",
+    );
     expect(
       buildArchiveUrl(urlFields("https://host/provider/alice/secret/42.ts", "xc"), {
         ...WINDOW,

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -7,6 +7,7 @@ import {
   hasArchive,
   substituteArchiveTemplate,
 } from "../src/lib/archive";
+import { archiveProbePoints } from "../src/lib/archiveProbe";
 
 function fields(
   catchup: string | null,
@@ -44,6 +45,15 @@ describe("archive helpers", () => {
     expect(archiveSortValue(fields(null, null))).toBeNull();
     expect(archiveSortValue(fields("xc", null))).toBe(0);
     expect(archiveSortValue(fields("xc", 7))).toBe(7);
+  });
+
+  it("clamps archive probes to the supported retention depth", () => {
+    const nowEpochS = 1_800_000_000;
+
+    expect(archiveProbePoints({ catchup_days: 0xffff_ffff }, nowEpochS)).toEqual([
+      { label: "Archive −1 h", startEpochS: nowEpochS - 3600 },
+      { label: "Archive −31 d", startEpochS: nowEpochS - 31 * 86_400 + 1800 },
+    ]);
   });
 });
 

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -182,13 +182,13 @@ describe("buildArchiveUrl", () => {
     );
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
-    ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);
+    ).toBe(`http://host/channel/archive-${START}-3600.ts?tok=1`);
     expect(
       buildArchiveUrl(urlFields("http://host/channel/index.m3u8#player", "flussonic"), WINDOW),
     ).toBe(`http://host/channel/archive-${START}-3600.m3u8#player`);
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts#player", "flussonic"), WINDOW),
-    ).toBe(`http://host/channel/timeshift_abs-${START}.ts#player`);
+    ).toBe(`http://host/channel/archive-${START}-3600.ts#player`);
   });
 
   it("uses the utc query convention for default and shift types", () => {

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -155,6 +155,12 @@ describe("buildArchiveUrl", () => {
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
     ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);
+    expect(
+      buildArchiveUrl(urlFields("http://host/channel/index.m3u8#player", "flussonic"), WINDOW),
+    ).toBe(`http://host/channel/archive-${START}-3600.m3u8#player`);
+    expect(
+      buildArchiveUrl(urlFields("http://host/channel/mono.ts#player", "flussonic"), WINDOW),
+    ).toBe(`http://host/channel/timeshift_abs-${START}.ts#player`);
   });
 
   it("uses the utc query convention for default and shift types", () => {

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -99,6 +99,12 @@ describe("buildArchiveUrl", () => {
         WINDOW,
       ),
     ).toBe(`http://h/replay/${START}-3600.m3u8`);
+    expect(
+      buildArchiveUrl(
+        urlFields("http://h/live/s.m3u8", "default", "HTTPS://h/replay/${start}.m3u8"),
+        WINDOW,
+      ),
+    ).toBe(`HTTPS://h/replay/${START}.m3u8`);
     // Query templates attach to the stream URL, respecting existing queries.
     expect(
       buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -142,6 +142,12 @@ describe("buildArchiveUrl", () => {
         WINDOW,
       ),
     ).toBe(`http://h/video-${START}-3600.m3u8#player`);
+    expect(
+      buildArchiveUrl(
+        urlFields("http://h/video?token=x#player", "append", "-${start}-${duration}.m3u8"),
+        WINDOW,
+      ),
+    ).toBe(`http://h/video-${START}-3600.m3u8?token=x#player`);
   });
 
   it("builds xtream timeshift URLs from live stream URLs", () => {

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -123,6 +123,12 @@ describe("buildArchiveUrl", () => {
     expect(
       buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
     ).toBe(`http://h/video-${START}-3600.m3u8`);
+    expect(
+      buildArchiveUrl(
+        urlFields("http://h/video#player", "append", "-${start}-${duration}.m3u8"),
+        WINDOW,
+      ),
+    ).toBe(`http://h/video-${START}-3600.m3u8#player`);
   });
 
   it("builds xtream timeshift URLs from live stream URLs", () => {

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { archiveBadgeText, archiveSortValue, archiveTitle, hasArchive } from "../src/lib/archive";
+import {
+  archiveBadgeText,
+  archiveSortValue,
+  archiveTitle,
+  buildArchiveUrl,
+  hasArchive,
+  substituteArchiveTemplate,
+} from "../src/lib/archive";
 
 function fields(
   catchup: string | null,
@@ -37,5 +44,91 @@ describe("archive helpers", () => {
     expect(archiveSortValue(fields(null, null))).toBeNull();
     expect(archiveSortValue(fields("xc", null))).toBe(0);
     expect(archiveSortValue(fields("xc", 7))).toBe(7);
+  });
+});
+
+// 2026-08-28 20:00:00 UTC
+const START = 1_787_947_200;
+const WINDOW = { startEpochS: START, durationS: 3600, nowEpochS: START + 8000 };
+
+function urlFields(
+  url: string,
+  catchup: string | null,
+  catchup_source: string | null = null,
+  catchup_days: number | null = 7,
+) {
+  return { url, catchup, catchup_days, catchup_source };
+}
+
+describe("substituteArchiveTemplate", () => {
+  it("fills dollar and brace placeholder forms", () => {
+    expect(substituteArchiveTemplate("?utc=${start}&lutc=${now}", WINDOW)).toBe(
+      `?utc=${START}&lutc=${START + 8000}`,
+    );
+    expect(substituteArchiveTemplate("/archive-{utc}-{duration}.m3u8", WINDOW)).toBe(
+      `/archive-${START}-3600.m3u8`,
+    );
+    expect(substituteArchiveTemplate("?offset=${offset}&end=${utcend}", WINDOW)).toBe(
+      `?offset=8000&end=${START + 3600}`,
+    );
+  });
+});
+
+describe("buildArchiveUrl", () => {
+  it("returns null without advertised catch-up", () => {
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8", null, null, null), WINDOW)).toBeNull();
+  });
+
+  it("prefers an explicit catchup-source template", () => {
+    expect(
+      buildArchiveUrl(
+        urlFields("http://h/live/s.m3u8", "default", "http://h/replay/${start}-${duration}.m3u8"),
+        WINDOW,
+      ),
+    ).toBe(`http://h/replay/${START}-3600.m3u8`);
+    // Query templates attach to the stream URL, respecting existing queries.
+    expect(
+      buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),
+    ).toBe(`http://h/s.m3u8?token=x&utc=${START}`);
+    // A leading & normalizes to ? when the URL has no query yet.
+    expect(
+      buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW),
+    ).toBe(`http://h/s.m3u8?start=${START}`);
+    // Non-query relative templates concatenate verbatim.
+    expect(
+      buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
+    ).toBe(`http://h/video-${START}-3600.m3u8`);
+  });
+
+  it("builds xtream timeshift URLs from live stream URLs", () => {
+    expect(
+      buildArchiveUrl(urlFields("http://host:8080/live/alice/secret/42.ts", "xc"), WINDOW),
+    ).toBe("http://host:8080/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8");
+    // Extension-less live URLs match too.
+    expect(buildArchiveUrl(urlFields("http://host/alice/secret/42", "xc"), WINDOW)).toBe(
+      "http://host/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8",
+    );
+    // Non-xtream shapes fall back to the utc query convention.
+    expect(buildArchiveUrl(urlFields("http://host/odd/path.m3u8", "xc"), WINDOW)).toBe(
+      `http://host/odd/path.m3u8?utc=${START}&lutc=${START + 8000}`,
+    );
+  });
+
+  it("builds flussonic archive URLs", () => {
+    expect(
+      buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW),
+    ).toBe(`http://host/channel/archive-${START}-3600.m3u8`);
+    expect(
+      buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
+    ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);
+  });
+
+  it("uses the utc query convention for default and shift types", () => {
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "default"), WINDOW)).toBe(
+      `http://h/s.m3u8?utc=${START}&lutc=${START + 8000}`,
+    );
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8?a=1", "shift"), WINDOW)).toBe(
+      `http://h/s.m3u8?a=1&utc=${START}&lutc=${START + 8000}`,
+    );
   });
 });

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -91,9 +91,9 @@ describe("buildArchiveUrl", () => {
       buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),
     ).toBe(`http://h/s.m3u8?token=x&utc=${START}`);
     // A leading & normalizes to ? when the URL has no query yet.
-    expect(
-      buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW),
-    ).toBe(`http://h/s.m3u8?start=${START}`);
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW)).toBe(
+      `http://h/s.m3u8?start=${START}`,
+    );
     // Non-query relative templates concatenate verbatim.
     expect(
       buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
@@ -108,6 +108,12 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://host/alice/secret/42", "xc"), WINDOW)).toBe(
       "http://host/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8",
     );
+    expect(
+      buildArchiveUrl(
+        urlFields("https://host/live/alice/secret/42.ts?token=x#playback", "xc"),
+        WINDOW,
+      ),
+    ).toBe("https://host/timeshift/alice/secret/60/2026-08-28:20-00/42.m3u8?token=x#playback");
     // Non-xtream shapes fall back to the utc query convention.
     expect(buildArchiveUrl(urlFields("http://host/odd/path.m3u8", "xc"), WINDOW)).toBe(
       `http://host/odd/path.m3u8?utc=${START}&lutc=${START + 8000}`,
@@ -115,9 +121,9 @@ describe("buildArchiveUrl", () => {
   });
 
   it("builds flussonic archive URLs", () => {
-    expect(
-      buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW),
-    ).toBe(`http://host/channel/archive-${START}-3600.m3u8`);
+    expect(buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW)).toBe(
+      `http://host/channel/archive-${START}-3600.m3u8`,
+    );
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
     ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);

--- a/tests/archiveProbe.test.ts
+++ b/tests/archiveProbe.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { cancelArchiveProbes, createArchiveProbeSequenceGuard } from "../src/lib/archiveProbe";
+
+describe("archive probe cancellation", () => {
+  it("invalidates the guard shared by a multi-channel probe sequence", async () => {
+    const sequenceIsCurrent = createArchiveProbeSequenceGuard();
+
+    expect(sequenceIsCurrent()).toBe(true);
+    await cancelArchiveProbes();
+    expect(sequenceIsCurrent()).toBe(false);
+  });
+});

--- a/tests/sourceFilter.test.ts
+++ b/tests/sourceFilter.test.ts
@@ -19,6 +19,7 @@ const preview: PlaylistPreview = {
   file_path: "/tmp/sample.m3u8",
   file_name: "sample.m3u8",
   source_identity: "path:/tmp/sample.m3u8",
+  saved_playlist_id: null,
   server_location: "SE",
   single_provider: true,
   xtream_max_connections: null,
@@ -28,6 +29,8 @@ const preview: PlaylistPreview = {
   movie_count: 1,
   series_count: 0,
   groups: ["Kids", "Sports", "Movies"],
+  epg_sources: [],
+  epg_sources_by_playlist: {},
   channels: [
     {
       index: 8,
@@ -118,6 +121,52 @@ describe("sourceFilter helpers", () => {
     expect(filtered.movie_count).toBe(1);
     expect(filtered.groups).toEqual(preview.groups);
     expect(filtered.channels.map((channel) => channel.index)).toEqual([8, 107]);
+  });
+
+  it("keeps only EPG sources for represented cached directory playlists", () => {
+    const filtered = applySourceFilterToPreview(
+      {
+        ...preview,
+        epg_sources: ["https://example.com/kids.xml", "https://example.com/sports.xml"],
+        epg_sources_by_playlist: {
+          "kids.m3u8": ["https://example.com/kids.xml"],
+          "sports.m3u8": ["https://example.com/sports.xml"],
+        },
+        channels: [
+          { ...preview.channels[0], playlist: "kids.m3u8" },
+          { ...preview.channels[1], playlist: "sports.m3u8" },
+        ],
+      },
+      "Disney",
+    );
+
+    expect(filtered.epg_sources).toEqual(["https://example.com/kids.xml"]);
+    expect(filtered.epg_sources_by_playlist).toEqual({
+      "kids.m3u8": ["https://example.com/kids.xml"],
+    });
+  });
+
+  it("preserves EPG sources when a represented playlist has no source mapping", () => {
+    const epgSources = ["https://example.com/kids.xml", "https://example.com/shared.xml"];
+    const epgSourcesByPlaylist = {
+      "kids.m3u8": ["https://example.com/kids.xml"],
+      "removed.m3u8": ["https://example.com/shared.xml"],
+    };
+    const filtered = applySourceFilterToPreview(
+      {
+        ...preview,
+        epg_sources: epgSources,
+        epg_sources_by_playlist: epgSourcesByPlaylist,
+        channels: [
+          { ...preview.channels[0], playlist: "kids.m3u8" },
+          { ...preview.channels[1], name: "Disney Sports", playlist: "unmapped.m3u8" },
+        ],
+      },
+      "Disney",
+    );
+
+    expect(filtered.epg_sources).toEqual(epgSources);
+    expect(filtered.epg_sources_by_playlist).toEqual(epgSourcesByPlaylist);
   });
 
   it("returns the preview unchanged when content visibility filtering is disabled", () => {

--- a/tests/sourceFilter.test.ts
+++ b/tests/sourceFilter.test.ts
@@ -214,4 +214,27 @@ describe("sourceFilter helpers", () => {
     expect(filtered.series_count).toBe(0);
     expect(filtered.groups).toEqual(["Kids", "Sports"]);
   });
+
+  it("prunes EPG sources for VOD-only directory children", () => {
+    const filtered = applyContentVisibilityToPreview(
+      {
+        ...preview,
+        epg_sources: ["https://example.com/live.xml", "https://example.com/vod.xml"],
+        epg_sources_by_playlist: {
+          "live.m3u8": ["https://example.com/live.xml"],
+          "vod.m3u8": ["https://example.com/vod.xml"],
+        },
+        channels: [
+          { ...preview.channels[0], playlist: "live.m3u8" },
+          { ...preview.channels[2], playlist: "vod.m3u8" },
+        ],
+      },
+      true,
+    );
+
+    expect(filtered.epg_sources).toEqual(["https://example.com/live.xml"]);
+    expect(filtered.epg_sources_by_playlist).toEqual({
+      "live.m3u8": ["https://example.com/live.xml"],
+    });
+  });
 });

--- a/tests/useStreamPlayer.test.ts
+++ b/tests/useStreamPlayer.test.ts
@@ -176,7 +176,7 @@ describe("useStreamPlayer helpers", () => {
     ).toEqual({ kind: "ignore" });
   });
 
-  it("does not auto-recover when VOD reaches a natural end", () => {
+  it("finishes VOD instead of recovering when playback reaches a natural end", () => {
     expect(
       decidePlaybackRecovery({
         issue: "ended",
@@ -185,7 +185,7 @@ describe("useStreamPlayer helpers", () => {
         isPaused: false,
         contentType: "movie",
       }),
-    ).toEqual({ kind: "ignore" });
+    ).toEqual({ kind: "finish" });
 
     expect(
       decidePlaybackRecovery({


### PR DESCRIPTION
Phase 2 of the catch-up plan (Ref #229, design: https://plans.kristofferr.com/d/5nwq8d7wj9h8). Stacked on #232.

Detection alone doesn't let you watch or verify an archive. This adds the playback and guide layer:

**Rust**
- Playlist parser captures `x-tvg-url` / `url-tvg` EPG sources from the `#EXTM3U` header (aggregated across directory playlists)
- New `engine/epg` module: streamed XMLTV download with a disk cache (6 h TTL, 1 GB cap), transparent gunzip, quick-xml parse into an in-memory index filtered to the playlist's tvg-ids
- `load_epg` / `get_epg_programmes` commands

**Frontend**
- `buildArchiveUrl`: catchup-source templates with `${var}`/`{var}` substitution, Xtream timeshift URLs, Flussonic archive rewrites, `utc`/`lutc` query fallback
- Player archive mode: violet time badge, seek bar (rebuilds the URL at the target time), corner GO LIVE; archive plays as a synthetic channel through the existing route/recovery pipeline, and archive failures never mark the live channel as failed
- Sidebar Archive card: EPG programme list grouped by day (lazy per-playlist XMLTV load on first open), date/time picker fallback when no EPG match
- Spot probes: card button + context-menu "Test Catch-up (n)", probing −1 h and the advertised depth via `quick_check_channel`, results shared in the store
- Report panel EPG Coverage shows real programme-data coverage once loaded

Not yet live-tested against a real catch-up provider; validated via unit tests (cargo 298, bun 126, tsc, biome clean).

Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added electronic programme guides with listings, channel matching, caching, and loading status.
  * Added catch-up TV playback with programme selection, archive seeking, and a **Go Live** control.
  * Added catch-up availability testing with response times.
  * Automatically detects EPG sources, including Xtream playlists.
  * Added support for compressed and legacy-encoded EPG data.
  * Improved Chromecast support for archive and on-demand playback.
* **Bug Fixes**
  * Improved playback recovery, casting failures, and archive controls.
  * Prevented outdated loads from replacing current results.
  * Redacted sensitive URL details in logs.
  * Playback now ends cleanly when on-demand content finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->