### PR TITLE
feat(catchup): Guide view with Table/Guide toolbar switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1038,6 +1038,7 @@ export default function App() {
     (result: ChannelResult, options: ArchivePlayOptions) => {
       getStore().setSelectedChannel(result);
       getStore().setSelectedChannelIndices([result.index]);
+      getStore().setPlayIntentActive(true);
       streamPlayer.playArchive(result, options);
     },
     [streamPlayer.playArchive],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
 import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
+import { resolveArchivePlayback } from "./lib/archive";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
   checkFfmpegAvailable,
@@ -533,6 +534,7 @@ export default function App() {
   const sidebarDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const reportSidebarDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const pendingArchivePlaybackRef = useRef<ArchivePlayOptions | null>(null);
 
   const handlePlaybackFailedRef = useRef<((result: ChannelResult) => void) | undefined>(undefined);
   const streamPlayer = useStreamPlayer({
@@ -1033,17 +1035,6 @@ export default function App() {
     getStore().setSelectedChannel(result);
   }, []);
 
-  // Guide playback also selects the channel so the sidebar player shows it.
-  const handleGuidePlayArchive = useCallback(
-    (result: ChannelResult, options: ArchivePlayOptions) => {
-      getStore().setSelectedChannel(result);
-      getStore().setSelectedChannelIndices([result.index]);
-      getStore().setPlayIntentActive(true);
-      streamPlayer.playArchive(result, options);
-    },
-    [streamPlayer.playArchive],
-  );
-
   const handleOpenSettings = useCallback(async () => {
     const existing = await WebviewWindow.getByLabel("settings");
     if (existing) {
@@ -1131,6 +1122,7 @@ export default function App() {
 
   const handlePlayInApp = useCallback(
     (result: ChannelResult) => {
+      pendingArchivePlaybackRef.current = null;
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
         getStore().setPendingPlaybackChannel(result);
         return;
@@ -1158,6 +1150,50 @@ export default function App() {
     [playStream],
   );
 
+  const playGuideArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      const currentChromecast = chromecastRef.current;
+      if (isCastSessionActive(currentChromecast.session)) {
+        const session = currentChromecast.session;
+        const device =
+          currentChromecast.devices.find((candidate) => candidate.id === session.deviceId) ??
+          (lastCastDeviceRef.current?.id === session.deviceId ? lastCastDeviceRef.current : null);
+        const playback = resolveArchivePlayback(result, options);
+        if (device && playback) {
+          void currentChromecast.cast(
+            device,
+            buildCastRequest({
+              ...result,
+              name: options.title ?? result.name,
+              url: playback.url,
+              stream_url: null,
+            }),
+          );
+          return;
+        }
+      }
+      getStore().setPlayIntentActive(true);
+      streamPlayer.playArchive(result, options);
+    },
+    [streamPlayer.playArchive],
+  );
+
+  // Guide playback also selects the channel so the sidebar player shows it.
+  const handleGuidePlayArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      getStore().setSelectedChannel(result);
+      getStore().setSelectedChannelIndices([result.index]);
+      if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
+        pendingArchivePlaybackRef.current = options;
+        getStore().setPendingPlaybackChannel(result);
+        return;
+      }
+      pendingArchivePlaybackRef.current = null;
+      playGuideArchive(result, options);
+    },
+    [playGuideArchive],
+  );
+
   const handlePip = useCallback(() => {
     const video = playbackVideoElement;
     if (!video) return;
@@ -1171,10 +1207,16 @@ export default function App() {
   const handleProceedPlayback = useCallback(() => {
     if (!pendingPlaybackChannel) return;
     const channel = pendingPlaybackChannel;
+    const archiveOptions = pendingArchivePlaybackRef.current;
+    pendingArchivePlaybackRef.current = null;
     getStore().setPendingPlaybackChannel(null);
+    if (archiveOptions) {
+      playGuideArchive(channel, archiveOptions);
+      return;
+    }
     getStore().setPlayIntentActive(true);
     playStream(channel);
-  }, [pendingPlaybackChannel, playStream]);
+  }, [pendingPlaybackChannel, playGuideArchive, playStream]);
 
   // Successful playback is itself a channel check. Keep the result row and
   // detail panel in sync with everything the active player can establish.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { setLiquidGlassEffect } from "tauri-plugin-liquid-glass-api";
 import { AppBanners } from "./components/AppBanners";
 import { ChannelTable } from "./components/ChannelTable";
 import { FilterBar } from "./components/FilterBar";
+import { GuideView } from "./components/GuideView";
 import { PlaylistReportPanel } from "./components/PlaylistReportPanel";
 import { ProgressBar } from "./components/ProgressBar";
 import { StartScreen } from "./components/StartScreen";
@@ -34,7 +35,7 @@ import { useMenuEventBridge } from "./hooks/useMenuEventBridge";
 import { usePlaylistSources } from "./hooks/usePlaylistSources";
 import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
-import { useStreamPlayer } from "./hooks/useStreamPlayer";
+import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
@@ -512,6 +513,7 @@ export default function App() {
   const platform = useAppStore((s) => s.platform);
   const isMac = useAppStore((s) => s.isMac);
   const sidebarHidden = useAppStore((s) => s.sidebarHidden);
+  const viewMode = useAppStore((s) => s.viewMode);
   const sidebarWidth = useAppStore((s) => s.sidebarWidth);
   const showReportPanel = useAppStore((s) => s.showReportPanel);
   const reportSidebarWidth = useAppStore((s) => s.reportSidebarWidth);
@@ -1031,6 +1033,16 @@ export default function App() {
     getStore().setSelectedChannel(result);
   }, []);
 
+  // Guide playback also selects the channel so the sidebar player shows it.
+  const handleGuidePlayArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      getStore().setSelectedChannel(result);
+      getStore().setSelectedChannelIndices([result.index]);
+      streamPlayer.playArchive(result, options);
+    },
+    [streamPlayer.playArchive],
+  );
+
   const handleOpenSettings = useCallback(async () => {
     const existing = await WebviewWindow.getByLabel("settings");
     if (existing) {
@@ -1456,7 +1468,9 @@ export default function App() {
             <div className="flex flex-col flex-1 min-w-0">
               {!isMac && <FilterBar onApply={handleApplySourceFilter} />}
               {playlist ? (
-                tableProfilerEnabled ? (
+                viewMode === "guide" ? (
+                  <GuideView onPlayArchive={handleGuidePlayArchive} />
+                ) : tableProfilerEnabled ? (
                   <Profiler id="ChannelTable" onRender={handleTableProfilerRender}>
                     {channelTableElement}
                   </Profiler>

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -3,8 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
 import { archiveTitle, hasArchive } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
-import { logger } from "../lib/logger";
-import { getEpgProgrammes, loadEpg } from "../lib/tauri";
+import { ensureEpgLoaded } from "../lib/epgLoader";
+import { getEpgProgrammes } from "../lib/tauri";
+import { dayLabel, timeLabel } from "../lib/timeFormat";
 import type { ChannelResult, EpgProgramme } from "../lib/types";
 import { useAppStore } from "../store";
 
@@ -12,60 +13,6 @@ interface ArchiveCardProps {
   result: ChannelResult;
   archiveSession: ArchiveSession | null;
   onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
-}
-
-// The EPG download can be hundreds of MB, so it loads lazily the first time a
-// catch-up channel's card opens, once per playlist+sources combination.
-let epgLoad: { key: string; promise: Promise<void> } | null = null;
-
-function ensureEpgLoaded(): Promise<void> {
-  const state = useAppStore.getState();
-  const sources = state.playlist?.epg_sources ?? [];
-  if (sources.length === 0) {
-    return Promise.resolve();
-  }
-  const key = `${state.playlist?.source_identity ?? state.playlist?.file_path ?? ""}|${sources.join(",")}`;
-  if (epgLoad?.key === key) {
-    return epgLoad.promise;
-  }
-  const tvgIds = [
-    ...new Set(
-      state.flatResults
-        .filter(hasArchive)
-        .map((result) => result.tvg_id)
-        .filter((id): id is string => !!id),
-    ),
-  ];
-  const promise = loadEpg(sources, tvgIds).then(
-    (summary) => {
-      useAppStore.getState().setEpgLoadSummary(summary);
-      logger.info(
-        "[EPG] Loaded",
-        summary.programme_count,
-        "programmes for",
-        summary.channels_matched,
-        "channels",
-      );
-    },
-    (error) => {
-      logger.warn("[EPG] Load failed:", error);
-    },
-  );
-  epgLoad = { key, promise };
-  return promise;
-}
-
-function dayLabel(epochS: number, now: Date): string {
-  const date = new Date(epochS * 1000);
-  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-  const dayDiff = Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000);
-  if (dayDiff === 0) return "Today";
-  if (dayDiff === 1) return "Yesterday";
-  return date.toLocaleDateString([], { weekday: "short", day: "numeric", month: "short" });
-}
-
-function timeLabel(epochS: number): string {
-  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function ArchiveProbe({ result }: { result: ChannelResult }) {

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -132,7 +132,12 @@ export function ArchiveCard({ result, archiveSession, onPlayArchive }: ArchiveCa
         if (!stale) setProgrammes([]);
         return;
       }
-      await ensureEpgLoaded();
+      try {
+        await ensureEpgLoaded();
+      } catch {
+        if (!stale) setProgrammes([]);
+        return;
+      }
       const now = Math.floor(Date.now() / 1000);
       const depthDays = result.catchup_days ?? 7;
       const list = await getEpgProgrammes(result.tvg_id, now - depthDays * 86_400, now).catch(

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -922,6 +922,17 @@ export function ChannelTable({
     return completedResults.filter((r) => indexSet.has(r.index)).sort((a, b) => a.index - b.index);
   }, [selectedIndices, contextMenuState, completedResults]);
 
+  const handleBrowseCatchup = useCallback(() => {
+    const channel = contextMenuState?.channel;
+    setContextMenuState(null);
+    if (!channel || !hasArchive(channel)) {
+      return;
+    }
+    const store = useAppStore.getState();
+    store.setGuideFocusChannelIndex(channel.index);
+    store.setViewMode("guide");
+  }, [contextMenuState]);
+
   const handleTestCatchup = useCallback(() => {
     const targets = getSelectedChannels().filter(hasArchive);
     setContextMenuState(null);
@@ -1456,13 +1467,24 @@ export function ChannelTable({
             const archiveCount = getSelectedChannels().filter(hasArchive).length;
             if (archiveCount === 0) return null;
             return (
-              <button
-                onClick={handleTestCatchup}
-                className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
-                type="button"
-              >
-                Test Catch-up ({archiveCount})
-              </button>
+              <>
+                <button
+                  onClick={handleTestCatchup}
+                  className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
+                  type="button"
+                >
+                  Test Catch-up ({archiveCount})
+                </button>
+                {hasArchive(contextMenuState.channel) && (
+                  <button
+                    onClick={handleBrowseCatchup}
+                    className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
+                    type="button"
+                  >
+                    Browse Catch-up
+                  </button>
+                )}
+              </>
             );
           })()}
           <div className="h-px my-1 bg-border-subtle" />

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -1,0 +1,366 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ChevronLeft, ChevronRight, CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import type { ArchivePlayOptions } from "../hooks/useStreamPlayer";
+import { archiveBadgeText, hasArchive } from "../lib/archive";
+import { type ArchiveProbeOutcome, probeArchivePoint } from "../lib/archiveProbe";
+import { fetchGuideProgrammes } from "../lib/epgLoader";
+import { filterResultsShared } from "../lib/filters";
+import { isInputLikeTarget } from "../lib/shortcuts";
+import { dayLabel, startOfDayEpochS, timeLabel } from "../lib/timeFormat";
+import type { ChannelResult, EpgProgramme } from "../lib/types";
+import { useAppStore } from "../store";
+
+const ROW_HEIGHT_PX = 32;
+const WINDOW_HOURS = 6;
+const MAX_GUIDE_DEPTH_DAYS = 14;
+
+interface GuideSelection {
+  result: ChannelResult;
+  programme: EpgProgramme;
+}
+
+function selectionKey(selection: GuideSelection | null): string | null {
+  return selection ? `${selection.result.index}:${selection.programme.start}` : null;
+}
+
+interface GuideRowProps {
+  result: ChannelResult;
+  windowFrom: number;
+  windowTo: number;
+  nowEpochS: number;
+  selectedKey: string | null;
+  onSelect: (selection: GuideSelection) => void;
+  onActivate: (selection: GuideSelection) => void;
+}
+
+const GuideRow = memo(function GuideRow({
+  result,
+  windowFrom,
+  windowTo,
+  nowEpochS,
+  selectedKey,
+  onSelect,
+  onActivate,
+}: GuideRowProps) {
+  const [programmes, setProgrammes] = useState<EpgProgramme[] | null>(null);
+
+  useEffect(() => {
+    let stale = false;
+    setProgrammes(null);
+    if (!result.tvg_id) {
+      setProgrammes([]);
+      return;
+    }
+    fetchGuideProgrammes(result.tvg_id, windowFrom, windowTo).then((list) => {
+      if (!stale) setProgrammes(list);
+    });
+    return () => {
+      stale = true;
+    };
+  }, [result.tvg_id, windowFrom, windowTo]);
+
+  const windowLength = windowTo - windowFrom;
+  const earliestPlayable =
+    result.catchup_days != null ? nowEpochS - result.catchup_days * 86_400 : null;
+
+  return (
+    <div className="flex h-full items-stretch border-b border-border-subtle">
+      <div className="flex w-[150px] shrink-0 items-center gap-1.5 border-r border-border-subtle px-2">
+        <span className="min-w-0 flex-1 truncate text-[11px] font-semibold">{result.name}</span>
+        <span className="shrink-0 text-[9px] font-bold uppercase text-violet-400">
+          {archiveBadgeText(result)}
+        </span>
+      </div>
+      <div className="relative min-w-0 flex-1">
+        {programmes === null ? (
+          <div className="flex h-full items-center px-2 text-[10px] text-text-tertiary">
+            <LoaderCircle className="mr-1.5 h-3 w-3 animate-spin" /> Loading...
+          </div>
+        ) : programmes.length === 0 ? (
+          <div className="flex h-full items-center px-2 text-[10px] text-text-tertiary">
+            {result.tvg_id ? "No programme data" : "No EPG id"}
+          </div>
+        ) : (
+          programmes.map((programme) => {
+            const left = Math.max(0, (programme.start - windowFrom) / windowLength);
+            const right = Math.min(1, (programme.stop - windowFrom) / windowLength);
+            const width = right - left;
+            if (width <= 0.005) return null;
+            const playable =
+              programme.start <= nowEpochS &&
+              (earliestPlayable == null || programme.start >= earliestPlayable);
+            const selection: GuideSelection = { result, programme };
+            const selected = selectedKey === `${result.index}:${programme.start}`;
+            return (
+              <button
+                key={programme.start}
+                type="button"
+                onClick={() => onSelect(selection)}
+                onDoubleClick={() => playable && onActivate(selection)}
+                title={`${timeLabel(programme.start)}–${timeLabel(programme.stop)} ${programme.title}${playable ? "" : " (unavailable)"}`}
+                className={`absolute inset-y-[3px] flex items-center gap-1 overflow-hidden rounded px-1.5 text-left text-[10.5px] transition-colors ${
+                  selected
+                    ? "bg-violet-500/35 text-violet-100 ring-1 ring-violet-400/70"
+                    : playable
+                      ? "bg-violet-500/12 text-text-primary ring-1 ring-violet-500/20 hover:bg-violet-500/25"
+                      : "bg-panel-subtle text-text-tertiary ring-1 ring-border-subtle"
+                }`}
+                style={{ left: `${left * 100}%`, width: `${width * 100}%` }}
+              >
+                <span className="shrink-0 text-[9px] tabular-nums opacity-70">
+                  {timeLabel(programme.start)}
+                </span>
+                <span className="truncate">{programme.title}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+});
+
+export function GuideView({
+  onPlayArchive,
+}: {
+  onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
+}) {
+  const flatResults = useAppStore((s) => s.flatResults);
+  const search = useAppStore((s) => s.search);
+  const groupFilter = useAppStore((s) => s.groupFilter);
+  const setViewMode = useAppStore((s) => s.setViewMode);
+  const guideFocusChannelIndex = useAppStore((s) => s.guideFocusChannelIndex);
+  const setGuideFocusChannelIndex = useAppStore((s) => s.setGuideFocusChannelIndex);
+
+  const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
+
+  const channels = useMemo(
+    () => filterResultsShared(flatResults, search, groupFilter, "all").filter(hasArchive),
+    [flatResults, search, groupFilter],
+  );
+
+  const maxDepthDays = useMemo(() => {
+    const deepest = channels.reduce((max, channel) => Math.max(max, channel.catchup_days ?? 1), 1);
+    return Math.min(MAX_GUIDE_DEPTH_DAYS, deepest);
+  }, [channels]);
+
+  const [daysAgo, setDaysAgo] = useState(0);
+  const [windowStartHour, setWindowStartHour] = useState(() => {
+    const hour = new Date().getHours();
+    return Math.floor(hour / WINDOW_HOURS) * WINDOW_HOURS;
+  });
+  const [selection, setSelection] = useState<GuideSelection | null>(null);
+  const [testOutcome, setTestOutcome] = useState<ArchiveProbeOutcome | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  const windowFrom = startOfDayEpochS(daysAgo) + windowStartHour * 3600;
+  const windowTo = windowFrom + WINDOW_HOURS * 3600;
+
+  const shiftWindow = (direction: -1 | 1) => {
+    const nextHour = windowStartHour + direction * WINDOW_HOURS;
+    if (nextHour < 0) {
+      if (daysAgo < maxDepthDays) {
+        setDaysAgo(daysAgo + 1);
+        setWindowStartHour(24 - WINDOW_HOURS);
+      }
+    } else if (nextHour >= 24) {
+      if (daysAgo > 0) {
+        setDaysAgo(daysAgo - 1);
+        setWindowStartHour(0);
+      }
+    } else {
+      setWindowStartHour(nextHour);
+    }
+  };
+
+  // Esc returns to the table view.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isInputLikeTarget(event.target)) {
+        setViewMode("table");
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [setViewMode]);
+
+  const parentRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: channels.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT_PX,
+    overscan: 10,
+  });
+
+  // Right-click "Browse Catch-up" lands on the requested channel.
+  useEffect(() => {
+    if (guideFocusChannelIndex == null) return;
+    const rowIndex = channels.findIndex((channel) => channel.index === guideFocusChannelIndex);
+    if (rowIndex >= 0) {
+      virtualizer.scrollToIndex(rowIndex, { align: "center" });
+    }
+    setGuideFocusChannelIndex(null);
+  }, [guideFocusChannelIndex, channels, virtualizer, setGuideFocusChannelIndex]);
+
+  const activate = (target: GuideSelection) => {
+    onPlayArchive(target.result, {
+      startEpochS: target.programme.start,
+      endEpochS: target.programme.stop,
+      title: target.programme.title,
+    });
+  };
+
+  const runTest = async () => {
+    if (!selection) return;
+    setTesting(true);
+    setTestOutcome(null);
+    const outcome = await probeArchivePoint(
+      selection.result,
+      { label: timeLabel(selection.programme.start), startEpochS: selection.programme.start },
+      Math.floor(Date.now() / 1000),
+    );
+    setTestOutcome(outcome);
+    setTesting(false);
+  };
+
+  const hourLabels = Array.from(
+    { length: WINDOW_HOURS },
+    (_, index) => `${String(windowStartHour + index).padStart(2, "0")}:00`,
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Control strip: date tabs, window pager, selection actions */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle bg-panel-muted px-3 py-1.5">
+        <div className="flex max-w-[40%] items-center gap-1 overflow-x-auto">
+          {Array.from({ length: maxDepthDays + 1 }, (_, index) => maxDepthDays - index).map(
+            (offset) => (
+              <button
+                key={offset}
+                type="button"
+                onClick={() => setDaysAgo(offset)}
+                className={`shrink-0 rounded-md px-2.5 py-0.5 text-[11px] transition-colors ${
+                  offset === daysAgo
+                    ? "bg-btn text-text-primary"
+                    : "text-text-secondary hover:bg-panel-subtle"
+                }`}
+              >
+                {dayLabel(startOfDayEpochS(offset) + 43_200)}
+              </button>
+            ),
+          )}
+        </div>
+        <div className="flex items-center gap-0.5 text-[11px] text-text-tertiary">
+          <button
+            type="button"
+            onClick={() => shiftWindow(-1)}
+            className="rounded p-0.5 hover:bg-panel-subtle hover:text-text-primary"
+            title="Earlier"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <span className="tabular-nums">
+            {hourLabels[0]} – {String((windowStartHour + WINDOW_HOURS) % 24 || 24).padStart(2, "0")}
+            :00
+          </span>
+          <button
+            type="button"
+            onClick={() => shiftWindow(1)}
+            className="rounded p-0.5 hover:bg-panel-subtle hover:text-text-primary"
+            title="Later"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <div className="ml-auto flex min-w-0 items-center gap-2">
+          {testOutcome &&
+            (testOutcome.ok ? (
+              <span className="flex items-center gap-1 text-[11px] font-medium text-green-400">
+                <CircleCheck className="h-3 w-3" />
+                OK{testOutcome.latencyMs != null ? ` · ${testOutcome.latencyMs} ms` : ""}
+              </span>
+            ) : (
+              <span
+                className="flex items-center gap-1 text-[11px] font-medium text-red-400"
+                title={testOutcome.error ?? undefined}
+              >
+                <CircleX className="h-3 w-3" />
+                Failed
+              </span>
+            ))}
+          {selection && (
+            <>
+              <span className="min-w-0 truncate text-[11px] text-text-secondary">
+                <span className="font-medium text-violet-300">{selection.programme.title}</span> ·{" "}
+                {selection.result.name} · {timeLabel(selection.programme.start)}
+              </span>
+              <button
+                type="button"
+                onClick={() => activate(selection)}
+                className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors"
+              >
+                <Play className="h-3 w-3" />
+                Play
+              </button>
+              <button
+                type="button"
+                disabled={testing}
+                onClick={runTest}
+                className="shrink-0 rounded-md border border-border-app bg-btn px-2.5 py-1 text-[11px] font-medium text-text-primary hover:bg-btn-hover transition-colors disabled:opacity-40"
+              >
+                {testing ? "Testing..." : "Test"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Time axis */}
+      <div className="flex shrink-0 border-b border-border-subtle bg-panel-muted pl-[150px] text-[9px] text-text-tertiary">
+        {hourLabels.map((label) => (
+          <span key={label} className="flex-1 border-l border-border-subtle/50 px-1 py-0.5">
+            {label}
+          </span>
+        ))}
+      </div>
+
+      {channels.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center text-sm text-text-tertiary">
+          No catch-up channels match the current filters
+        </div>
+      ) : (
+        <div ref={parentRef} className="native-scroll min-h-0 flex-1 overflow-y-auto">
+          <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const channel = channels[virtualRow.index];
+              return (
+                <div
+                  key={channel.index}
+                  className="absolute inset-x-0"
+                  style={{
+                    height: `${virtualRow.size}px`,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <GuideRow
+                    result={channel}
+                    windowFrom={windowFrom}
+                    windowTo={windowTo}
+                    nowEpochS={nowEpochS}
+                    selectedKey={selectionKey(selection)}
+                    onSelect={(next) => {
+                      setSelection(next);
+                      setTestOutcome(null);
+                    }}
+                    onActivate={activate}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -225,6 +225,7 @@ export function GuideView({
   }, [guideFocusChannelIndex, channels, virtualizer, setGuideFocusChannelIndex]);
 
   const activate = (target: GuideSelection) => {
+    if (testing) return;
     if (!isSelectionPlayable(target, Math.floor(Date.now() / 1000))) return;
     onPlayArchive(target.result, {
       startEpochS: target.programme.start,
@@ -324,7 +325,7 @@ export function GuideView({
               </span>
               <button
                 type="button"
-                disabled={!selectionPlayable}
+                disabled={!selectionPlayable || testing}
                 onClick={() => activate(selection)}
                 className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -24,6 +24,17 @@ function selectionKey(selection: GuideSelection | null): string | null {
   return selection ? `${selection.result.index}:${selection.programme.start}` : null;
 }
 
+function isSelectionPlayable(selection: GuideSelection, nowEpochS: number): boolean {
+  const earliestPlayable =
+    selection.result.catchup_days != null
+      ? nowEpochS - selection.result.catchup_days * 86_400
+      : null;
+  return (
+    selection.programme.start <= nowEpochS &&
+    (earliestPlayable == null || selection.programme.start >= earliestPlayable)
+  );
+}
+
 interface GuideRowProps {
   result: ChannelResult;
   windowFrom: number;
@@ -153,6 +164,7 @@ export function GuideView({
   const [selection, setSelection] = useState<GuideSelection | null>(null);
   const [testOutcome, setTestOutcome] = useState<ArchiveProbeOutcome | null>(null);
   const [testing, setTesting] = useState(false);
+  const testRequestRef = useRef(0);
 
   const windowFrom = startOfDayEpochS(daysAgo) + windowStartHour * 3600;
   const windowTo = windowFrom + WINDOW_HOURS * 3600;
@@ -204,6 +216,7 @@ export function GuideView({
   }, [guideFocusChannelIndex, channels, virtualizer, setGuideFocusChannelIndex]);
 
   const activate = (target: GuideSelection) => {
+    if (!isSelectionPlayable(target, Math.floor(Date.now() / 1000))) return;
     onPlayArchive(target.result, {
       startEpochS: target.programme.start,
       endEpochS: target.programme.stop,
@@ -213,6 +226,7 @@ export function GuideView({
 
   const runTest = async () => {
     if (!selection) return;
+    const requestId = ++testRequestRef.current;
     setTesting(true);
     setTestOutcome(null);
     const outcome = await probeArchivePoint(
@@ -220,9 +234,15 @@ export function GuideView({
       { label: timeLabel(selection.programme.start), startEpochS: selection.programme.start },
       Math.floor(Date.now() / 1000),
     );
-    setTestOutcome(outcome);
-    setTesting(false);
+    if (requestId === testRequestRef.current) {
+      setTestOutcome(outcome);
+      setTesting(false);
+    }
   };
+
+  const selectionPlayable = selection
+    ? isSelectionPlayable(selection, Math.floor(Date.now() / 1000))
+    : false;
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },
@@ -297,8 +317,9 @@ export function GuideView({
               </span>
               <button
                 type="button"
+                disabled={!selectionPlayable}
                 onClick={() => activate(selection)}
-                className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors"
+                className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <Play className="h-3 w-3" />
                 Play
@@ -350,8 +371,10 @@ export function GuideView({
                     nowEpochS={nowEpochS}
                     selectedKey={selectionKey(selection)}
                     onSelect={(next) => {
+                      testRequestRef.current += 1;
                       setSelection(next);
                       setTestOutcome(null);
+                      setTesting(false);
                     }}
                     onActivate={activate}
                   />

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -14,6 +14,7 @@ import { useAppStore } from "../store";
 const ROW_HEIGHT_PX = 32;
 const WINDOW_HOURS = 6;
 const MAX_GUIDE_DEPTH_DAYS = 14;
+const GUIDE_CLOCK_INTERVAL_MS = 30_000;
 
 interface GuideSelection {
   result: ChannelResult;
@@ -144,7 +145,15 @@ export function GuideView({
   const guideFocusChannelIndex = useAppStore((s) => s.guideFocusChannelIndex);
   const setGuideFocusChannelIndex = useAppStore((s) => s.setGuideFocusChannelIndex);
 
-  const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
+  const [nowEpochS, setNowEpochS] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const interval = window.setInterval(
+      () => setNowEpochS(Math.floor(Date.now() / 1000)),
+      GUIDE_CLOCK_INTERVAL_MS,
+    );
+    return () => window.clearInterval(interval);
+  }, []);
 
   const channels = useMemo(
     () => filterResultsShared(flatResults, search, groupFilter, "all").filter(hasArchive),
@@ -240,9 +249,7 @@ export function GuideView({
     }
   };
 
-  const selectionPlayable = selection
-    ? isSelectionPlayable(selection, Math.floor(Date.now() / 1000))
-    : false;
+  const selectionPlayable = selection ? isSelectionPlayable(selection, nowEpochS) : false;
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -590,7 +590,7 @@ export const Toolbar = memo(function Toolbar({
       </div>
 
       {/* Table / Guide mode switch; only meaningful with catch-up channels */}
-      {hasPlaylist && (statusOptionCounts.catchup ?? 0) > 0 && (
+      {hasPlaylist && ((statusOptionCounts.catchup ?? 0) > 0 || viewMode === "guide") && (
         <div
           data-no-window-drag
           className="ml-1.5 flex shrink-0 items-center gap-0.5 rounded-lg border border-border-app bg-input p-0.5"

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -135,6 +135,8 @@ export const Toolbar = memo(function Toolbar({
   const channelSearch = useAppStore((s) => s.channelSearch);
   const groupFilter = useAppStore((s) => s.groupFilter);
   const statusFilter = useAppStore((s) => s.statusFilter);
+  const viewMode = useAppStore((s) => s.viewMode);
+  const setViewMode = useAppStore((s) => s.setViewMode);
   const completedResults = useAppStore((s) => s.flatResults);
   const duplicateIndices = useAppStore((s) => s.duplicateIndices);
   const menuExportRequest = useAppStore((s) => s.menuExportRequest);
@@ -586,6 +588,37 @@ export const Toolbar = memo(function Toolbar({
           {showButtonText && "Saved"}
         </button>
       </div>
+
+      {/* Table / Guide mode switch; only meaningful with catch-up channels */}
+      {hasPlaylist && (statusOptionCounts.catchup ?? 0) > 0 && (
+        <div
+          data-no-window-drag
+          className="ml-1.5 flex shrink-0 items-center gap-0.5 rounded-lg border border-border-app bg-input p-0.5"
+        >
+          <button
+            type="button"
+            onClick={() => setViewMode("table")}
+            className={`rounded-md px-2.5 py-1 text-[12px] transition-colors ${
+              viewMode === "table"
+                ? "bg-btn text-text-primary font-medium"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            Table
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode("guide")}
+            className={`rounded-md px-2.5 py-1 text-[12px] transition-colors ${
+              viewMode === "guide"
+                ? "bg-violet-600 text-white font-medium"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            Guide
+          </button>
+        </div>
+      )}
 
       {/* macOS: playlist name centered in title bar area */}
       {playlistName && isMac && (

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { buildArchiveUrl } from "../lib/archive";
+import { buildArchiveUrl, resolveArchivePlayback } from "../lib/archive";
 import { normalizeCodecName, resolveResolutionLabel } from "../lib/format";
 import { logger } from "../lib/logger";
 import {
@@ -979,24 +979,20 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
 
   const playArchive = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
-      const now = Math.floor(Date.now() / 1000);
-      const windowEnd = Math.min(options.endEpochS ?? now, now);
-      const start = Math.min(Math.floor(options.startEpochS), windowEnd - 1);
-      const durationS = Math.max(60, windowEnd - start);
-      const url = buildArchiveUrl(result, { startEpochS: start, durationS, nowEpochS: now });
-      if (!url) {
+      const playback = resolveArchivePlayback(result, options);
+      if (!playback) {
         return;
       }
       setArchiveSession({
         baseResult: result,
-        startEpochS: start,
-        windowStartEpochS: start,
-        windowEndEpochS: windowEnd,
+        startEpochS: playback.startEpochS,
+        windowStartEpochS: playback.startEpochS,
+        windowEndEpochS: playback.windowEndEpochS,
         title: options.title ?? null,
       });
       // The archive URL rides through the normal route/recovery pipeline as a
       // synthetic channel; it is not live, so MPEG-TS routes get a VOD hint.
-      beginPlayback({ ...result, url, content_type: "movie", stream_url: null });
+      beginPlayback({ ...result, url: playback.url, content_type: "movie", stream_url: null });
     },
     [beginPlayback],
   );

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -47,6 +47,17 @@ export interface ArchiveWindow {
   nowEpochS: number;
 }
 
+export interface ArchivePlaybackRange {
+  startEpochS: number;
+  endEpochS?: number;
+}
+
+export interface ResolvedArchivePlayback {
+  url: string;
+  startEpochS: number;
+  windowEndEpochS: number;
+}
+
 type ArchiveUrlFields = Pick<ChannelResult, "url" | "catchup" | "catchup_days" | "catchup_source">;
 
 /**
@@ -127,10 +138,7 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       const start = Math.floor(window.startEpochS);
       const duration = Math.max(1, Math.floor(window.durationS));
       if (/\.m3u8(\?|$)/.test(channel.url)) {
-        return channel.url.replace(
-          /\/[^/?]+\.m3u8(\?|$)/,
-          `/archive-${start}-${duration}.m3u8$1`,
-        );
+        return channel.url.replace(/\/[^/?]+\.m3u8(\?|$)/, `/archive-${start}-${duration}.m3u8$1`);
       }
       if (/\.ts(\?|$)/.test(channel.url)) {
         return channel.url.replace(/\/[^/?]+\.ts(\?|$)/, `/timeshift_abs-${start}.ts$1`);
@@ -142,4 +150,17 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       // use the standard utc/lutc query convention.
       return defaultArchiveUrl(channel.url, window);
   }
+}
+
+/** Resolve the bounded archive window shared by local and cast playback. */
+export function resolveArchivePlayback(
+  channel: ArchiveUrlFields,
+  range: ArchivePlaybackRange,
+  nowEpochS: number = Math.floor(Date.now() / 1000),
+): ResolvedArchivePlayback | null {
+  const windowEndEpochS = Math.min(range.endEpochS ?? nowEpochS, nowEpochS);
+  const startEpochS = Math.min(Math.floor(range.startEpochS), windowEndEpochS - 1);
+  const durationS = Math.max(60, windowEndEpochS - startEpochS);
+  const url = buildArchiveUrl(channel, { startEpochS, durationS, nowEpochS });
+  return url ? { url, startEpochS, windowEndEpochS } : null;
 }

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -159,8 +159,9 @@ export function resolveArchivePlayback(
   nowEpochS: number = Math.floor(Date.now() / 1000),
 ): ResolvedArchivePlayback | null {
   const windowEndEpochS = Math.min(range.endEpochS ?? nowEpochS, nowEpochS);
-  const startEpochS = Math.min(Math.floor(range.startEpochS), windowEndEpochS - 1);
-  const durationS = Math.max(60, windowEndEpochS - startEpochS);
+  const requestedStartEpochS = Math.min(Math.floor(range.startEpochS), windowEndEpochS - 1);
+  const durationS = Math.max(60, windowEndEpochS - requestedStartEpochS);
+  const startEpochS = windowEndEpochS - durationS;
   const url = buildArchiveUrl(channel, { startEpochS, durationS, nowEpochS });
   return url ? { url, startEpochS, windowEndEpochS } : null;
 }

--- a/src/lib/epgLoader.ts
+++ b/src/lib/epgLoader.ts
@@ -1,0 +1,75 @@
+import { useAppStore } from "../store";
+import { hasArchive } from "./archive";
+import { logger } from "./logger";
+import { getEpgProgrammes, loadEpg } from "./tauri";
+import type { EpgProgramme } from "./types";
+
+// The EPG download can be hundreds of MB, so it loads lazily the first time a
+// catch-up surface opens, once per playlist+sources combination.
+let epgLoad: { key: string; promise: Promise<void> } | null = null;
+// Programme window cache; invalidated together with the load key.
+let programmeCache = new Map<string, Promise<EpgProgramme[]>>();
+
+function currentEpgKey(): string | null {
+  const state = useAppStore.getState();
+  const sources = state.playlist?.epg_sources ?? [];
+  if (sources.length === 0) {
+    return null;
+  }
+  return `${state.playlist?.source_identity ?? state.playlist?.file_path ?? ""}|${sources.join(",")}`;
+}
+
+export function ensureEpgLoaded(): Promise<void> {
+  const key = currentEpgKey();
+  if (key == null) {
+    return Promise.resolve();
+  }
+  if (epgLoad?.key === key) {
+    return epgLoad.promise;
+  }
+  const state = useAppStore.getState();
+  const tvgIds = [
+    ...new Set(
+      state.flatResults
+        .filter(hasArchive)
+        .map((result) => result.tvg_id)
+        .filter((id): id is string => !!id),
+    ),
+  ];
+  const promise = loadEpg(state.playlist?.epg_sources ?? [], tvgIds).then(
+    (summary) => {
+      useAppStore.getState().setEpgLoadSummary(summary);
+      logger.info(
+        "[EPG] Loaded",
+        summary.programme_count,
+        "programmes for",
+        summary.channels_matched,
+        "channels",
+      );
+    },
+    (error) => {
+      logger.warn("[EPG] Load failed:", error);
+    },
+  );
+  epgLoad = { key, promise };
+  programmeCache = new Map();
+  return promise;
+}
+
+/** Programmes for one channel in a window, deduped across concurrent callers. */
+export function fetchGuideProgrammes(
+  tvgId: string,
+  from: number,
+  to: number,
+): Promise<EpgProgramme[]> {
+  const cacheKey = `${tvgId}|${from}|${to}`;
+  const cached = programmeCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const promise = ensureEpgLoaded()
+    .then(() => getEpgProgrammes(tvgId, from, to))
+    .catch(() => [] as EpgProgramme[]);
+  programmeCache.set(cacheKey, promise);
+  return promise;
+}

--- a/src/lib/epgLoader.ts
+++ b/src/lib/epgLoader.ts
@@ -49,6 +49,11 @@ export function ensureEpgLoaded(): Promise<void> {
     },
     (error) => {
       logger.warn("[EPG] Load failed:", error);
+      if (epgLoad?.key === key && epgLoad.promise === promise) {
+        epgLoad = null;
+        programmeCache = new Map();
+      }
+      throw error;
     },
   );
   epgLoad = { key, promise };

--- a/src/lib/epgLoader.ts
+++ b/src/lib/epgLoader.ts
@@ -62,7 +62,7 @@ export function fetchGuideProgrammes(
   from: number,
   to: number,
 ): Promise<EpgProgramme[]> {
-  const cacheKey = `${tvgId}|${from}|${to}`;
+  const cacheKey = `${currentEpgKey() ?? ""}|${tvgId}|${from}|${to}`;
   const cached = programmeCache.get(cacheKey);
   if (cached) {
     return cached;

--- a/src/lib/timeFormat.ts
+++ b/src/lib/timeFormat.ts
@@ -1,0 +1,20 @@
+/** "Today", "Yesterday", or a short local date like "Wed 28 Aug". */
+export function dayLabel(epochS: number, now: Date = new Date()): string {
+  const date = new Date(epochS * 1000);
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const dayDiff = Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000);
+  if (dayDiff === 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  return date.toLocaleDateString([], { weekday: "short", day: "numeric", month: "short" });
+}
+
+/** Local wall-clock time like "21:00". */
+export function timeLabel(epochS: number): string {
+  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/** Local midnight of the day `daysAgo` days before now, in epoch seconds. */
+export function startOfDayEpochS(daysAgo: number, now: Date = new Date()): number {
+  const date = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysAgo);
+  return Math.floor(date.getTime() / 1000);
+}

--- a/src/lib/timeFormat.ts
+++ b/src/lib/timeFormat.ts
@@ -10,7 +10,11 @@ export function dayLabel(epochS: number, now: Date = new Date()): string {
 
 /** Local wall-clock time like "21:00". */
 export function timeLabel(epochS: number): string {
-  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return new Date(epochS * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
 }
 
 /** Local midnight of the day `daysAgo` days before now, in epoch seconds. */

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -10,6 +10,8 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
   platform: initialPlatform,
   isMac: initialPlatform === "macos",
   sidebarHidden: false,
+  viewMode: "table",
+  guideFocusChannelIndex: null,
   sidebarWidth: (() => {
     const saved = localStorage.getItem("sidebar-width");
     return saved ? Math.max(100, Math.min(600, Number(saved))) : 288;
@@ -39,6 +41,8 @@ export const createUiSlice: StateCreator<AppStore, [], [], UiSlice> = (set, get)
 
   setPlatform: (platform) => set({ platform, isMac: platform === "macos" }),
   setSidebarHidden: (sidebarHidden) => set({ sidebarHidden }),
+  setViewMode: (viewMode) => set({ viewMode }),
+  setGuideFocusChannelIndex: (guideFocusChannelIndex) => set({ guideFocusChannelIndex }),
   setSidebarWidth: (sidebarWidth) => set({ sidebarWidth }),
   // Manual visibility changes own the auto-reveal bookkeeping so every
   // entry point (toolbar, menu, stats bar) behaves identically: during an

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,8 +5,8 @@ import type { ScanState } from "../lib/scanState";
 import type {
   AppSettings,
   ChannelResult,
-  EpgLoadSummary,
   CurrentSourceDescriptor,
+  EpgLoadSummary,
   PlaylistLoadProgress,
   PlaylistPreview,
   RecentPlaylistEntry,
@@ -151,8 +151,14 @@ export interface MenuExportRequest {
 
 export type { UpdateNotice, UpdatePhase } from "../lib/updateState";
 
+export type MainViewMode = "table" | "guide";
+
 export interface UiSlice {
   platform: Platform;
+  /** Table shows all channels; guide is the catch-up EPG grid. */
+  viewMode: MainViewMode;
+  /** Channel the guide should scroll to when opened via right-click. */
+  guideFocusChannelIndex: number | null;
   isMac: boolean;
   sidebarHidden: boolean;
   sidebarWidth: number;
@@ -178,6 +184,8 @@ export interface UiSlice {
 
   setPlatform: (platform: Platform) => void;
   setSidebarHidden: (hidden: boolean) => void;
+  setViewMode: (mode: MainViewMode) => void;
+  setGuideFocusChannelIndex: (index: number | null) => void;
   setSidebarWidth: (width: number) => void;
   toggleReportPanel: () => void;
   setReportPanelManually: (visible: boolean) => void;

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -144,9 +144,44 @@ describe("resolveArchivePlayback", () => {
         nowEpochS,
       ),
     ).toEqual({
-      url: `http://h/s.m3u8?utc=${nowEpochS - 1}&lutc=${nowEpochS}`,
-      startEpochS: nowEpochS - 1,
+      url: `http://h/s.m3u8?utc=${nowEpochS - 60}&lutc=${nowEpochS}`,
+      startEpochS: nowEpochS - 60,
       windowEndEpochS: nowEpochS,
     });
+  });
+
+  it("moves short archive windows earlier without extending duration-bearing URLs", () => {
+    const nowEpochS = START + 8000;
+    const range = { startEpochS: nowEpochS - 1, endEpochS: nowEpochS + 3600 };
+
+    expect(
+      resolveArchivePlayback(
+        urlFields(
+          "http://h/live/s.m3u8",
+          "default",
+          "http://h/replay/${start}-${duration}-${end}-${utcend}.m3u8",
+        ),
+        range,
+        nowEpochS,
+      ),
+    ).toEqual({
+      url: `http://h/replay/${nowEpochS - 60}-60-${nowEpochS}-${nowEpochS}.m3u8`,
+      startEpochS: nowEpochS - 60,
+      windowEndEpochS: nowEpochS,
+    });
+    expect(
+      resolveArchivePlayback(
+        urlFields("http://host/channel/index.m3u8", "flussonic"),
+        range,
+        nowEpochS,
+      )?.url,
+    ).toBe(`http://host/channel/archive-${nowEpochS - 60}-60.m3u8`);
+    expect(
+      resolveArchivePlayback(
+        urlFields("http://host/live/alice/secret/42.ts", "xc"),
+        range,
+        nowEpochS,
+      )?.url,
+    ).toBe("http://host/timeshift/alice/secret/1/2026-08-28:22-12/42.m3u8");
   });
 });

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -5,6 +5,7 @@ import {
   archiveTitle,
   buildArchiveUrl,
   hasArchive,
+  resolveArchivePlayback,
   substituteArchiveTemplate,
 } from "../src/lib/archive";
 
@@ -91,9 +92,9 @@ describe("buildArchiveUrl", () => {
       buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),
     ).toBe(`http://h/s.m3u8?token=x&utc=${START}`);
     // A leading & normalizes to ? when the URL has no query yet.
-    expect(
-      buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW),
-    ).toBe(`http://h/s.m3u8?start=${START}`);
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW)).toBe(
+      `http://h/s.m3u8?start=${START}`,
+    );
     // Non-query relative templates concatenate verbatim.
     expect(
       buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
@@ -115,9 +116,9 @@ describe("buildArchiveUrl", () => {
   });
 
   it("builds flussonic archive URLs", () => {
-    expect(
-      buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW),
-    ).toBe(`http://host/channel/archive-${START}-3600.m3u8`);
+    expect(buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW)).toBe(
+      `http://host/channel/archive-${START}-3600.m3u8`,
+    );
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
     ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);
@@ -130,5 +131,22 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8?a=1", "shift"), WINDOW)).toBe(
       `http://h/s.m3u8?a=1&utc=${START}&lutc=${START + 8000}`,
     );
+  });
+});
+
+describe("resolveArchivePlayback", () => {
+  it("clamps future programme windows to the current time", () => {
+    const nowEpochS = START + 8000;
+    expect(
+      resolveArchivePlayback(
+        urlFields("http://h/s.m3u8", "default"),
+        { startEpochS: nowEpochS + 3600, endEpochS: nowEpochS + 7200 },
+        nowEpochS,
+      ),
+    ).toEqual({
+      url: `http://h/s.m3u8?utc=${nowEpochS - 1}&lutc=${nowEpochS}`,
+      startEpochS: nowEpochS - 1,
+      windowEndEpochS: nowEpochS,
+    });
   });
 });


### PR DESCRIPTION
Phase 3 of the catch-up plan (Ref #229, design: https://plans.kristofferr.com/d/5nwq8d7wj9h8, "Guide mode" screenshot). Stacked on #233.

Browsing archives channel by channel in the sidebar doesn't scale; this adds the cross-channel guide:

- Segmented **Table / Guide** switch in the toolbar, shown once the playlist has catch-up channels
- Guide mode replaces the table edge to edge: virtualized rows for catch-up channels (toolbar group/search filters apply), date strip across the archive window, 6-hour time pager, programme blocks on the time axis (dimmed outside the channel's depth or in the future)
- Click selects a programme into the control strip with **Play** (plays in the sidebar player, selecting the channel) and **Test** (probes that exact timestamp); double-click plays directly
- Esc returns to Table; right-click on a catch-up channel gains **Browse Catch-up**, opening the guide scrolled to that channel
- The lazy EPG loader is extracted to `lib/epgLoader` (shared with the sidebar Archive card) with a programme-window cache; day/time formatting to `lib/timeFormat`

The guide is built as a self-contained component with no checker dependencies, since it doubles as the programme guide for the planned player flavor (see #231).

Validation: bun test 126, tsc, biome (new files clean). Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Guide view for browsing catch-up programming across eligible channels.
  - Navigate six-hour schedule windows and previous days.
  - Select programmes for details or start archive playback.
  - Added Table/Guide switching and “Browse Catch-up” from channel menus.
- **Improvements**
  - Guide content loads as needed for faster browsing.
  - Added local date and time labels, including Today and Yesterday.
  - Added keyboard navigation and automatic scrolling to focused channels.
  - Improved archive playback, Chromecast routing, and handling of unavailable guide data or short playback windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->