### PR TITLE
feat(catchup): playlist-wide verification, graduated chips, and score

### DIFF
--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -67,7 +67,10 @@ pub async fn load_epg(
                 sources_loaded += 1;
             }
             Err(error) => {
-                log::warn!("EPG source {source} failed: {error}");
+                log::warn!(
+                    "EPG source {} failed: {error}",
+                    crate::engine::resume::sanitize_url_for_persistence(&source)
+                );
                 failed_sources.push(source);
             }
         }

--- a/src-tauri/src/commands/playlist.rs
+++ b/src-tauri/src/commands/playlist.rs
@@ -18,8 +18,9 @@ use crate::engine::stalker::{
     STALKER_API_TIMEOUT,
 };
 use crate::engine::xtream::{
-    apply_xtream_archive_flags, build_xtream_download_url, fetch_xtream_account_info,
-    fetch_xtream_live_streams, fetch_xtream_playlist_via_json_api, xtream_archive_flags,
+    apply_xtream_archive_flags, build_xtream_download_url, build_xtream_epg_url,
+    fetch_xtream_account_info, fetch_xtream_live_streams, fetch_xtream_playlist_via_json_api,
+    xtream_archive_flags,
 };
 use crate::error::AppError;
 use crate::models::channel::Channel;
@@ -795,6 +796,12 @@ pub(crate) async fn open_playlist_xtream_inner(
     }
     let server_host = server.host_str().unwrap_or("Xtream");
     preview.file_name = format!("{} ({})", server_host, username);
+    // Xtream serves its guide from xmltv.php rather than advertising it in the
+    // playlist header, so the source is derived from the account instead.
+    let epg_url = build_xtream_epg_url(&server, &username, &password).to_string();
+    if !preview.epg_sources.iter().any(|source| source == &epg_url) {
+        preview.epg_sources.insert(0, epg_url);
+    }
     preview.source_identity = Some(source_identity_override.unwrap_or(source_key));
     preview.xtream_max_connections = xtream_account_info
         .as_ref()

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -290,7 +290,7 @@ async fn compute_shared_url_result(
     let status = if checked_status == ChannelStatus::Geoblocked && test_geoblock {
         if let Some(proxies) = proxy_list {
             if !proxies.is_empty() {
-                proxy::confirm_geoblock(channel_url, proxies, timeout).await
+                proxy::confirm_geoblock(channel_url, proxies, timeout, cancel).await
             } else {
                 checked_status
             }
@@ -2812,10 +2812,10 @@ pub async fn quick_check_channel(
         } => outcome,
     };
 
-    if let Some(request_id) = request_id.as_deref() {
-        state.unregister_quick_check(request_id).await;
-    }
     if matches!(outcome, Err(AppError::Cancelled)) {
+        if let Some(request_id) = request_id.as_deref() {
+            state.unregister_quick_check(request_id).await;
+        }
         return Err(AppError::Cancelled);
     }
 
@@ -2848,7 +2848,8 @@ pub async fn quick_check_channel(
         match settings.proxy_file.as_deref() {
             Some(proxy_file) => match proxy::load_proxy_list(proxy_file) {
                 Ok(proxies) => {
-                    proxy::confirm_geoblock(&channel.url, &proxies, settings.timeout).await
+                    proxy::confirm_geoblock(&channel.url, &proxies, settings.timeout, &cancel_token)
+                        .await
                 }
                 Err(error) => {
                     log::warn!(
@@ -2865,12 +2866,22 @@ pub async fn quick_check_channel(
         checked_status
     };
 
+    if cancel_token.is_cancelled() {
+        if let Some(request_id) = request_id.as_deref() {
+            state.unregister_quick_check(request_id).await;
+        }
+        return Err(AppError::Cancelled);
+    }
+
     let mut result = channel;
     result.status = status;
     result.stream_url = stream_url;
     result.latency_ms = latency_ms;
     result.error_reason = error_reason;
     result.screenshot_error_reason = None;
+    if let Some(request_id) = request_id.as_deref() {
+        state.unregister_quick_check(request_id).await;
+    }
     Ok(result)
 }
 

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2759,12 +2759,18 @@ fn get_quick_check_client(accept_invalid_certs: bool) -> reqwest::Client {
 pub async fn quick_check_channel(
     app: AppHandle,
     channel: ChannelResult,
+    request_id: Option<String>,
 ) -> Result<ChannelResult, AppError> {
     let check_started_at = Instant::now();
     let state = app.state::<Arc<AppState>>();
     let settings = state.settings.lock().await.clone();
 
     let cancel_token = CancellationToken::new();
+    if let Some(request_id) = request_id.as_ref() {
+        state
+            .register_quick_check(request_id.clone(), cancel_token.clone())
+            .await;
+    }
     let client = get_quick_check_client(settings.accept_invalid_certs);
 
     let uses_ffprobe_liveness = checker::uses_ffprobe_liveness(&channel.url);
@@ -2775,31 +2781,43 @@ pub async fn quick_check_channel(
         false
     };
 
-    let outcome = if uses_ffprobe_liveness {
-        checker::check_channel_status_with_ffprobe_debug(
-            &app,
-            &channel.url,
-            settings.ffprobe_timeout_secs,
-            settings.retries,
-            settings.retry_backoff,
-            None,
-            ffprobe_ok,
-            &cancel_token,
-        )
-        .await
-    } else {
-        checker::check_channel_status_with_debug(
-            &client,
-            &channel.url,
-            settings.timeout,
-            settings.retries,
-            settings.retry_backoff,
-            settings.extended_timeout,
-            &settings.user_agent,
-            &cancel_token,
-        )
-        .await
+    let outcome = tokio::select! {
+        _ = cancel_token.cancelled() => Err(AppError::Cancelled),
+        outcome = async {
+            if uses_ffprobe_liveness {
+                checker::check_channel_status_with_ffprobe_debug(
+                    &app,
+                    &channel.url,
+                    settings.ffprobe_timeout_secs,
+                    settings.retries,
+                    settings.retry_backoff,
+                    None,
+                    ffprobe_ok,
+                    &cancel_token,
+                )
+                .await
+            } else {
+                checker::check_channel_status_with_debug(
+                    &client,
+                    &channel.url,
+                    settings.timeout,
+                    settings.retries,
+                    settings.retry_backoff,
+                    settings.extended_timeout,
+                    &settings.user_agent,
+                    &cancel_token,
+                )
+                .await
+            }
+        } => outcome,
     };
+
+    if let Some(request_id) = request_id.as_deref() {
+        state.unregister_quick_check(request_id).await;
+    }
+    if matches!(outcome, Err(AppError::Cancelled)) {
+        return Err(AppError::Cancelled);
+    }
 
     let (checked_status, stream_url, latency_ms, error_reason) = match outcome {
         Ok(o) => {
@@ -2854,6 +2872,13 @@ pub async fn quick_check_channel(
     result.error_reason = error_reason;
     result.screenshot_error_reason = None;
     Ok(result)
+}
+
+#[tauri::command]
+pub async fn cancel_quick_check(app: AppHandle, request_id: String) {
+    app.state::<Arc<AppState>>()
+        .cancel_quick_check(&request_id)
+        .await;
 }
 
 #[cfg(test)]
@@ -3263,6 +3288,19 @@ mod tests {
             .await;
 
         cancel_scan_token(state.as_ref(), scan_scope).await;
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancel_quick_check_cancels_registered_token() {
+        let state = AppState::new();
+        let token = CancellationToken::new();
+
+        state
+            .register_quick_check("archive-probe".to_string(), token.clone())
+            .await;
+        state.cancel_quick_check("archive-probe").await;
+
         assert!(token.is_cancelled());
     }
 

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2825,10 +2825,19 @@ pub async fn quick_check_channel(
 
     let status = if checked_status == ChannelStatus::Geoblocked && settings.test_geoblock {
         match settings.proxy_file.as_deref() {
-            Some(proxy_file) => {
-                let proxies = proxy::load_proxy_list(proxy_file)?;
-                proxy::confirm_geoblock(&channel.url, &proxies, settings.timeout).await
-            }
+            Some(proxy_file) => match proxy::load_proxy_list(proxy_file) {
+                Ok(proxies) => {
+                    proxy::confirm_geoblock(&channel.url, &proxies, settings.timeout).await
+                }
+                Err(error) => {
+                    log::warn!(
+                        "[Quick Check] Could not confirm geoblock because proxy file '{}' failed to load: {}",
+                        proxy_file,
+                        error
+                    );
+                    checked_status
+                }
+            },
             None => checked_status,
         }
     } else {

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2767,12 +2767,15 @@ pub async fn quick_check_channel(
     let cancel_token = CancellationToken::new();
     let client = get_quick_check_client(settings.accept_invalid_certs);
 
-    let ffprobe_ok = {
+    let uses_ffprobe_liveness = checker::uses_ffprobe_liveness(&channel.url);
+    let ffprobe_ok = if uses_ffprobe_liveness {
         let (_, fp) = ffmpeg::check_availability(&app).await;
         fp
+    } else {
+        false
     };
 
-    let outcome = if checker::uses_ffprobe_liveness(&channel.url) {
+    let outcome = if uses_ffprobe_liveness {
         checker::check_channel_status_with_ffprobe_debug(
             &app,
             &channel.url,

--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -2798,7 +2798,7 @@ pub async fn quick_check_channel(
         .await
     };
 
-    let (status, stream_url, latency_ms, error_reason) = match outcome {
+    let (checked_status, stream_url, latency_ms, error_reason) = match outcome {
         Ok(o) => {
             log::info!(
                 "[Quick Check] #{} {} → {} in {:.1}s (url: {})",
@@ -2821,6 +2821,18 @@ pub async fn quick_check_channel(
             );
             (ChannelStatus::Dead, None, None, None)
         }
+    };
+
+    let status = if checked_status == ChannelStatus::Geoblocked && settings.test_geoblock {
+        match settings.proxy_file.as_deref() {
+            Some(proxy_file) => {
+                let proxies = proxy::load_proxy_list(proxy_file)?;
+                proxy::confirm_geoblock(&channel.url, &proxies, settings.timeout).await
+            }
+            None => checked_status,
+        }
+    } else {
+        checked_status
     };
 
     let mut result = channel;

--- a/src-tauri/src/engine/epg.rs
+++ b/src-tauri/src/engine/epg.rs
@@ -269,7 +269,10 @@ pub async fn download_epg_source(
 ) -> Result<PathBuf, AppError> {
     let target = cache_path_for(cache_dir, url);
     if !force_refresh && cache_is_fresh(&target) {
-        log::info!("EPG cache hit for {url}");
+        log::info!(
+            "EPG cache hit for {}",
+            crate::engine::resume::sanitize_url_for_persistence(url)
+        );
         return Ok(target);
     }
 
@@ -314,7 +317,10 @@ pub async fn download_epg_source(
     file.flush().map_err(AppError::Io)?;
     drop(file);
     std::fs::rename(&temp, &target).map_err(AppError::Io)?;
-    log::info!("Downloaded EPG {url} ({downloaded} bytes)");
+    log::info!(
+        "Downloaded EPG {} ({downloaded} bytes)",
+        crate::engine::resume::sanitize_url_for_persistence(url)
+    );
     Ok(target)
 }
 

--- a/src-tauri/src/engine/proxy.rs
+++ b/src-tauri/src/engine/proxy.rs
@@ -145,10 +145,11 @@ pub async fn test_with_proxy(url: &str, proxy: &str, timeout: f64, retries: u32)
     )
     .await;
 
-    matches!(
-        outcome.map(|result| result.status),
-        Ok(ChannelStatus::Alive | ChannelStatus::Drm | ChannelStatus::Placeholder)
-    )
+    outcome.is_ok_and(|result| proxy_confirms_access(result.status))
+}
+
+fn proxy_confirms_access(status: ChannelStatus) -> bool {
+    matches!(status, ChannelStatus::Alive | ChannelStatus::Drm)
 }
 
 /// Confirm geoblock by testing with up to 3 random proxies.
@@ -178,7 +179,8 @@ pub async fn confirm_geoblock(
 
 #[cfg(test)]
 mod tests {
-    use super::load_proxy_list;
+    use super::{load_proxy_list, proxy_confirms_access};
+    use crate::models::channel::ChannelStatus;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_temp_path(prefix: &str) -> std::path::PathBuf {
@@ -187,6 +189,13 @@ mod tests {
             .expect("system time should be monotonic")
             .as_nanos();
         std::env::temp_dir().join(format!("{prefix}-{unique}.txt"))
+    }
+
+    #[test]
+    fn proxy_confirmation_requires_playable_content() {
+        assert!(proxy_confirms_access(ChannelStatus::Alive));
+        assert!(proxy_confirms_access(ChannelStatus::Drm));
+        assert!(!proxy_confirms_access(ChannelStatus::Placeholder));
     }
 
     #[test]

--- a/src-tauri/src/engine/proxy.rs
+++ b/src-tauri/src/engine/proxy.rs
@@ -117,6 +117,21 @@ pub fn load_proxy_list(proxy_file: &str) -> Result<Vec<String>, AppError> {
 
 /// Test stream access through a specific proxy.
 pub async fn test_with_proxy(url: &str, proxy: &str, timeout: f64, retries: u32) -> bool {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    test_with_proxy_cancellable(url, proxy, timeout, retries, &cancel).await
+}
+
+async fn test_with_proxy_cancellable(
+    url: &str,
+    proxy: &str,
+    timeout: f64,
+    retries: u32,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> bool {
+    if cancel.is_cancelled() {
+        return false;
+    }
+
     let proxy_url = match reqwest::Proxy::all(proxy) {
         Ok(p) => p,
         Err(_) => return false,
@@ -132,7 +147,6 @@ pub async fn test_with_proxy(url: &str, proxy: &str, timeout: f64, retries: u32)
         Err(_) => return false,
     };
 
-    let cancel = tokio_util::sync::CancellationToken::new();
     let outcome = crate::engine::checker::check_channel_status_with_debug(
         &client,
         url,
@@ -141,7 +155,7 @@ pub async fn test_with_proxy(url: &str, proxy: &str, timeout: f64, retries: u32)
         RetryBackoff::None,
         None,
         "TiviMate/5.1.6 (Android 12)",
-        &cancel,
+        cancel,
     )
     .await;
 
@@ -157,6 +171,7 @@ pub async fn confirm_geoblock(
     url: &str,
     proxy_list: &[String],
     timeout: f64,
+    cancel: &tokio_util::sync::CancellationToken,
 ) -> crate::models::channel::ChannelStatus {
     use rand::seq::IndexedRandom;
 
@@ -168,8 +183,11 @@ pub async fn confirm_geoblock(
     };
 
     for proxy in &sample {
+        if cancel.is_cancelled() {
+            break;
+        }
         log::debug!("Testing geoblock via proxy: {}", proxy);
-        if test_with_proxy(url, proxy, timeout, 3).await {
+        if test_with_proxy_cancellable(url, proxy, timeout, 3, cancel).await {
             return crate::models::channel::ChannelStatus::GeoblockedConfirmed;
         }
     }

--- a/src-tauri/src/engine/proxy.rs
+++ b/src-tauri/src/engine/proxy.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use url::Url;
 
 use crate::error::AppError;
+use crate::models::channel::ChannelStatus;
+use crate::models::scan::RetryBackoff;
 
 fn is_valid_proxy_entry(candidate: &str) -> bool {
     let parsed = match Url::parse(candidate) {
@@ -131,65 +132,23 @@ pub async fn test_with_proxy(url: &str, proxy: &str, timeout: f64, retries: u32)
         Err(_) => return false,
     };
 
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        USER_AGENT,
-        HeaderValue::from_static("TiviMate/5.1.6 (Android 12)"),
-    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let outcome = crate::engine::checker::check_channel_status_with_debug(
+        &client,
+        url,
+        timeout,
+        retries.max(1).saturating_sub(1),
+        RetryBackoff::None,
+        None,
+        "TiviMate/5.1.6 (Android 12)",
+        &cancel,
+    )
+    .await;
 
-    let stream_extensions = [".ts", ".m2ts", ".m4s", ".mp4", ".aac", ".m3u8"];
-
-    for attempt in 0..retries.max(1) {
-        let resp = match client.get(url).headers(headers.clone()).send().await {
-            Ok(r) => r,
-            Err(_) => {
-                if attempt + 1 < retries.max(1) {
-                    tokio::time::sleep(Duration::from_secs_f64(0.5 * (attempt as f64 + 1.0))).await;
-                }
-                continue;
-            }
-        };
-
-        if resp.status() != 200 {
-            continue;
-        }
-
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_lowercase();
-
-        let stream_path = Url::parse(resp.url().as_str())
-            .map(|u| u.path().to_lowercase())
-            .unwrap_or_default();
-
-        let is_stream = content_type.starts_with("video/")
-            || content_type.starts_with("audio/")
-            || content_type.contains("application/vnd.apple.mpegurl")
-            || content_type.contains("application/x-mpegurl")
-            || content_type.contains("application/octet-stream")
-            || content_type.contains("application/mp4")
-            || stream_extensions
-                .iter()
-                .any(|ext| stream_path.ends_with(ext));
-
-        if is_stream {
-            // Read 500KB to verify
-            use futures::StreamExt;
-            let mut stream = resp.bytes_stream();
-            let mut read = 0u64;
-            while let Some(Ok(chunk)) = stream.next().await {
-                read += chunk.len() as u64;
-                if read >= 1024 * 500 {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
+    matches!(
+        outcome.map(|result| result.status),
+        Ok(ChannelStatus::Alive | ChannelStatus::Drm | ChannelStatus::Placeholder)
+    )
 }
 
 /// Confirm geoblock by testing with up to 3 random proxies.

--- a/src-tauri/src/engine/xtream.rs
+++ b/src-tauri/src/engine/xtream.rs
@@ -96,6 +96,26 @@ pub(crate) fn build_xtream_download_url(server: &Url, username: &str, password: 
     playlist_url
 }
 
+/// XMLTV guide endpoint. Xtream serves the EPG separately from the playlist
+/// (`xmltv.php`), and few panels advertise it in the M3U header.
+pub(crate) fn build_xtream_epg_url(server: &Url, username: &str, password: &str) -> Url {
+    let mut epg_url = server.clone();
+    let mut endpoint_path = epg_url.path().trim_end_matches('/').to_string();
+    if endpoint_path.is_empty() || endpoint_path == "/" {
+        endpoint_path = "/xmltv.php".to_string();
+    } else {
+        endpoint_path.push_str("/xmltv.php");
+    }
+    epg_url.set_path(&endpoint_path);
+    epg_url.set_query(None);
+    epg_url.set_fragment(None);
+    epg_url
+        .query_pairs_mut()
+        .append_pair("username", username)
+        .append_pair("password", password);
+    epg_url
+}
+
 pub(crate) fn build_xtream_player_api_url(server: &Url, username: &str, password: &str) -> Url {
     let mut api_url = server.clone();
     let mut endpoint_path = api_url.path().trim_end_matches('/').to_string();
@@ -733,6 +753,22 @@ mod tests {
         extract_xtream_account_info, extract_xtream_max_connections, normalize_xtream_server,
     };
     use std::collections::HashMap;
+    use url::Url;
+
+    #[test]
+    fn epg_url_targets_xmltv_endpoint_with_credentials() {
+        let server = Url::parse("https://provider.example.com/panel").expect("url");
+        let url = super::build_xtream_epg_url(&server, "alice", "s3cret");
+        assert_eq!(
+            url.as_str(),
+            "https://provider.example.com/panel/xmltv.php?username=alice&password=s3cret"
+        );
+        let root = Url::parse("https://provider.example.com").expect("url");
+        assert_eq!(
+            super::build_xtream_epg_url(&root, "alice", "s3cret").path(),
+            "/xmltv.php"
+        );
+    }
 
     #[test]
     fn generated_xtream_entries_carry_catchup_attributes() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1047,6 +1047,7 @@ pub fn run() {
             commands::scan::cancel_scan,
             commands::scan::reset_scan,
             commands::scan::quick_check_channel,
+            commands::scan::cancel_quick_check,
             commands::epg::load_epg,
             commands::epg::get_epg_programmes,
             commands::export::export_csv,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -79,6 +79,7 @@ pub struct AppState {
     /// the stored session.
     pub cast_lifecycle_lock: Mutex<()>,
     window_scan_states: Mutex<HashMap<String, WindowScanState>>,
+    quick_check_tokens: Mutex<HashMap<String, CancellationToken>>,
     backend_perf_samples: Mutex<VecDeque<BackendPerfSample>>,
     playlist_preview_cache: Mutex<HashMap<String, CachedPlaylistPreview>>,
     /// Programme index from the most recent load_epg call.
@@ -110,6 +111,7 @@ impl AppState {
             cast_state: Mutex::new(CastState::default()),
             cast_lifecycle_lock: Mutex::new(()),
             window_scan_states: Mutex::new(HashMap::new()),
+            quick_check_tokens: Mutex::new(HashMap::new()),
             backend_perf_samples: Mutex::new(VecDeque::new()),
             playlist_preview_cache: Mutex::new(HashMap::new()),
             epg: Mutex::new(None),
@@ -136,6 +138,30 @@ impl AppState {
     pub async fn window_pause_notify(&self, window_label: &str) -> Arc<Notify> {
         self.with_window_scan_state(window_label, |scan_state| scan_state.pause_notify.clone())
             .await
+    }
+
+    pub async fn register_quick_check(&self, request_id: String, token: CancellationToken) {
+        let mut quick_check_tokens = self.quick_check_tokens.lock().await;
+        if quick_check_tokens
+            .get(&request_id)
+            .is_some_and(CancellationToken::is_cancelled)
+        {
+            token.cancel();
+        }
+        quick_check_tokens.insert(request_id, token);
+    }
+
+    pub async fn cancel_quick_check(&self, request_id: &str) {
+        self.quick_check_tokens
+            .lock()
+            .await
+            .entry(request_id.to_string())
+            .or_insert_with(CancellationToken::new)
+            .cancel();
+    }
+
+    pub async fn unregister_quick_check(&self, request_id: &str) {
+        self.quick_check_tokens.lock().await.remove(request_id);
     }
 
     pub async fn push_backend_perf_sample(&self, sample: BackendPerfSample) {

--- a/src-tauri/tests/scan_pipeline_integration.rs
+++ b/src-tauri/tests/scan_pipeline_integration.rs
@@ -253,6 +253,7 @@ async fn geoblock_confirmation_unconfirmed_when_proxy_candidates_fail_fast() {
             "also-invalid".to_string(),
         ],
         1.0,
+        &CancellationToken::new(),
     )
     .await;
 

--- a/src-tauri/tests/scan_pipeline_integration.rs
+++ b/src-tauri/tests/scan_pipeline_integration.rs
@@ -206,6 +206,44 @@ async fn proxy_stream_check_succeeds_with_http_proxy_response() {
 }
 
 #[tokio::test]
+async fn proxy_stream_check_follows_hls_manifest_to_media_segment() {
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::clone(&request_count);
+    let handler = Arc::new(move |path: &str| {
+        handler_count.fetch_add(1, Ordering::SeqCst);
+        if path.contains("live.m3u8") {
+            return TestHttpResponse {
+                status_code: 200,
+                reason: "OK",
+                headers: vec![(
+                    "Content-Type".to_string(),
+                    "application/vnd.apple.mpegurl".to_string(),
+                )],
+                body:
+                    b"#EXTM3U\n#EXT-X-TARGETDURATION:4\n#EXTINF:4,\nhttp://example.com/segment.ts\n"
+                        .to_vec(),
+            };
+        }
+
+        TestHttpResponse {
+            status_code: 200,
+            reason: "OK",
+            headers: vec![("Content-Type".to_string(), "video/mp2t".to_string())],
+            body: vec![b'x'; 200 * 1024],
+        }
+    });
+    let (proxy_url, server_handle) = spawn_http_server(handler).await;
+
+    let ok = test_with_proxy("http://example.com/live.m3u8", &proxy_url, 2.0, 1).await;
+    assert!(
+        ok,
+        "proxy check should follow HLS manifests to a live segment"
+    );
+    assert_eq!(request_count.load(Ordering::SeqCst), 2);
+    server_handle.abort();
+}
+
+#[tokio::test]
 async fn geoblock_confirmation_unconfirmed_when_proxy_candidates_fail_fast() {
     let result = confirm_geoblock(
         "http://example.com/live.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
 import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
-import { verifyAllArchives } from "./lib/archiveVerifyRun";
+import { isArchiveVerificationBlockingPlayback, verifyAllArchives } from "./lib/archiveVerifyRun";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
   checkFfmpegAvailable,
@@ -96,6 +96,13 @@ const TABLE_PROFILER_ROW_LIMIT = 50_000;
 
 // Non-reactive store access for writes inside callbacks/effects.
 const getStore = () => useAppStore.getState();
+const ARCHIVE_VERIFICATION_PLAYBACK_ERROR = "Cancel catch-up verification before starting playback";
+
+function blockPlaybackDuringArchiveVerification(): boolean {
+  if (!isArchiveVerificationBlockingPlayback()) return false;
+  getStore().setPlaybackError(ARCHIVE_VERIFICATION_PLAYBACK_ERROR);
+  return true;
+}
 
 function formatScanNotificationBody(stats: {
   alive: number;
@@ -573,6 +580,9 @@ export default function App() {
   const baseCastFn = baseChromecast.cast;
   const wrappedCast = useCallback<UseChromecastResult["cast"]>(
     async (device, request) => {
+      if (blockPlaybackDuringArchiveVerification()) {
+        throw new Error(ARCHIVE_VERIFICATION_PLAYBACK_ERROR);
+      }
       lastCastDeviceRef.current = device;
       await baseCastFn(device, request);
     },
@@ -1082,6 +1092,7 @@ export default function App() {
   // Guide playback also selects the channel so the sidebar player shows it.
   const handleGuidePlayArchive = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
+      if (blockPlaybackDuringArchiveVerification()) return;
       getStore().setSelectedChannel(result);
       getStore().setSelectedChannelIndices([result.index]);
       streamPlayer.playArchive(result, options);
@@ -1156,6 +1167,7 @@ export default function App() {
 
   const handleOpenExternal = useCallback(
     async (result: ChannelResult) => {
+      if (blockPlaybackDuringArchiveVerification()) return;
       if (isSingleConnectionPlaylist(getStore().playlist)) {
         handleStopPlayer();
       }
@@ -1176,6 +1188,7 @@ export default function App() {
 
   const handlePlayInApp = useCallback(
     (result: ChannelResult) => {
+      if (blockPlaybackDuringArchiveVerification()) return;
       if (isScanActive(getStore().scanState) && getStore().playlist?.single_provider) {
         getStore().setPendingPlaybackChannel(result);
         return;
@@ -1215,6 +1228,7 @@ export default function App() {
 
   const handleProceedPlayback = useCallback(() => {
     if (!pendingPlaybackChannel) return;
+    if (blockPlaybackDuringArchiveVerification()) return;
     const channel = pendingPlaybackChannel;
     getStore().setPendingPlaybackChannel(null);
     getStore().setPlayIntentActive(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useScan } from "./hooks/useScan";
 import { useSettings } from "./hooks/useSettings";
 import { type ArchivePlayOptions, useStreamPlayer } from "./hooks/useStreamPlayer";
 import { useUpdateCheck } from "./hooks/useUpdateCheck";
+import { verifyAllArchives } from "./lib/archiveVerifyRun";
 import { buildCastRequest, isCastSessionActive } from "./lib/cast";
 import {
   checkFfmpegAvailable,
@@ -514,6 +515,20 @@ export default function App() {
   const isMac = useAppStore((s) => s.isMac);
   const sidebarHidden = useAppStore((s) => s.sidebarHidden);
   const viewMode = useAppStore((s) => s.viewMode);
+  const verifyCatchupAfterScan = useAppStore((s) => s.verifyCatchupAfterScan);
+  const scanState = useAppStore((s) => s.scanState);
+
+  // Opt-in "Scan + Verify Catch-up": run the verification pass once the scan
+  // finishes; a cancelled or reset scan drops the request.
+  useEffect(() => {
+    if (!verifyCatchupAfterScan) return;
+    if (scanState === "complete") {
+      getStore().setVerifyCatchupAfterScan(false);
+      void verifyAllArchives();
+    } else if (scanState === "idle" || scanState === "cancelled") {
+      getStore().setVerifyCatchupAfterScan(false);
+    }
+  }, [verifyCatchupAfterScan, scanState]);
   const sidebarWidth = useAppStore((s) => s.sidebarWidth);
   const showReportPanel = useAppStore((s) => s.showReportPanel);
   const reportSidebarWidth = useAppStore((s) => s.reportSidebarWidth);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,7 @@ function SelectedChannelSidebar({
   streamPlayer,
   chromecast,
   onPlayChannel,
+  onPlayArchive,
   onScanChannel,
   onStopPlayer,
   onOpenExternal,
@@ -188,6 +189,7 @@ function SelectedChannelSidebar({
   streamPlayer: StreamPlayerController;
   chromecast: UseChromecastResult;
   onPlayChannel: (result: ChannelResult) => void;
+  onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
   onScanChannel: (indices: number[]) => void;
   onStopPlayer: () => void;
   onOpenExternal: (result: ChannelResult) => void;
@@ -300,7 +302,7 @@ function SelectedChannelSidebar({
         muted={streamPlayer.muted}
         videoElement={streamPlayer.videoElement}
         archiveSession={streamPlayer.archiveSession}
-        onPlayArchive={streamPlayer.playArchive}
+        onPlayArchive={onPlayArchive}
         onSeekArchive={streamPlayer.seekArchive}
         onGoLive={streamPlayer.goLive}
         onTogglePause={streamPlayer.togglePause}
@@ -1089,15 +1091,24 @@ export default function App() {
     getStore().setSelectedChannel(result);
   }, []);
 
+  const handlePlayArchive = useCallback(
+    (result: ChannelResult, options: ArchivePlayOptions) => {
+      if (blockPlaybackDuringArchiveVerification()) return;
+      getStore().setPlayIntentActive(true);
+      streamPlayer.playArchive(result, options);
+    },
+    [streamPlayer.playArchive],
+  );
+
   // Guide playback also selects the channel so the sidebar player shows it.
   const handleGuidePlayArchive = useCallback(
     (result: ChannelResult, options: ArchivePlayOptions) => {
       if (blockPlaybackDuringArchiveVerification()) return;
       getStore().setSelectedChannel(result);
       getStore().setSelectedChannelIndices([result.index]);
-      streamPlayer.playArchive(result, options);
+      handlePlayArchive(result, options);
     },
-    [streamPlayer.playArchive],
+    [handlePlayArchive],
   );
 
   const handleOpenSettings = useCallback(async () => {
@@ -1519,6 +1530,7 @@ export default function App() {
                 streamPlayer={streamPlayer}
                 chromecast={chromecast}
                 onPlayChannel={handlePlayInApp}
+                onPlayArchive={handlePlayArchive}
                 onScanChannel={handleScanSelected}
                 onStopPlayer={handleStopPlayer}
                 onOpenExternal={handleOpenExternal}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1197,6 +1197,7 @@ export default function App() {
           metadata_lines: result.metadata_lines,
           url: result.url,
         });
+        getStore().setExternalPlaybackActive(true);
       } catch (err) {
         logger.error("[Player] Failed to open channel in external player:", errorToString(err));
         getStore().setPlaybackError(errorToString(err));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,7 +593,13 @@ export default function App() {
         throw new Error(ARCHIVE_VERIFICATION_PLAYBACK_ERROR);
       }
       lastCastDeviceRef.current = device;
-      await baseCastFn(device, request);
+      getStore().setCastActive(true);
+      try {
+        await baseCastFn(device, request);
+      } catch (error) {
+        getStore().setCastActive(false);
+        throw error;
+      }
     },
     [baseCastFn],
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -589,6 +589,10 @@ export default function App() {
   const castSession = chromecast.session;
   const isCasting = isCastSessionActive(castSession);
 
+  useEffect(() => {
+    getStore().setCastActive(isCasting);
+  }, [isCasting]);
+
   const { settings, save: saveSettings, applyExternal: applyExternalSettings } = useSettings();
   const { start, cancel, pause, resume, initFromPlaylist, syncFromPlaylist, updateResult } =
     useScan();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -893,6 +893,7 @@ export default function App() {
       const state = getStore();
       if (
         state.archiveVerifyRun ||
+        state.archiveGuideTestRunning ||
         Object.values(state.archiveProbes).some((entry) => entry.running)
       ) {
         return false;
@@ -912,6 +913,7 @@ export default function App() {
       const refreshedState = getStore();
       if (
         refreshedState.archiveVerifyRun ||
+        refreshedState.archiveGuideTestRunning ||
         Object.values(refreshedState.archiveProbes).some((entry) => entry.running)
       ) {
         return false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -526,6 +526,8 @@ export default function App() {
   const viewMode = useAppStore((s) => s.viewMode);
   const verifyCatchupAfterScan = useAppStore((s) => s.verifyCatchupAfterScan);
   const scanState = useAppStore((s) => s.scanState);
+  const playIntentActive = useAppStore((s) => s.playIntentActive);
+  const castActive = useAppStore((s) => s.castActive);
   const verifyCatchupScanStartedRef = useRef(false);
 
   // Opt-in "Scan + Verify Catch-up": run the verification pass once the scan
@@ -537,12 +539,13 @@ export default function App() {
     }
     if (!verifyCatchupScanStartedRef.current) return;
     if (scanState === "complete") {
+      if ((playIntentActive || castActive) && isSingleConnectionPlaylist(playlist)) return;
       getStore().setVerifyCatchupAfterScan(false);
       void verifyAllArchives();
     } else if (scanState === "idle" || scanState === "cancelled") {
       getStore().setVerifyCatchupAfterScan(false);
     }
-  }, [verifyCatchupAfterScan, scanState]);
+  }, [verifyCatchupAfterScan, scanState, playIntentActive, castActive, playlist]);
   const sidebarWidth = useAppStore((s) => s.sidebarWidth);
   const showReportPanel = useAppStore((s) => s.showReportPanel);
   const reportSidebarWidth = useAppStore((s) => s.reportSidebarWidth);
@@ -565,7 +568,12 @@ export default function App() {
 
   const handlePlaybackFailedRef = useRef<((result: ChannelResult) => void) | undefined>(undefined);
   const streamPlayer = useStreamPlayer({
-    onPlaybackFailed: (result) => handlePlaybackFailedRef.current?.(result),
+    onPlaybackFailed: (result, affectsChannelHealth) => {
+      getStore().setPlayIntentActive(false);
+      if (affectsChannelHealth) {
+        handlePlaybackFailedRef.current?.(result);
+      }
+    },
   });
   const {
     activeChannelIndex: playbackChannelIndex,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -517,11 +517,16 @@ export default function App() {
   const viewMode = useAppStore((s) => s.viewMode);
   const verifyCatchupAfterScan = useAppStore((s) => s.verifyCatchupAfterScan);
   const scanState = useAppStore((s) => s.scanState);
+  const verifyCatchupScanStartedRef = useRef(false);
 
   // Opt-in "Scan + Verify Catch-up": run the verification pass once the scan
   // finishes; a cancelled or reset scan drops the request.
   useEffect(() => {
-    if (!verifyCatchupAfterScan) return;
+    if (!verifyCatchupAfterScan) {
+      verifyCatchupScanStartedRef.current = false;
+      return;
+    }
+    if (!verifyCatchupScanStartedRef.current) return;
     if (scanState === "complete") {
       getStore().setVerifyCatchupAfterScan(false);
       void verifyAllArchives();
@@ -884,8 +889,14 @@ export default function App() {
   }, []);
 
   const startScanWithSelection = useCallback(
-    async (selection: number[]) => {
+    async (selection: number[], verifyCatchup = false) => {
       const state = getStore();
+      if (
+        state.archiveVerifyRun ||
+        Object.values(state.archiveProbes).some((entry) => entry.running)
+      ) {
+        return false;
+      }
       const currentChannelSearchError = validateSourceFilterPattern(state.channelSearch);
 
       if (currentChannelSearchError) {
@@ -899,6 +910,12 @@ export default function App() {
       }
 
       const refreshedState = getStore();
+      if (
+        refreshedState.archiveVerifyRun ||
+        Object.values(refreshedState.archiveProbes).some((entry) => entry.running)
+      ) {
+        return false;
+      }
       const currentPlaylist = refreshedState.playlist;
       const currentChannelSearch = normalizeSourceFilter(refreshedState.channelSearch);
       const currentGroupFilter = refreshedState.groupFilter;
@@ -938,18 +955,26 @@ export default function App() {
         },
       };
 
+      verifyCatchupScanStartedRef.current = verifyCatchup;
+      refreshedState.setVerifyCatchupAfterScan(verifyCatchup);
       await start(config, currentPlaylist.total_channels, effectiveSelection);
       return true;
     },
     [ensureSourceFilterApplied, start],
   );
 
-  const handleStartScan = useCallback(async () => {
-    const started = await startScanWithSelection(getStore().selectedChannelIndices);
-    if (started) {
-      void triggerHaptic(HapticFeedbackPattern.LevelChange, PerformanceTime.Now);
-    }
-  }, [startScanWithSelection]);
+  const handleStartScan = useCallback(
+    async (verifyCatchup = false) => {
+      const started = await startScanWithSelection(
+        getStore().selectedChannelIndices,
+        verifyCatchup,
+      );
+      if (started) {
+        void triggerHaptic(HapticFeedbackPattern.LevelChange, PerformanceTime.Now);
+      }
+    },
+    [startScanWithSelection],
+  );
 
   const handleScanSelected = useCallback(
     (indices: number[]) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,7 +310,7 @@ function SelectedChannelSidebar({
         onSetVolume={streamPlayer.setVolume}
         onToggleMute={streamPlayer.toggleMute}
         onOpenExternal={onOpenExternal}
-        onRetryPlay={(result) => streamPlayer.play(result)}
+        onRetryPlay={onPlayChannel}
         onPip={document.pictureInPictureEnabled ? onPip : undefined}
       />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -540,7 +540,6 @@ export default function App() {
     if (!verifyCatchupScanStartedRef.current) return;
     if (scanState === "complete") {
       if ((playIntentActive || castActive) && isSingleConnectionPlaylist(playlist)) return;
-      getStore().setVerifyCatchupAfterScan(false);
       void verifyAllArchives();
     } else if (scanState === "idle" || scanState === "cancelled") {
       getStore().setVerifyCatchupAfterScan(false);
@@ -1438,10 +1437,8 @@ export default function App() {
   // Auto-stop player when selected channel changes or is deselected
   useEffect(() => {
     if (playbackChannelIndex === null) return;
-    if (!liveSelectedChannel) {
+    if (!liveSelectedChannel || liveSelectedChannel.index !== playbackChannelIndex) {
       getStore().setPlayIntentActive(false);
-      stopStream();
-    } else if (liveSelectedChannel.index !== playbackChannelIndex) {
       stopStream();
     }
   }, [liveSelectedChannel, playbackChannelIndex, stopStream]);

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -4,6 +4,7 @@ import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlaye
 import { archiveTitle, hasArchive } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { ensureEpgLoaded } from "../lib/epgLoader";
+import { isScanActive } from "../lib/scanState";
 import { getEpgProgrammes } from "../lib/tauri";
 import { dayLabel, timeLabel } from "../lib/timeFormat";
 import type { ChannelResult, EpgProgramme } from "../lib/types";
@@ -18,10 +19,22 @@ interface ArchiveCardProps {
 function ArchiveProbe({ result }: { result: ChannelResult }) {
   const entry = useAppStore((state) => state.archiveProbes[result.index]);
   const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
+  const scanState = useAppStore((state) => state.scanState);
+  const anotherProbeRunning = useAppStore((state) =>
+    Object.values(state.archiveProbes).some((probe) => probe.running),
+  );
   const running = entry?.running ?? false;
+  const disabled = anotherProbeRunning || isScanActive(scanState);
   const outcomes = entry?.outcomes ?? [];
 
   const runProbe = () => {
+    const state = useAppStore.getState();
+    if (
+      isScanActive(state.scanState) ||
+      Object.values(state.archiveProbes).some((probe) => probe.running)
+    ) {
+      return;
+    }
     void probeChannelArchive(result, (update) => setArchiveProbe(result.index, update));
   };
 
@@ -29,7 +42,8 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
     <div className="mt-2 border-t border-violet-500/15 pt-2">
       <button
         type="button"
-        disabled={running}
+        disabled={disabled}
+        title={isScanActive(scanState) ? "Wait for the scan to finish" : undefined}
         onClick={runProbe}
         className="flex w-full items-center justify-center gap-1.5 rounded-md bg-btn px-3 py-1.5 text-[12px] font-medium text-text-primary border border-border-app shadow-sm hover:bg-btn-hover transition-colors disabled:opacity-40"
       >

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -48,7 +48,8 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
     ) {
       return;
     }
-    void probeChannelArchive(result, (update) => setArchiveProbe(result.index, update));
+    const generation = state.archiveProbeGeneration;
+    void probeChannelArchive(result, (update) => setArchiveProbe(generation, result.index, update));
   };
 
   return (

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -1,7 +1,7 @@
 import { CircleCheck, CircleX, LoaderCircle, Play } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlayer";
-import { archiveTitle, hasArchive } from "../lib/archive";
+import { archivePickerDefault, archiveTitle, hasArchive } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { ensureEpgLoaded } from "../lib/epgLoader";
 import { isSingleConnectionPlaylist } from "../lib/playback";
@@ -107,8 +107,8 @@ function ArchivePicker({
   onPlayArchive,
 }: Pick<ArchiveCardProps, "result" | "onPlayArchive">) {
   const depthDays = Math.max(1, result.catchup_days ?? 1);
-  const [daysBack, setDaysBack] = useState(0);
-  const [time, setTime] = useState("20:00");
+  const [daysBack, setDaysBack] = useState(() => archivePickerDefault().daysBack);
+  const [time, setTime] = useState(() => archivePickerDefault().time);
   const now = new Date();
 
   const watchFrom = () => {

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -58,10 +58,16 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
           className="mt-1.5 flex items-center justify-between gap-2 text-[11px]"
         >
           <span className="text-text-secondary">{outcome.label}</span>
-          {outcome.ok ? (
+          {outcome.ok && outcome.depthVerified ? (
             <span className="flex items-center gap-1 font-medium text-green-400">
               <CircleCheck className="h-3 w-3" />
               OK{outcome.latencyMs != null ? ` \u00b7 ${outcome.latencyMs} ms` : ""}
+            </span>
+          ) : outcome.ok ? (
+            <span className="flex items-center gap-1 font-medium text-amber-400">
+              <CircleCheck className="h-3 w-3" />
+              {outcome.depthUnknown ? "Reachable" : "Unverified"}
+              {outcome.latencyMs != null ? ` \u00b7 ${outcome.latencyMs} ms` : ""}
             </span>
           ) : (
             <span

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -4,6 +4,7 @@ import type { ArchivePlayOptions, ArchiveSession } from "../hooks/useStreamPlaye
 import { archiveTitle, hasArchive } from "../lib/archive";
 import { probeChannelArchive } from "../lib/archiveProbe";
 import { ensureEpgLoaded } from "../lib/epgLoader";
+import { isSingleConnectionPlaylist } from "../lib/playback";
 import { isScanActive } from "../lib/scanState";
 import { getEpgProgrammes } from "../lib/tauri";
 import { dayLabel, timeLabel } from "../lib/timeFormat";
@@ -21,11 +22,20 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
   const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
   const scanState = useAppStore((state) => state.scanState);
   const archiveGuideTestRunning = useAppStore((state) => state.archiveGuideTestRunning);
+  const playlist = useAppStore((state) => state.playlist);
+  const playIntentActive = useAppStore((state) => state.playIntentActive);
+  const castActive = useAppStore((state) => state.castActive);
   const anotherProbeRunning = useAppStore((state) =>
     Object.values(state.archiveProbes).some((probe) => probe.running),
   );
   const running = entry?.running ?? false;
-  const disabled = archiveGuideTestRunning || anotherProbeRunning || isScanActive(scanState);
+  const playbackBlocksProbe =
+    (playIntentActive || castActive) && isSingleConnectionPlaylist(playlist);
+  const disabled =
+    archiveGuideTestRunning ||
+    anotherProbeRunning ||
+    isScanActive(scanState) ||
+    playbackBlocksProbe;
   const outcomes = entry?.outcomes ?? [];
 
   const runProbe = () => {
@@ -33,7 +43,8 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
     if (
       isScanActive(state.scanState) ||
       state.archiveGuideTestRunning ||
-      Object.values(state.archiveProbes).some((probe) => probe.running)
+      Object.values(state.archiveProbes).some((probe) => probe.running) ||
+      ((state.playIntentActive || state.castActive) && isSingleConnectionPlaylist(state.playlist))
     ) {
       return;
     }
@@ -45,7 +56,13 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
       <button
         type="button"
         disabled={disabled}
-        title={isScanActive(scanState) ? "Wait for the scan to finish" : undefined}
+        title={
+          isScanActive(scanState)
+            ? "Wait for the scan to finish"
+            : playbackBlocksProbe
+              ? "Stop playback before testing catch-up"
+              : undefined
+        }
         onClick={runProbe}
         className="flex w-full items-center justify-center gap-1.5 rounded-md bg-btn px-3 py-1.5 text-[12px] font-medium text-text-primary border border-border-app shadow-sm hover:bg-btn-hover transition-colors disabled:opacity-40"
       >

--- a/src/components/ArchiveCard.tsx
+++ b/src/components/ArchiveCard.tsx
@@ -20,17 +20,19 @@ function ArchiveProbe({ result }: { result: ChannelResult }) {
   const entry = useAppStore((state) => state.archiveProbes[result.index]);
   const setArchiveProbe = useAppStore((state) => state.setArchiveProbe);
   const scanState = useAppStore((state) => state.scanState);
+  const archiveGuideTestRunning = useAppStore((state) => state.archiveGuideTestRunning);
   const anotherProbeRunning = useAppStore((state) =>
     Object.values(state.archiveProbes).some((probe) => probe.running),
   );
   const running = entry?.running ?? false;
-  const disabled = anotherProbeRunning || isScanActive(scanState);
+  const disabled = archiveGuideTestRunning || anotherProbeRunning || isScanActive(scanState);
   const outcomes = entry?.outcomes ?? [];
 
   const runProbe = () => {
     const state = useAppStore.getState();
     if (
       isScanActive(state.scanState) ||
+      state.archiveGuideTestRunning ||
       Object.values(state.archiveProbes).some((probe) => probe.running)
     ) {
       return;

--- a/src/components/ChannelRow.tsx
+++ b/src/components/ChannelRow.tsx
@@ -1,6 +1,7 @@
 import { Radio, Tv } from "lucide-react";
 import { memo, useEffect, useMemo, useState } from "react";
 import { archiveBadgeText, archiveTitle } from "../lib/archive";
+import { archiveVerdict, measuredDepthDays } from "../lib/archiveVerification";
 import { channelLogoPixels, channelRowHeightPixels } from "../lib/channelLogoSize";
 import { getChannelErrorReason } from "../lib/channelResults";
 import { extractTvgLogoUrl, normalizeTvgLogoUrl } from "../lib/extinf";
@@ -8,6 +9,7 @@ import { useLogoCacheStatus } from "../lib/logoCache";
 import { detectChannelProtocol } from "../lib/streamProtocol";
 import type { ColumnDefinition } from "../lib/tableColumns";
 import type { ChannelLogoSize, ChannelResult } from "../lib/types";
+import { useAppStore } from "../store";
 import { StatusBadge } from "./StatusBadge";
 
 function formatLatency(latencyMs: number): string {
@@ -69,6 +71,7 @@ function ChannelRowImpl({
   const errorReason = getChannelErrorReason(result);
   const drmStatusTitle = result.drm_system ? `DRM: ${result.drm_system}` : "DRM-protected stream";
   const streamProtocol = useMemo(() => detectChannelProtocol(result), [result]);
+  const probeEntry = useAppStore((s) => s.archiveProbes[result.index]);
 
   useEffect(() => {
     setLogoLoadFailed(false);
@@ -204,12 +207,34 @@ function ChannelRowImpl({
         if (!badge) {
           return <span className="text-text-secondary tabular-nums">—</span>;
         }
+        const verdict = archiveVerdict(result, probeEntry);
+        const chipClass = {
+          advertised: "bg-violet-500/15 text-violet-300 ring-violet-500/30",
+          verified: "bg-green-500/15 text-green-300 ring-green-500/30",
+          shallower: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+          broken: "bg-red-500/15 text-red-300 ring-red-500/30",
+        }[verdict];
+        const measured = verdict === "shallower" ? measuredDepthDays(probeEntry) : null;
+        const chipText =
+          verdict === "verified"
+            ? `✓ ${badge}`
+            : verdict === "shallower"
+              ? `⚠ ${measured ?? "?"}/${result.catchup_days ?? "?"}d`
+              : verdict === "broken"
+                ? `✕ ${badge}`
+                : badge;
+        const verdictTitle =
+          verdict === "advertised"
+            ? null
+            : verdict === "shallower"
+              ? `Verified depth ${measured ?? "?"} of ${result.catchup_days ?? "?"} days`
+              : `Archive ${verdict}`;
         return (
           <span
-            className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-violet-300 ring-1 ring-violet-500/30 tabular-nums"
-            title={archiveTitle(result) ?? undefined}
+            className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.06em] ring-1 tabular-nums ${chipClass}`}
+            title={[archiveTitle(result), verdictTitle].filter(Boolean).join(" · ") || undefined}
           >
-            {badge}
+            {chipText}
           </span>
         );
       }

--- a/src/components/ChannelRow.tsx
+++ b/src/components/ChannelRow.tsx
@@ -215,11 +215,12 @@ function ChannelRowImpl({
           broken: "bg-red-500/15 text-red-300 ring-red-500/30",
         }[verdict];
         const measured = verdict === "shallower" ? measuredDepthDays(probeEntry) : null;
+        const measuredLabel = measured != null && measured < 1 ? "<1" : measured;
         const chipText =
           verdict === "verified"
             ? `✓ ${badge}`
             : verdict === "shallower"
-              ? `⚠ ${measured ?? "?"}/${result.catchup_days ?? "?"}d`
+              ? `⚠ ${measuredLabel ?? "?"}/${result.catchup_days ?? "?"}d`
               : verdict === "broken"
                 ? `✕ ${badge}`
                 : badge;
@@ -227,7 +228,9 @@ function ChannelRowImpl({
           verdict === "advertised"
             ? null
             : verdict === "shallower"
-              ? `Verified depth ${measured ?? "?"} of ${result.catchup_days ?? "?"} days`
+              ? measured != null && measured < 1
+                ? `Verified depth less than 1 of ${result.catchup_days ?? "?"} days`
+                : `Verified depth ${measured ?? "?"} of ${result.catchup_days ?? "?"} days`
               : `Archive ${verdict}`;
         return (
           <span

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -948,11 +948,13 @@ export function ChannelTable({
       return;
     }
     void (async () => {
+      const generation = useAppStore.getState().archiveProbeGeneration;
       // Sequential on purpose: IPTV providers commonly cap concurrent
       // connections, and each probe already opens up to two archive URLs.
       for (const target of targets) {
+        if (useAppStore.getState().archiveProbeGeneration !== generation) break;
         await probeChannelArchive(target, (entry) =>
-          useAppStore.getState().setArchiveProbe(target.index, entry),
+          useAppStore.getState().setArchiveProbe(generation, target.index, entry),
         );
       }
     })();

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -141,6 +141,7 @@ export function ChannelTable({
   const groupFilter = useAppStore((s) => s.groupFilter);
   const statusFilter = useAppStore((s) => s.statusFilter);
   const scanState = useAppStore((s) => s.scanState);
+  const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
   const archiveProbeRunning = useAppStore((s) =>
     Object.values(s.archiveProbes).some((entry) => entry.running),
   );
@@ -937,7 +938,7 @@ export function ChannelTable({
   }, [contextMenuState]);
 
   const handleTestCatchup = useCallback(() => {
-    if (isScanActive(scanState) || archiveProbeRunning) {
+    if (isScanActive(scanState) || archiveGuideTestRunning || archiveProbeRunning) {
       setContextMenuState(null);
       return;
     }
@@ -955,7 +956,7 @@ export function ChannelTable({
         );
       }
     })();
-  }, [archiveProbeRunning, getSelectedChannels, scanState]);
+  }, [archiveGuideTestRunning, archiveProbeRunning, getSelectedChannels, scanState]);
 
   const handleCopyChannelName = useCallback(async () => {
     if (!contextMenuState) return;
@@ -1477,7 +1478,9 @@ export function ChannelTable({
               <>
                 <button
                   onClick={handleTestCatchup}
-                  disabled={isScanActive(scanState) || archiveProbeRunning}
+                  disabled={
+                    isScanActive(scanState) || archiveGuideTestRunning || archiveProbeRunning
+                  }
                   className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover disabled:opacity-50 disabled:pointer-events-none"
                   type="button"
                 >

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -141,6 +141,9 @@ export function ChannelTable({
   const groupFilter = useAppStore((s) => s.groupFilter);
   const statusFilter = useAppStore((s) => s.statusFilter);
   const scanState = useAppStore((s) => s.scanState);
+  const archiveProbeRunning = useAppStore((s) =>
+    Object.values(s.archiveProbes).some((entry) => entry.running),
+  );
   const isMac = useAppStore((s) => s.isMac);
   const channelLogoSize = useAppStore((s) => s.settings.channel_logo_size);
   const isPlaying = useAppStore((s) => s.playIntentActive);
@@ -934,6 +937,10 @@ export function ChannelTable({
   }, [contextMenuState]);
 
   const handleTestCatchup = useCallback(() => {
+    if (isScanActive(scanState) || archiveProbeRunning) {
+      setContextMenuState(null);
+      return;
+    }
     const targets = getSelectedChannels().filter(hasArchive);
     setContextMenuState(null);
     if (targets.length === 0) {
@@ -948,7 +955,7 @@ export function ChannelTable({
         );
       }
     })();
-  }, [getSelectedChannels]);
+  }, [archiveProbeRunning, getSelectedChannels, scanState]);
 
   const handleCopyChannelName = useCallback(async () => {
     if (!contextMenuState) return;
@@ -1470,7 +1477,8 @@ export function ChannelTable({
               <>
                 <button
                   onClick={handleTestCatchup}
-                  className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover"
+                  disabled={isScanActive(scanState) || archiveProbeRunning}
+                  className="w-full text-left px-3 py-2 text-[13px] hover:bg-btn-hover disabled:opacity-50 disabled:pointer-events-none"
                   type="button"
                 >
                   Test Catch-up ({archiveCount})

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -3,7 +3,11 @@ import { ChevronLeft, ChevronRight, CircleCheck, CircleX, LoaderCircle, Play } f
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { ArchivePlayOptions } from "../hooks/useStreamPlayer";
 import { archiveBadgeText, hasArchive } from "../lib/archive";
-import { type ArchiveProbeOutcome, probeArchivePoint } from "../lib/archiveProbe";
+import {
+  type ArchiveProbeOutcome,
+  probeArchivePoint,
+  verifyArchivePointResponse,
+} from "../lib/archiveProbe";
 import { fetchGuideProgrammes } from "../lib/epgLoader";
 import { filterResultsShared } from "../lib/filters";
 import { isSingleConnectionPlaylist } from "../lib/playback";
@@ -20,6 +24,17 @@ const MAX_GUIDE_DEPTH_DAYS = 14;
 interface GuideSelection {
   result: ChannelResult;
   programme: EpgProgramme;
+}
+
+function isProgrammePlayable(selection: GuideSelection, nowEpochS: number): boolean {
+  const earliestPlayable =
+    selection.result.catchup_days != null
+      ? nowEpochS - selection.result.catchup_days * 86_400
+      : null;
+  return (
+    selection.programme.start <= nowEpochS &&
+    (earliestPlayable == null || selection.programme.start >= earliestPlayable)
+  );
 }
 
 function selectionKey(selection: GuideSelection | null): string | null {
@@ -246,11 +261,11 @@ export function GuideView({
     ) {
       return;
     }
-    state.setExternalPlaybackActive(false);
     const target = selection;
     const playlistAtStart = state.playlist;
     const now = Math.floor(Date.now() / 1000);
     if (target.programme.start > now) return;
+    state.setExternalPlaybackActive(false);
     setTesting(true);
     setTestOutcome(null);
     state.setArchiveGuideTestRunning(true);
@@ -261,7 +276,8 @@ export function GuideView({
     };
     let outcome: ArchiveProbeOutcome | null = null;
     try {
-      outcome = await probeArchivePoint(target.result, point, now);
+      const probed = await probeArchivePoint(target.result, point, now);
+      outcome = probed ? verifyArchivePointResponse(probed) : null;
     } catch (error) {
       outcome = {
         label: point.label,
@@ -291,6 +307,7 @@ export function GuideView({
     archiveGuideTestRunning ||
     archiveProbeRunning ||
     ((playIntentActive || castActive) && isSingleConnectionPlaylist(playlist));
+  const selectionPlayable = selection != null && isProgrammePlayable(selection, nowEpochS);
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },
@@ -343,10 +360,15 @@ export function GuideView({
         </div>
         <div className="ml-auto flex min-w-0 items-center gap-2">
           {testOutcome &&
-            (testOutcome.ok ? (
+            (testOutcome.ok && testOutcome.depthVerified ? (
               <span className="flex items-center gap-1 text-[11px] font-medium text-green-400">
                 <CircleCheck className="h-3 w-3" />
                 OK{testOutcome.latencyMs != null ? ` · ${testOutcome.latencyMs} ms` : ""}
+              </span>
+            ) : testOutcome.ok ? (
+              <span className="flex items-center gap-1 text-[11px] font-medium text-amber-400">
+                <CircleCheck className="h-3 w-3" />
+                Unverified{testOutcome.latencyMs != null ? ` · ${testOutcome.latencyMs} ms` : ""}
               </span>
             ) : (
               <span
@@ -365,8 +387,10 @@ export function GuideView({
               </span>
               <button
                 type="button"
+                disabled={!selectionPlayable}
                 onClick={() => activate(selection)}
-                className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors"
+                title={selectionPlayable ? undefined : "This programme is outside catch-up range"}
+                className="flex shrink-0 items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-blue-500 transition-colors disabled:opacity-40"
               >
                 <Play className="h-3 w-3" />
                 Play

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -237,13 +237,14 @@ export function GuideView({
     }
     const target = selection;
     const playlistAtStart = state.playlist;
+    const now = Math.floor(Date.now() / 1000);
+    if (target.programme.start > now) return;
     setTesting(true);
     setTestOutcome(null);
     state.setArchiveGuideTestRunning(true);
-    const now = Math.floor(Date.now() / 1000);
     const point = {
       label: timeLabel(target.programme.start),
-      daysBack: Math.max(0, Math.round((now - target.programme.start) / 86_400)),
+      daysBack: Math.round((now - target.programme.start) / 86_400),
       startEpochS: target.programme.start,
     };
     let outcome: ArchiveProbeOutcome | null = null;

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -6,6 +6,7 @@ import { archiveBadgeText, hasArchive } from "../lib/archive";
 import { type ArchiveProbeOutcome, probeArchivePoint } from "../lib/archiveProbe";
 import { fetchGuideProgrammes } from "../lib/epgLoader";
 import { filterResultsShared } from "../lib/filters";
+import { isScanActive } from "../lib/scanState";
 import { isInputLikeTarget } from "../lib/shortcuts";
 import { dayLabel, startOfDayEpochS, timeLabel } from "../lib/timeFormat";
 import type { ChannelResult, EpgProgramme } from "../lib/types";
@@ -132,6 +133,11 @@ export function GuideView({
   const setViewMode = useAppStore((s) => s.setViewMode);
   const guideFocusChannelIndex = useAppStore((s) => s.guideFocusChannelIndex);
   const setGuideFocusChannelIndex = useAppStore((s) => s.setGuideFocusChannelIndex);
+  const scanState = useAppStore((s) => s.scanState);
+  const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveProbeRunning = useAppStore((s) =>
+    Object.values(s.archiveProbes).some((entry) => entry.running),
+  );
 
   const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
 
@@ -213,21 +219,43 @@ export function GuideView({
 
   const runTest = async () => {
     if (!selection) return;
+    const state = useAppStore.getState();
+    if (
+      isScanActive(state.scanState) ||
+      state.archiveVerifyRun ||
+      Object.values(state.archiveProbes).some((entry) => entry.running)
+    ) {
+      return;
+    }
+    const target = selection;
     setTesting(true);
     setTestOutcome(null);
+    state.setArchiveProbe(target.result.index, {
+      running: true,
+      outcomes: [],
+      checkedAt: null,
+    });
     const now = Math.floor(Date.now() / 1000);
     const outcome = await probeArchivePoint(
-      selection.result,
+      target.result,
       {
-        label: timeLabel(selection.programme.start),
-        daysBack: Math.max(0, Math.round((now - selection.programme.start) / 86_400)),
-        startEpochS: selection.programme.start,
+        label: timeLabel(target.programme.start),
+        daysBack: Math.max(0, Math.round((now - target.programme.start) / 86_400)),
+        startEpochS: target.programme.start,
       },
       now,
     );
+    useAppStore.getState().setArchiveProbe(target.result.index, {
+      running: false,
+      outcomes: outcome ? [outcome] : [],
+      checkedAt: now,
+    });
     setTestOutcome(outcome);
     setTesting(false);
   };
+
+  const testBlocked =
+    testing || isScanActive(scanState) || archiveVerifyRun !== null || archiveProbeRunning;
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },
@@ -310,7 +338,7 @@ export function GuideView({
               </button>
               <button
                 type="button"
-                disabled={testing}
+                disabled={testBlocked}
                 onClick={runTest}
                 className="shrink-0 rounded-md border border-border-app bg-btn px-2.5 py-1 text-[11px] font-medium text-text-primary hover:bg-btn-hover transition-colors disabled:opacity-40"
               >

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -128,6 +128,7 @@ export function GuideView({
   onPlayArchive: (result: ChannelResult, options: ArchivePlayOptions) => void;
 }) {
   const flatResults = useAppStore((s) => s.flatResults);
+  const playlist = useAppStore((s) => s.playlist);
   const search = useAppStore((s) => s.search);
   const groupFilter = useAppStore((s) => s.groupFilter);
   const setViewMode = useAppStore((s) => s.setViewMode);
@@ -135,6 +136,7 @@ export function GuideView({
   const setGuideFocusChannelIndex = useAppStore((s) => s.setGuideFocusChannelIndex);
   const scanState = useAppStore((s) => s.scanState);
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
   const archiveProbeRunning = useAppStore((s) =>
     Object.values(s.archiveProbes).some((entry) => entry.running),
   );
@@ -159,6 +161,11 @@ export function GuideView({
   const [selection, setSelection] = useState<GuideSelection | null>(null);
   const [testOutcome, setTestOutcome] = useState<ArchiveProbeOutcome | null>(null);
   const [testing, setTesting] = useState(false);
+
+  useEffect(() => {
+    setSelection(null);
+    setTestOutcome(null);
+  }, [playlist]);
 
   const windowFrom = startOfDayEpochS(daysAgo) + windowStartHour * 3600;
   const windowTo = windowFrom + WINDOW_HOURS * 3600;
@@ -223,39 +230,49 @@ export function GuideView({
     if (
       isScanActive(state.scanState) ||
       state.archiveVerifyRun ||
+      state.archiveGuideTestRunning ||
       Object.values(state.archiveProbes).some((entry) => entry.running)
     ) {
       return;
     }
     const target = selection;
+    const playlistAtStart = state.playlist;
     setTesting(true);
     setTestOutcome(null);
-    state.setArchiveProbe(target.result.index, {
-      running: true,
-      outcomes: [],
-      checkedAt: null,
-    });
+    state.setArchiveGuideTestRunning(true);
     const now = Math.floor(Date.now() / 1000);
-    const outcome = await probeArchivePoint(
-      target.result,
-      {
-        label: timeLabel(target.programme.start),
-        daysBack: Math.max(0, Math.round((now - target.programme.start) / 86_400)),
-        startEpochS: target.programme.start,
-      },
-      now,
-    );
-    useAppStore.getState().setArchiveProbe(target.result.index, {
-      running: false,
-      outcomes: outcome ? [outcome] : [],
-      checkedAt: now,
-    });
-    setTestOutcome(outcome);
-    setTesting(false);
+    const point = {
+      label: timeLabel(target.programme.start),
+      daysBack: Math.max(0, Math.round((now - target.programme.start) / 86_400)),
+      startEpochS: target.programme.start,
+    };
+    let outcome: ArchiveProbeOutcome | null = null;
+    try {
+      outcome = await probeArchivePoint(target.result, point, now);
+    } catch (error) {
+      outcome = {
+        label: point.label,
+        daysBack: point.daysBack,
+        ok: false,
+        latencyMs: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      const currentState = useAppStore.getState();
+      currentState.setArchiveGuideTestRunning(false);
+      if (currentState.playlist === playlistAtStart) {
+        setTestOutcome(outcome);
+      }
+      setTesting(false);
+    }
   };
 
   const testBlocked =
-    testing || isScanActive(scanState) || archiveVerifyRun !== null || archiveProbeRunning;
+    testing ||
+    isScanActive(scanState) ||
+    archiveVerifyRun !== null ||
+    archiveGuideTestRunning ||
+    archiveProbeRunning;
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -254,6 +254,8 @@ export function GuideView({
         label: point.label,
         daysBack: point.daysBack,
         ok: false,
+        depthVerified: false,
+        responseUrl: null,
         latencyMs: null,
         error: error instanceof Error ? error.message : String(error),
       };

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -6,6 +6,7 @@ import { archiveBadgeText, hasArchive } from "../lib/archive";
 import { type ArchiveProbeOutcome, probeArchivePoint } from "../lib/archiveProbe";
 import { fetchGuideProgrammes } from "../lib/epgLoader";
 import { filterResultsShared } from "../lib/filters";
+import { isSingleConnectionPlaylist } from "../lib/playback";
 import { isScanActive } from "../lib/scanState";
 import { isInputLikeTarget } from "../lib/shortcuts";
 import { dayLabel, startOfDayEpochS, timeLabel } from "../lib/timeFormat";
@@ -140,6 +141,9 @@ export function GuideView({
   const archiveProbeRunning = useAppStore((s) =>
     Object.values(s.archiveProbes).some((entry) => entry.running),
   );
+  const playIntentActive = useAppStore((s) => s.playIntentActive);
+  const castActive = useAppStore((s) => s.castActive);
+  const externalPlaybackActive = useAppStore((s) => s.externalPlaybackActive);
 
   const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
 
@@ -231,7 +235,9 @@ export function GuideView({
       isScanActive(state.scanState) ||
       state.archiveVerifyRun ||
       state.archiveGuideTestRunning ||
-      Object.values(state.archiveProbes).some((entry) => entry.running)
+      Object.values(state.archiveProbes).some((entry) => entry.running) ||
+      ((state.playIntentActive || state.castActive || state.externalPlaybackActive) &&
+        isSingleConnectionPlaylist(state.playlist))
     ) {
       return;
     }
@@ -275,7 +281,9 @@ export function GuideView({
     isScanActive(scanState) ||
     archiveVerifyRun !== null ||
     archiveGuideTestRunning ||
-    archiveProbeRunning;
+    archiveProbeRunning ||
+    ((playIntentActive || castActive || externalPlaybackActive) &&
+      isSingleConnectionPlaylist(playlist));
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -159,7 +159,14 @@ export function GuideView({
   const playIntentActive = useAppStore((s) => s.playIntentActive);
   const castActive = useAppStore((s) => s.castActive);
 
-  const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
+  const [nowEpochS, setNowEpochS] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNowEpochS(Math.floor(Date.now() / 1000));
+    }, 60_000);
+    return () => window.clearInterval(interval);
+  }, []);
 
   const channels = useMemo(
     () => filterResultsShared(flatResults, search, groupFilter, "all").filter(hasArchive),

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -215,10 +215,15 @@ export function GuideView({
     if (!selection) return;
     setTesting(true);
     setTestOutcome(null);
+    const now = Math.floor(Date.now() / 1000);
     const outcome = await probeArchivePoint(
       selection.result,
-      { label: timeLabel(selection.programme.start), startEpochS: selection.programme.start },
-      Math.floor(Date.now() / 1000),
+      {
+        label: timeLabel(selection.programme.start),
+        daysBack: Math.max(0, Math.round((now - selection.programme.start) / 86_400)),
+        startEpochS: selection.programme.start,
+      },
+      now,
     );
     setTestOutcome(outcome);
     setTesting(false);

--- a/src/components/GuideView.tsx
+++ b/src/components/GuideView.tsx
@@ -143,7 +143,6 @@ export function GuideView({
   );
   const playIntentActive = useAppStore((s) => s.playIntentActive);
   const castActive = useAppStore((s) => s.castActive);
-  const externalPlaybackActive = useAppStore((s) => s.externalPlaybackActive);
 
   const nowEpochS = useMemo(() => Math.floor(Date.now() / 1000), []);
 
@@ -236,11 +235,18 @@ export function GuideView({
       state.archiveVerifyRun ||
       state.archiveGuideTestRunning ||
       Object.values(state.archiveProbes).some((entry) => entry.running) ||
-      ((state.playIntentActive || state.castActive || state.externalPlaybackActive) &&
-        isSingleConnectionPlaylist(state.playlist))
+      ((state.playIntentActive || state.castActive) && isSingleConnectionPlaylist(state.playlist))
     ) {
       return;
     }
+    if (
+      state.externalPlaybackActive &&
+      isSingleConnectionPlaylist(state.playlist) &&
+      !window.confirm("Close the external player before testing catch-up. Continue?")
+    ) {
+      return;
+    }
+    state.setExternalPlaybackActive(false);
     const target = selection;
     const playlistAtStart = state.playlist;
     const now = Math.floor(Date.now() / 1000);
@@ -262,6 +268,8 @@ export function GuideView({
         daysBack: point.daysBack,
         ok: false,
         depthVerified: false,
+        requestedStartEpochS: point.startEpochS,
+        requestUrl: target.result.url,
         responseUrl: null,
         latencyMs: null,
         error: error instanceof Error ? error.message : String(error),
@@ -282,8 +290,7 @@ export function GuideView({
     archiveVerifyRun !== null ||
     archiveGuideTestRunning ||
     archiveProbeRunning ||
-    ((playIntentActive || castActive || externalPlaybackActive) &&
-      isSingleConnectionPlaylist(playlist));
+    ((playIntentActive || castActive) && isSingleConnectionPlaylist(playlist));
 
   const hourLabels = Array.from(
     { length: WINDOW_HOURS },

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from "react";
 import { hasArchive } from "../lib/archive";
 import { archiveVerdict, measuredDepthDays } from "../lib/archiveVerification";
 import { cancelArchiveVerification, verifyAllArchives } from "../lib/archiveVerifyRun";
-import { blendOverallScore, computeCatchupScore } from "../lib/catchupScore";
+import { computeCatchupScore } from "../lib/catchupScore";
 import { summarizeEpgCoverage } from "../lib/epgCoverage";
 import { summarizeLanguageDistribution } from "../lib/languageDistribution";
 import { isSingleConnectionPlaylist } from "../lib/playback";
@@ -305,7 +305,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     playlist.channels.map((channel) => ({ language: channel.language })),
   );
   const displayScore = summary?.playlist_score ?? computedScore;
-  const ringScore = displayScore ? blendOverallScore(displayScore, catchupScore) : 0;
+  const ringScore = displayScore?.overall ?? 0;
   const ringPercent = clamp01(ringScore / 10);
   const ringRadius = 38;
   const ringCircumference = 2 * Math.PI * ringRadius;

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -6,6 +6,7 @@ import { cancelArchiveVerification, verifyAllArchives } from "../lib/archiveVeri
 import { blendOverallScore, computeCatchupScore } from "../lib/catchupScore";
 import { summarizeEpgCoverage } from "../lib/epgCoverage";
 import { summarizeLanguageDistribution } from "../lib/languageDistribution";
+import { isSingleConnectionPlaylist } from "../lib/playback";
 import {
   hasScanStarted,
   shouldShowContentCounts,
@@ -167,7 +168,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const archiveProbes = useAppStore((s) => s.archiveProbes);
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
   const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
+  const playIntentActive = useAppStore((s) => s.playIntentActive);
   const archiveProbeRunning = Object.values(archiveProbes).some((entry) => entry.running);
+  const playbackBlocksVerification = playIntentActive && isSingleConnectionPlaylist(playlist);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
   // Every hook below must run unconditionally: the "no playlist" early return
@@ -572,14 +575,19 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                   type="button"
                   onClick={() => void verifyAllArchives()}
                   disabled={
-                    isScanActive(scanState) || archiveGuideTestRunning || archiveProbeRunning
+                    playbackBlocksVerification ||
+                    isScanActive(scanState) ||
+                    archiveGuideTestRunning ||
+                    archiveProbeRunning
                   }
                   title={
-                    isScanActive(scanState)
-                      ? "Wait for the scan to finish"
-                      : archiveGuideTestRunning || archiveProbeRunning
-                        ? "Another catch-up verification is running"
-                        : undefined
+                    playbackBlocksVerification
+                      ? "Stop playback before verifying catch-up"
+                      : isScanActive(scanState)
+                        ? "Wait for the scan to finish"
+                        : archiveGuideTestRunning || archiveProbeRunning
+                          ? "Another catch-up verification is running"
+                          : undefined
                   }
                   className="rounded-md border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 text-[11px] font-medium text-violet-300 hover:bg-violet-500/20 transition-colors disabled:opacity-40 disabled:pointer-events-none"
                 >

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -169,8 +169,10 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
   const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
   const playIntentActive = useAppStore((s) => s.playIntentActive);
+  const castActive = useAppStore((s) => s.castActive);
   const archiveProbeRunning = Object.values(archiveProbes).some((entry) => entry.running);
-  const playbackBlocksVerification = playIntentActive && isSingleConnectionPlaylist(playlist);
+  const playbackBlocksVerification =
+    (playIntentActive || castActive) && isSingleConnectionPlaylist(playlist);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
   // Every hook below must run unconditionally: the "no playlist" early return
@@ -236,9 +238,9 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     }
     const buckets: Array<{ label: string; count: number }> = [
       { label: "<1 d", count: depths.filter((d) => d < 1).length },
-      { label: "1-2 d", count: depths.filter((d) => d >= 1 && d <= 2).length },
-      { label: "3-6 d", count: depths.filter((d) => d >= 3 && d <= 6).length },
-      { label: "7 d", count: depths.filter((d) => d === 7).length },
+      { label: "1-2 d", count: depths.filter((d) => d >= 1 && d < 3).length },
+      { label: "3-6 d", count: depths.filter((d) => d >= 3 && d < 7).length },
+      { label: "7 d", count: depths.filter((d) => d >= 7 && d < 8).length },
       { label: "8+ d", count: depths.filter((d) => d >= 8).length },
     ];
     const medianLatency = median(latencies);
@@ -601,7 +603,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                   {catchupStats.advertised}
                 </span>
                 <span className="text-text-tertiary uppercase text-[9px] tracking-[0.04em]">
-                  advertise
+                  advertised
                 </span>
               </div>
               <div className="rounded-md bg-input/60 px-2 py-1.5">

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -166,6 +166,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const epgLoadSummary = useAppStore((s) => s.epgLoadSummary);
   const archiveProbes = useAppStore((s) => s.archiveProbes);
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
   const archiveProbeRunning = Object.values(archiveProbes).some((entry) => entry.running);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
@@ -570,11 +571,13 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                 <button
                   type="button"
                   onClick={() => void verifyAllArchives()}
-                  disabled={isScanActive(scanState) || archiveProbeRunning}
+                  disabled={
+                    isScanActive(scanState) || archiveGuideTestRunning || archiveProbeRunning
+                  }
                   title={
                     isScanActive(scanState)
                       ? "Wait for the scan to finish"
-                      : archiveProbeRunning
+                      : archiveGuideTestRunning || archiveProbeRunning
                         ? "Another catch-up verification is running"
                         : undefined
                   }

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -1,5 +1,9 @@
 import { BarChart3, X } from "lucide-react";
 import { memo, useMemo } from "react";
+import { hasArchive } from "../lib/archive";
+import { archiveVerdict, measuredDepthDays } from "../lib/archiveVerification";
+import { cancelArchiveVerification, verifyAllArchives } from "../lib/archiveVerifyRun";
+import { blendOverallScore, computeCatchupScore } from "../lib/catchupScore";
 import { summarizeEpgCoverage } from "../lib/epgCoverage";
 import { summarizeLanguageDistribution } from "../lib/languageDistribution";
 import {
@@ -159,6 +163,8 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const results = useAppStore((s) => s.flatResults);
   const progress = useAppStore((s) => s.progress);
   const epgLoadSummary = useAppStore((s) => s.epgLoadSummary);
+  const archiveProbes = useAppStore((s) => s.archiveProbes);
+  const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
   // Every hook below must run unconditionally: the "no playlist" early return
@@ -191,6 +197,56 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     () => summarizeEpgCoverage((channels ?? []).map((channel) => ({ tvg_id: channel.tvg_id }))),
     [channels],
   );
+
+  const catchupScore = useMemo(
+    () => computeCatchupScore(results, archiveProbes),
+    [results, archiveProbes],
+  );
+
+  const catchupStats = useMemo(() => {
+    const channels = results.filter(hasArchive);
+    if (channels.length === 0) return null;
+    let verified = 0;
+    let shallower = 0;
+    let broken = 0;
+    const depths: number[] = [];
+    const latencies: number[] = [];
+    for (const channel of channels) {
+      const entry = archiveProbes[channel.index];
+      const verdict = archiveVerdict(channel, entry);
+      if (verdict === "verified") {
+        verified += 1;
+        depths.push(Math.min(channel.catchup_days ?? measuredDepthDays(entry) ?? 1, 14));
+      } else if (verdict === "shallower") {
+        shallower += 1;
+        const measured = measuredDepthDays(entry);
+        if (measured != null) depths.push(Math.min(measured, 14));
+      } else if (verdict === "broken") {
+        broken += 1;
+      }
+      for (const outcome of entry?.outcomes ?? []) {
+        if (outcome.ok && outcome.latencyMs != null) latencies.push(outcome.latencyMs);
+      }
+    }
+    const buckets: Array<{ label: string; count: number }> = [
+      { label: "1-2 d", count: depths.filter((d) => d <= 2).length },
+      { label: "3-6 d", count: depths.filter((d) => d >= 3 && d <= 6).length },
+      { label: "7 d", count: depths.filter((d) => d === 7).length },
+      { label: "8+ d", count: depths.filter((d) => d >= 8).length },
+    ];
+    const sortedLatencies = [...latencies].sort((a, b) => a - b);
+    const medianLatency =
+      sortedLatencies.length > 0 ? sortedLatencies[Math.floor(sortedLatencies.length / 2)] : null;
+    return {
+      advertised: channels.length,
+      verified,
+      shallower,
+      broken,
+      tested: verified + shallower + broken,
+      buckets,
+      medianLatency,
+    };
+  }, [results, archiveProbes]);
 
   const protocolSummary = useMemo(() => {
     let http = 0;
@@ -242,7 +298,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
     playlist.channels.map((channel) => ({ language: channel.language })),
   );
   const displayScore = summary?.playlist_score ?? computedScore;
-  const ringScore = displayScore?.overall ?? 0;
+  const ringScore = displayScore ? blendOverallScore(displayScore, catchupScore) : 0;
   const ringPercent = clamp01(ringScore / 10);
   const ringRadius = 38;
   const ringCircumference = 2 * Math.PI * ringRadius;
@@ -362,6 +418,12 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                   <span className="text-text-tertiary">Quality</span>
                   <span className="text-text-primary">
                     {(displayScore?.quality ?? 0).toFixed(1)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between rounded-md bg-input/60 px-2 py-1 ring-1 ring-violet-500/25">
+                  <span className="text-violet-400">Catch-up</span>
+                  <span className={catchupScore != null ? "text-violet-300" : "text-text-tertiary"}>
+                    {catchupScore != null ? catchupScore.toFixed(1) : "N/A"}
                   </span>
                 </div>
               </div>
@@ -490,6 +552,109 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
             </div>
           </div>
         </section>
+
+        {catchupStats && (
+          <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">Catch-up</p>
+              {archiveVerifyRun ? (
+                <button
+                  type="button"
+                  onClick={cancelArchiveVerification}
+                  className="rounded-md border border-border-app bg-btn px-2 py-0.5 text-[11px] text-text-primary hover:bg-btn-hover transition-colors"
+                >
+                  {archiveVerifyRun.done}/{archiveVerifyRun.total} · Cancel
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void verifyAllArchives()}
+                  className="rounded-md border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 text-[11px] font-medium text-violet-300 hover:bg-violet-500/20 transition-colors"
+                >
+                  Verify ({catchupStats.advertised})
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-[11px]">
+              <div className="rounded-md bg-input/60 px-2 py-1.5">
+                <span className="block text-[15px] font-semibold text-violet-300 tabular-nums">
+                  {catchupStats.advertised}
+                </span>
+                <span className="text-text-tertiary uppercase text-[9px] tracking-[0.04em]">
+                  advertise
+                </span>
+              </div>
+              <div className="rounded-md bg-input/60 px-2 py-1.5">
+                <span className="block text-[15px] font-semibold text-green-400 tabular-nums">
+                  {catchupStats.verified}
+                </span>
+                <span className="text-text-tertiary uppercase text-[9px] tracking-[0.04em]">
+                  verified
+                </span>
+              </div>
+              <div className="rounded-md bg-input/60 px-2 py-1.5">
+                <span className="block text-[15px] font-semibold text-amber-400 tabular-nums">
+                  {catchupStats.shallower}
+                </span>
+                <span className="text-text-tertiary uppercase text-[9px] tracking-[0.04em]">
+                  shallower
+                </span>
+              </div>
+              <div className="rounded-md bg-input/60 px-2 py-1.5">
+                <span className="block text-[15px] font-semibold text-red-400 tabular-nums">
+                  {catchupStats.broken}
+                </span>
+                <span className="text-text-tertiary uppercase text-[9px] tracking-[0.04em]">
+                  broken
+                </span>
+              </div>
+            </div>
+            {catchupStats.tested > 0 && (
+              <>
+                <p className="mt-3 mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+                  Verified depth
+                </p>
+                {catchupStats.buckets.map((bucket) => {
+                  const maxCount = Math.max(1, ...catchupStats.buckets.map((b) => b.count));
+                  return (
+                    <div key={bucket.label} className="mb-1 flex items-center gap-2 text-[10px]">
+                      <span className="w-8 shrink-0 text-right text-text-secondary tabular-nums">
+                        {bucket.label}
+                      </span>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-btn/40">
+                        <div
+                          className="h-full rounded-full bg-violet-500"
+                          style={{ width: `${(bucket.count / maxCount) * 100}%` }}
+                        />
+                      </div>
+                      <span className="w-7 shrink-0 text-text-tertiary tabular-nums">
+                        {bucket.count}
+                      </span>
+                    </div>
+                  );
+                })}
+                <div className="mt-2 space-y-1 text-[12px]">
+                  <div className="flex items-center justify-between">
+                    <span className="text-text-tertiary">Median archive start</span>
+                    <span className="text-text-primary tabular-nums">
+                      {catchupStats.medianLatency != null
+                        ? `${Math.round(catchupStats.medianLatency)} ms`
+                        : "N/A"}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-text-tertiary">Average live start</span>
+                    <span className="text-text-primary tabular-nums">
+                      {latencyStats.average != null
+                        ? `${Math.round(latencyStats.average)} ms`
+                        : "N/A"}
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
+          </section>
+        )}
 
         <section className="rounded-xl border border-border-app bg-panel-subtle p-3">
           <p className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary mb-2">

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -11,6 +11,7 @@ import {
   shouldShowContentCounts,
   shouldShowLanguageDistribution,
 } from "../lib/playlistReportVisibility";
+import { isScanActive } from "../lib/scanState";
 import type { ChannelResult, PlaylistScore } from "../lib/types";
 import { useAppStore } from "../store";
 
@@ -165,6 +166,7 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const epgLoadSummary = useAppStore((s) => s.epgLoadSummary);
   const archiveProbes = useAppStore((s) => s.archiveProbes);
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveProbeRunning = Object.values(archiveProbes).some((entry) => entry.running);
   const summary = useAppStore((s) => s.summary);
   const scanState = useAppStore((s) => s.scanState);
   // Every hook below must run unconditionally: the "no playlist" early return
@@ -229,14 +231,13 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
       }
     }
     const buckets: Array<{ label: string; count: number }> = [
-      { label: "1-2 d", count: depths.filter((d) => d <= 2).length },
+      { label: "<1 d", count: depths.filter((d) => d < 1).length },
+      { label: "1-2 d", count: depths.filter((d) => d >= 1 && d <= 2).length },
       { label: "3-6 d", count: depths.filter((d) => d >= 3 && d <= 6).length },
       { label: "7 d", count: depths.filter((d) => d === 7).length },
       { label: "8+ d", count: depths.filter((d) => d >= 8).length },
     ];
-    const sortedLatencies = [...latencies].sort((a, b) => a - b);
-    const medianLatency =
-      sortedLatencies.length > 0 ? sortedLatencies[Math.floor(sortedLatencies.length / 2)] : null;
+    const medianLatency = median(latencies);
     return {
       advertised: channels.length,
       verified,
@@ -569,7 +570,15 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
                 <button
                   type="button"
                   onClick={() => void verifyAllArchives()}
-                  className="rounded-md border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 text-[11px] font-medium text-violet-300 hover:bg-violet-500/20 transition-colors"
+                  disabled={isScanActive(scanState) || archiveProbeRunning}
+                  title={
+                    isScanActive(scanState)
+                      ? "Wait for the scan to finish"
+                      : archiveProbeRunning
+                        ? "Another catch-up verification is running"
+                        : undefined
+                  }
+                  className="rounded-md border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 text-[11px] font-medium text-violet-300 hover:bg-violet-500/20 transition-colors disabled:opacity-40 disabled:pointer-events-none"
                 >
                   Verify ({catchupStats.advertised})
                 </button>

--- a/src/components/PlaylistReportPanel.tsx
+++ b/src/components/PlaylistReportPanel.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from "react";
 import { hasArchive } from "../lib/archive";
 import { archiveVerdict, measuredDepthDays } from "../lib/archiveVerification";
 import { cancelArchiveVerification, verifyAllArchives } from "../lib/archiveVerifyRun";
-import { computeCatchupScore } from "../lib/catchupScore";
+import { computeCatchupScore, withCatchupScore } from "../lib/catchupScore";
 import { summarizeEpgCoverage } from "../lib/epgCoverage";
 import { summarizeLanguageDistribution } from "../lib/languageDistribution";
 import { isSingleConnectionPlaylist } from "../lib/playback";
@@ -304,7 +304,8 @@ export const PlaylistReportPanel = memo(function PlaylistReportPanel({
   const showLanguageDistribution = shouldShowLanguageDistribution(
     playlist.channels.map((channel) => ({ language: channel.language })),
   );
-  const displayScore = summary?.playlist_score ?? computedScore;
+  const baseScore = summary?.playlist_score ?? computedScore;
+  const displayScore = baseScore ? withCatchupScore(baseScore, catchupScore) : null;
   const ringScore = displayScore?.overall ?? 0;
   const ringPercent = clamp01(ringScore / 10);
   const ringRadius = 38;

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, type ReactNode, startTransition, useDeferredValue, useMemo } from "react";
 import { hasArchive } from "../lib/archive";
+import { computeCatchupScore, withCatchupScore } from "../lib/catchupScore";
 import type { Channel } from "../lib/types";
 import { useAppStore } from "../store";
 import {
@@ -88,6 +89,8 @@ export const StatsPanel = memo(function StatsPanel() {
   const progress = useAppStore((s) => s.progress);
   const summary = useAppStore((s) => s.summary);
   const playlist = useAppStore((s) => s.playlist);
+  const results = useAppStore((s) => s.flatResults);
+  const archiveProbes = useAppStore((s) => s.archiveProbes);
   const totalChannels = playlist?.total_channels ?? 0;
   const channels = playlist?.channels ?? noChannels;
   const scanState = useAppStore((s) => s.scanState);
@@ -103,6 +106,10 @@ export const StatsPanel = memo(function StatsPanel() {
   const stats = summary ?? progress;
   const effectiveLowFpsCount = summary?.low_framerate ?? lowFpsCount;
   const effectiveMislabeledCount = summary?.mislabeled ?? mislabeledCount;
+  const displayScore = useMemo(() => {
+    if (!summary?.playlist_score) return null;
+    return withCatchupScore(summary.playlist_score, computeCatchupScore(results, archiveProbes));
+  }, [summary?.playlist_score, results, archiveProbes]);
 
   const { catchupCount, visibleCatchupCount } = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -215,10 +222,10 @@ export const StatsPanel = memo(function StatsPanel() {
           onClick={() => toggleFilter("catchup")}
         />
       )}
-      {summary?.playlist_score && (
+      {displayScore && (
         <Pill
           icon={null}
-          label={`Score ${summary.playlist_score.overall.toFixed(1)}/10`}
+          label={`Score ${displayScore.overall.toFixed(1)}/10`}
           color="blue"
           onClick={toggleReportPanel}
         />

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, type ReactNode, startTransition, useDeferredValue, useMemo } from "react";
 import { hasArchive } from "../lib/archive";
+import { blendOverallScore, computeCatchupScore } from "../lib/catchupScore";
 import type { Channel } from "../lib/types";
 import { useAppStore } from "../store";
 import {
@@ -98,6 +99,8 @@ export const StatsPanel = memo(function StatsPanel() {
   const setStatusFilter = useAppStore((s) => s.setStatusFilter);
   const toggleReportPanel = useAppStore((s) => s.toggleReportPanel);
   const selectedChannelIndices = useAppStore((s) => s.selectedChannelIndices);
+  const flatResults = useAppStore((s) => s.flatResults);
+  const archiveProbes = useAppStore((s) => s.archiveProbes);
   const search = useDeferredValue(useAppStore((s) => s.search));
   const groupFilter = useAppStore((s) => s.groupFilter);
   const stats = summary ?? progress;
@@ -136,6 +139,11 @@ export const StatsPanel = memo(function StatsPanel() {
     visibleCatchupCount === catchupCount
       ? `${catchupCount} catch-up`
       : `${visibleCatchupCount} of ${catchupCount} catch-up`;
+
+  const catchupScore = useMemo(
+    () => computeCatchupScore(flatResults, archiveProbes),
+    [flatResults, archiveProbes],
+  );
 
   const showSelectionInfo = selectedChannelIndices.length > 1 && catchupCount > 0;
   const showRightStatus =
@@ -218,7 +226,7 @@ export const StatsPanel = memo(function StatsPanel() {
       {summary?.playlist_score && (
         <Pill
           icon={null}
-          label={`Score ${summary.playlist_score.overall.toFixed(1)}/10`}
+          label={`Score ${blendOverallScore(summary.playlist_score, catchupScore).toFixed(1)}/10`}
           color="blue"
           onClick={toggleReportPanel}
         />

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,6 +1,5 @@
 import { memo, type ReactNode, startTransition, useDeferredValue, useMemo } from "react";
 import { hasArchive } from "../lib/archive";
-import { blendOverallScore, computeCatchupScore } from "../lib/catchupScore";
 import type { Channel } from "../lib/types";
 import { useAppStore } from "../store";
 import {
@@ -99,8 +98,6 @@ export const StatsPanel = memo(function StatsPanel() {
   const setStatusFilter = useAppStore((s) => s.setStatusFilter);
   const toggleReportPanel = useAppStore((s) => s.toggleReportPanel);
   const selectedChannelIndices = useAppStore((s) => s.selectedChannelIndices);
-  const flatResults = useAppStore((s) => s.flatResults);
-  const archiveProbes = useAppStore((s) => s.archiveProbes);
   const search = useDeferredValue(useAppStore((s) => s.search));
   const groupFilter = useAppStore((s) => s.groupFilter);
   const stats = summary ?? progress;
@@ -139,11 +136,6 @@ export const StatsPanel = memo(function StatsPanel() {
     visibleCatchupCount === catchupCount
       ? `${catchupCount} catch-up`
       : `${visibleCatchupCount} of ${catchupCount} catch-up`;
-
-  const catchupScore = useMemo(
-    () => computeCatchupScore(flatResults, archiveProbes),
-    [flatResults, archiveProbes],
-  );
 
   const showSelectionInfo = selectedChannelIndices.length > 1 && catchupCount > 0;
   const showRightStatus =
@@ -226,7 +218,7 @@ export const StatsPanel = memo(function StatsPanel() {
       {summary?.playlist_score && (
         <Pill
           icon={null}
-          label={`Score ${blendOverallScore(summary.playlist_score, catchupScore).toFixed(1)}/10`}
+          label={`Score ${summary.playlist_score.overall.toFixed(1)}/10`}
           color="blue"
           onClick={toggleReportPanel}
         />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -137,6 +137,7 @@ export const Toolbar = memo(function Toolbar({
   const statusFilter = useAppStore((s) => s.statusFilter);
   const viewMode = useAppStore((s) => s.viewMode);
   const setViewMode = useAppStore((s) => s.setViewMode);
+  const setVerifyCatchupAfterScan = useAppStore((s) => s.setVerifyCatchupAfterScan);
   const completedResults = useAppStore((s) => s.flatResults);
   const duplicateIndices = useAppStore((s) => s.duplicateIndices);
   const menuExportRequest = useAppStore((s) => s.menuExportRequest);
@@ -152,6 +153,8 @@ export const Toolbar = memo(function Toolbar({
   const openMenuRef = useRef<HTMLDivElement | null>(null);
   const groupSelectRef = useRef<HTMLSelectElement | null>(null);
   const [openMenuVisible, setOpenMenuVisible] = useState(false);
+  const scanMenuRef = useRef<HTMLDivElement | null>(null);
+  const [scanMenuVisible, setScanMenuVisible] = useState(false);
   const [groupSelectWidth, setGroupSelectWidth] = useState<number | null>(null);
 
   const filteredExportResults = useMemo(
@@ -216,11 +219,15 @@ export const Toolbar = memo(function Toolbar({
       if (openMenuRef.current && !openMenuRef.current.contains(event.target as Node)) {
         setOpenMenuVisible(false);
       }
+      if (scanMenuRef.current && !scanMenuRef.current.contains(event.target as Node)) {
+        setScanMenuVisible(false);
+      }
     };
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setOpenMenuVisible(false);
+        setScanMenuVisible(false);
       }
     };
 
@@ -476,16 +483,58 @@ export const Toolbar = memo(function Toolbar({
             )}
           </>
         ) : (
-          <button
-            onClick={onStartScan}
-            disabled={scanDisabledReason !== null}
-            title={scanDisabledReason ?? "Scan"}
-            className={btnWithOptionalText("toolbar-btn-primary")}
-            aria-label={scanLabel}
-          >
-            <IconScan className="w-[22px] h-[22px]" />
-            {showButtonText && scanLabel}
-          </button>
+          <div className="relative flex items-center" ref={scanMenuRef} data-no-window-drag>
+            <button
+              onClick={onStartScan}
+              disabled={scanDisabledReason !== null}
+              title={scanDisabledReason ?? "Scan"}
+              className={btnWithOptionalText("toolbar-btn-primary")}
+              aria-label={scanLabel}
+            >
+              <IconScan className="w-[22px] h-[22px]" />
+              {showButtonText && scanLabel}
+            </button>
+            {(statusOptionCounts.catchup ?? 0) > 0 && (
+              <button
+                type="button"
+                onClick={() => setScanMenuVisible((visible) => !visible)}
+                disabled={scanDisabledReason !== null}
+                className="toolbar-btn rounded-md px-0.5 py-2 disabled:opacity-40 disabled:pointer-events-none"
+                title="Scan options"
+                aria-label="Scan options"
+                aria-haspopup="menu"
+                aria-expanded={scanMenuVisible}
+              >
+                <SFChevronDown className="w-3 h-3" />
+              </button>
+            )}
+            {scanMenuVisible && (
+              <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-lg border border-border-app bg-dropdown py-1 shadow-2xl">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setScanMenuVisible(false);
+                    setVerifyCatchupAfterScan(false);
+                    onStartScan();
+                  }}
+                  className="w-full px-3 py-2 text-left text-[13px] hover:bg-btn-hover"
+                >
+                  Scan
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setScanMenuVisible(false);
+                    setVerifyCatchupAfterScan(true);
+                    onStartScan();
+                  }}
+                  className="w-full px-3 py-2 text-left text-[13px] hover:bg-btn-hover"
+                >
+                  Scan + Verify Catch-up ({statusOptionCounts.catchup ?? 0})
+                </button>
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -55,7 +55,7 @@ interface ToolbarProps {
   onOpenXtream: () => void;
   onSavePlaylist: () => void;
   onManageSavedPlaylists: () => void;
-  onStartScan: () => void;
+  onStartScan: (verifyCatchup?: boolean) => void;
   onPauseScan: () => void;
   onResumeScan: () => void;
   onStopScan: () => void;
@@ -137,7 +137,10 @@ export const Toolbar = memo(function Toolbar({
   const statusFilter = useAppStore((s) => s.statusFilter);
   const viewMode = useAppStore((s) => s.viewMode);
   const setViewMode = useAppStore((s) => s.setViewMode);
-  const setVerifyCatchupAfterScan = useAppStore((s) => s.setVerifyCatchupAfterScan);
+  const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveProbeRunning = useAppStore((s) =>
+    Object.values(s.archiveProbes).some((entry) => entry.running),
+  );
   const completedResults = useAppStore((s) => s.flatResults);
   const duplicateIndices = useAppStore((s) => s.duplicateIndices);
   const menuExportRequest = useAppStore((s) => s.menuExportRequest);
@@ -279,7 +282,11 @@ export const Toolbar = memo(function Toolbar({
   const hasResults = exportScopeCounts.all > 0;
   const scanLabel =
     selectedIndices.length > 0 ? `Scan Selected (${selectedIndices.length})` : "Scan";
-  const scanDisabledReason = !hasPlaylist ? "Open a playlist first" : scanBlockedReason;
+  const scanDisabledReason = !hasPlaylist
+    ? "Open a playlist first"
+    : archiveVerifyRun || archiveProbeRunning
+      ? "Wait for catch-up verification to finish"
+      : scanBlockedReason;
   const canSavePlaylist =
     hasPlaylist && currentSourceDescriptor !== null && currentSourceDescriptor.kind !== "stalker";
   const filtersDisabled = !hasPlaylist;
@@ -485,7 +492,7 @@ export const Toolbar = memo(function Toolbar({
         ) : (
           <div className="relative flex items-center" ref={scanMenuRef} data-no-window-drag>
             <button
-              onClick={onStartScan}
+              onClick={() => onStartScan(false)}
               disabled={scanDisabledReason !== null}
               title={scanDisabledReason ?? "Scan"}
               className={btnWithOptionalText("toolbar-btn-primary")}
@@ -514,8 +521,7 @@ export const Toolbar = memo(function Toolbar({
                   type="button"
                   onClick={() => {
                     setScanMenuVisible(false);
-                    setVerifyCatchupAfterScan(false);
-                    onStartScan();
+                    onStartScan(false);
                   }}
                   className="w-full px-3 py-2 text-left text-[13px] hover:bg-btn-hover"
                 >
@@ -525,8 +531,7 @@ export const Toolbar = memo(function Toolbar({
                   type="button"
                   onClick={() => {
                     setScanMenuVisible(false);
-                    setVerifyCatchupAfterScan(true);
-                    onStartScan();
+                    onStartScan(true);
                   }}
                   className="w-full px-3 py-2 text-left text-[13px] hover:bg-btn-hover"
                 >

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -306,10 +306,10 @@ export const Toolbar = memo(function Toolbar({
   }, [inScanSession]);
 
   useEffect(() => {
-    if (scanDisabledReason !== null) {
+    if (inScanSession || scanDisabledReason !== null) {
       setScanMenuVisible(false);
     }
-  }, [scanDisabledReason]);
+  }, [inScanSession, scanDisabledReason]);
 
   useLayoutEffect(() => {
     const select = groupSelectRef.current;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -139,6 +139,7 @@ export const Toolbar = memo(function Toolbar({
   const viewMode = useAppStore((s) => s.viewMode);
   const setViewMode = useAppStore((s) => s.setViewMode);
   const archiveVerifyRun = useAppStore((s) => s.archiveVerifyRun);
+  const archiveGuideTestRunning = useAppStore((s) => s.archiveGuideTestRunning);
   const archiveProbeRunning = useAppStore((s) =>
     Object.values(s.archiveProbes).some((entry) => entry.running),
   );
@@ -289,7 +290,7 @@ export const Toolbar = memo(function Toolbar({
     selectedIndices.length > 0 ? `Scan Selected (${selectedIndices.length})` : "Scan";
   const scanDisabledReason = !hasPlaylist
     ? "Open a playlist first"
-    : archiveVerifyRun || archiveProbeRunning
+    : archiveVerifyRun || archiveGuideTestRunning || archiveProbeRunning
       ? "Wait for catch-up verification to finish"
       : scanBlockedReason;
   const canSavePlaylist =
@@ -303,6 +304,12 @@ export const Toolbar = memo(function Toolbar({
       setOpenMenuVisible(false);
     }
   }, [inScanSession]);
+
+  useEffect(() => {
+    if (scanDisabledReason !== null) {
+      setScanMenuVisible(false);
+    }
+  }, [scanDisabledReason]);
 
   useLayoutEffect(() => {
     const select = groupSelectRef.current;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -29,6 +29,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { hasArchive } from "../lib/archive";
 import type { ExportScope } from "../lib/exportScope";
 import { countStatusOptions, filterResultsShared, sharedSearchTextCache } from "../lib/filters";
 import { measureUiPerf } from "../lib/perf";
@@ -201,6 +202,10 @@ export const Toolbar = memo(function Toolbar({
         separatePlaceholder,
       ),
     [completedResults, deferredSearch, groupFilter, duplicateIndices, separatePlaceholder],
+  );
+  const catchupChannelCount = useMemo(
+    () => completedResults.filter(hasArchive).length,
+    [completedResults],
   );
 
   const exportContextRef = useRef({
@@ -501,7 +506,7 @@ export const Toolbar = memo(function Toolbar({
               <IconScan className="w-[22px] h-[22px]" />
               {showButtonText && scanLabel}
             </button>
-            {(statusOptionCounts.catchup ?? 0) > 0 && (
+            {catchupChannelCount > 0 && (
               <button
                 type="button"
                 onClick={() => setScanMenuVisible((visible) => !visible)}
@@ -535,7 +540,7 @@ export const Toolbar = memo(function Toolbar({
                   }}
                   className="w-full px-3 py-2 text-left text-[13px] hover:bg-btn-hover"
                 >
-                  Scan + Verify Catch-up ({statusOptionCounts.catchup ?? 0})
+                  Scan + Verify Catch-up ({catchupChannelCount})
                 </button>
               </div>
             )}

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -76,7 +76,7 @@ export interface UseStreamPlayerReturn {
 }
 
 interface UseStreamPlayerOptions {
-  onPlaybackFailed?: (result: ChannelResult) => void;
+  onPlaybackFailed?: (result: ChannelResult, affectsChannelHealth: boolean) => void;
 }
 
 function readStoredVolume(): number {
@@ -413,10 +413,8 @@ export function useStreamPlayer(options?: UseStreamPlayerOptions): UseStreamPlay
       setIsPaused(false);
       setActiveChannelIndex(null);
       // A failed archive URL says nothing about the live channel's health, so
-      // never report it to the backend as a channel failure.
-      if (notifyBackend && !archiveSessionRef.current) {
-        onPlaybackFailedRef.current?.(result);
-      }
+      // let the caller distinguish it from a live channel failure.
+      onPlaybackFailedRef.current?.(result, notifyBackend && !archiveSessionRef.current);
       setArchiveSession(null);
     },
     [cleanup, clearRecoveryTimer, resetRecoveryUi],

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -140,3 +140,19 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       return defaultArchiveUrl(channel.url, window);
   }
 }
+
+/** How far back the sidebar picker starts: just under an hour ago. */
+export const ARCHIVE_PICKER_DEFAULT_BACK_S = 59 * 60 + 30;
+
+/**
+ * Default picker position: 59:30 before `now`, expressed as the day offset
+ * and local HH:MM the picker's controls use. A start in the future can never
+ * play, so the default always lands inside the archive.
+ */
+export function archivePickerDefault(now: Date = new Date()): { daysBack: number; time: string } {
+  const start = new Date(now.getTime() - ARCHIVE_PICKER_DEFAULT_BACK_S * 1000);
+  const dayOf = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const daysBack = Math.round((dayOf(now).getTime() - dayOf(start).getTime()) / 86_400_000);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return { daysBack, time: `${pad(start.getHours())}:${pad(start.getMinutes())}` };
+}

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -127,10 +127,7 @@ export function buildArchiveUrl(channel: ArchiveUrlFields, window: ArchiveWindow
       const start = Math.floor(window.startEpochS);
       const duration = Math.max(1, Math.floor(window.durationS));
       if (/\.m3u8(\?|$)/.test(channel.url)) {
-        return channel.url.replace(
-          /\/[^/?]+\.m3u8(\?|$)/,
-          `/archive-${start}-${duration}.m3u8$1`,
-        );
+        return channel.url.replace(/\/[^/?]+\.m3u8(\?|$)/, `/archive-${start}-${duration}.m3u8$1`);
       }
       if (/\.ts(\?|$)/.test(channel.url)) {
         return channel.url.replace(/\/[^/?]+\.ts(\?|$)/, `/timeshift_abs-${start}.ts$1`);

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -69,6 +69,17 @@ function responseMediaTimeMatchesRequest(outcome: ArchiveProbeOutcome): boolean 
   }
 }
 
+/** A point is verified only when returned media identifies the requested archive time. */
+export function verifyArchivePointResponse(outcome: ArchiveProbeOutcome): ArchiveProbeOutcome {
+  if (!outcome.ok) return outcome;
+  const mediaTimeMatches = responseMediaTimeMatchesRequest(outcome);
+  return {
+    ...outcome,
+    depthVerified: mediaTimeMatches === true,
+    depthUnknown: outcome.depthUnknown || mediaTimeMatches == null,
+  };
+}
+
 /** A deep response proves depth only when returned media identifies the requested archive time. */
 export function verifyArchiveDepthResponse(
   outcome: ArchiveProbeOutcome,

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -101,7 +101,9 @@ export async function probeArchivePoint(
       depthVerified: reachable && point.daysBack <= 0,
       depthUnknown: checked.status === "geoblocked_confirmed" && point.daysBack > 0,
       responseUrl: checked.stream_url,
-      latencyMs: checked.latency_ms,
+      // The quick check keeps the failed direct request's latency when a proxy
+      // confirms access, so it does not represent archive startup time.
+      latencyMs: checked.status === "geoblocked_confirmed" ? null : checked.latency_ms,
       error: reachable ? null : (checked.error_reason ?? checked.status),
     };
   } catch (error) {

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -43,7 +43,9 @@ function responseIdentity(responseUrl: string | null): string | null {
   }
 }
 
-const MEDIA_TIME_TOLERANCE_SECONDS = 3600;
+// The requested five-minute window may be segment-aligned, but must not
+// accept a live segment returned in place of the requested archive media.
+const MEDIA_TIME_TOLERANCE_SECONDS = 300;
 
 function responseMediaTimeMatchesRequest(outcome: ArchiveProbeOutcome): boolean | null {
   const response = responseIdentity(outcome.responseUrl);
@@ -185,7 +187,11 @@ export async function probeChannelArchive(
   onUpdate({ running: true, outcomes: [], checkedAt: null });
   for (const point of archiveProbePoints(result, nowEpochS)) {
     const probed = await probeArchivePoint(result, point, nowEpochS);
-    const outcome = probed ? verifyArchiveDepthResponse(probed, outcomes[0]) : null;
+    const outcome = probed
+      ? point.daysBack <= 0
+        ? verifyArchivePointResponse(probed)
+        : verifyArchiveDepthResponse(probed, outcomes[0])
+      : null;
     if (outcome) {
       outcomes.push(outcome);
       onUpdate({ running: true, outcomes: [...outcomes], checkedAt: null });

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -11,6 +11,10 @@ export interface ArchiveProbeOutcome {
   depthVerified: boolean;
   /** The probe reached through a proxy but cannot establish media identity. */
   depthUnknown?: boolean;
+  /** Archive start requested from the provider. */
+  requestedStartEpochS: number;
+  /** URL requested from the provider before redirects or manifest traversal. */
+  requestUrl: string;
   responseUrl: string | null;
   latencyMs: number | null;
   error: string | null;
@@ -39,7 +43,33 @@ function responseIdentity(responseUrl: string | null): string | null {
   }
 }
 
-/** A deep response proves depth when its successful request identifies a different archive window. */
+const MEDIA_TIME_TOLERANCE_SECONDS = 3600;
+
+function responseMediaTimeMatchesRequest(outcome: ArchiveProbeOutcome): boolean | null {
+  const response = responseIdentity(outcome.responseUrl);
+  const request = responseIdentity(outcome.requestUrl);
+  if (response == null || response === request) return null;
+
+  try {
+    const pathname = new URL(response).pathname;
+    const timestamps = Array.from(
+      pathname.matchAll(/(?:^|\D)(\d{13}|\d{10})(?=\D|$)/g),
+      (match) => {
+        const value = Number(match[1]);
+        return match[1].length === 13 ? value / 1000 : value;
+      },
+    );
+    if (timestamps.length === 0) return null;
+    return timestamps.some(
+      (timestamp) =>
+        Math.abs(timestamp - outcome.requestedStartEpochS) <= MEDIA_TIME_TOLERANCE_SECONDS,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** A deep response proves depth only when returned media identifies the requested archive time. */
 export function verifyArchiveDepthResponse(
   outcome: ArchiveProbeOutcome,
   near: ArchiveProbeOutcome | undefined,
@@ -47,9 +77,16 @@ export function verifyArchiveDepthResponse(
   if (!outcome.ok || outcome.daysBack <= 0) return outcome;
   const response = responseIdentity(outcome.responseUrl);
   const nearResponse = responseIdentity(near?.responseUrl ?? null);
+  const mediaTimeMatches = responseMediaTimeMatchesRequest(outcome);
+  const depthVerified =
+    response != null &&
+    nearResponse != null &&
+    response !== nearResponse &&
+    mediaTimeMatches === true;
   return {
     ...outcome,
-    depthVerified: response != null && nearResponse != null && response !== nearResponse,
+    depthVerified,
+    depthUnknown: outcome.depthUnknown || mediaTimeMatches == null,
   };
 }
 
@@ -100,6 +137,8 @@ export async function probeArchivePoint(
       ok: reachable,
       depthVerified: reachable && point.daysBack <= 0,
       depthUnknown: checked.status === "geoblocked_confirmed" && point.daysBack > 0,
+      requestedStartEpochS: point.startEpochS,
+      requestUrl: url,
       responseUrl: checked.stream_url,
       // The quick check keeps the failed direct request's latency when a proxy
       // confirms access, so it does not represent archive startup time.
@@ -112,6 +151,8 @@ export async function probeArchivePoint(
       daysBack: point.daysBack,
       ok: false,
       depthVerified: false,
+      requestedStartEpochS: point.startEpochS,
+      requestUrl: url,
       responseUrl: null,
       latencyMs: null,
       error: error instanceof Error ? error.message : String(error),

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -28,25 +28,10 @@ export interface ArchiveProbePoint {
   startEpochS: number;
 }
 
-const ARCHIVE_TIME_QUERY_PARAMS = [
-  "begin",
-  "duration",
-  "end",
-  "lutc",
-  "offset",
-  "start",
-  "timestamp",
-  "utc",
-  "utcend",
-];
-
 function responseIdentity(responseUrl: string | null): string | null {
   if (!responseUrl) return null;
   try {
     const parsed = new URL(responseUrl);
-    for (const param of ARCHIVE_TIME_QUERY_PARAMS) {
-      parsed.searchParams.delete(param);
-    }
     parsed.hash = "";
     return parsed.toString();
   } catch {
@@ -54,7 +39,7 @@ function responseIdentity(responseUrl: string | null): string | null {
   }
 }
 
-/** A deep response only proves depth when it resolves to different media. */
+/** A deep response proves depth when its successful request identifies a different archive window. */
 export function verifyArchiveDepthResponse(
   outcome: ArchiveProbeOutcome,
   near: ArchiveProbeOutcome | undefined,

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -1,5 +1,5 @@
 import { buildArchiveUrl } from "./archive";
-import { quickCheckChannel } from "./tauri";
+import { cancelQuickCheck, quickCheckChannel } from "./tauri";
 import type { ChannelResult } from "./types";
 
 export interface ArchiveProbeOutcome {
@@ -49,8 +49,7 @@ const MEDIA_TIME_TOLERANCE_SECONDS = 300;
 
 function responseMediaTimeMatchesRequest(outcome: ArchiveProbeOutcome): boolean | null {
   const response = responseIdentity(outcome.responseUrl);
-  const request = responseIdentity(outcome.requestUrl);
-  if (response == null || response === request) return null;
+  if (response == null) return null;
 
   try {
     const pathname = new URL(response).pathname;
@@ -123,6 +122,7 @@ export async function probeArchivePoint(
   result: ChannelResult,
   point: ArchiveProbePoint,
   nowEpochS: number,
+  signal?: AbortSignal,
 ): Promise<ArchiveProbeOutcome | null> {
   const url = buildArchiveUrl(result, {
     startEpochS: point.startEpochS,
@@ -132,14 +132,25 @@ export async function probeArchivePoint(
   if (!url) {
     return null;
   }
+  if (signal?.aborted) {
+    return null;
+  }
+  const requestId = crypto.randomUUID();
+  const cancel = () => {
+    void cancelQuickCheck(requestId);
+  };
+  signal?.addEventListener("abort", cancel, { once: true });
   try {
-    const checked = await quickCheckChannel({
-      ...result,
-      url,
-      content_type: "movie",
-      stream_url: null,
-      status: "pending",
-    });
+    const checked = await quickCheckChannel(
+      {
+        ...result,
+        url,
+        content_type: "movie",
+        stream_url: null,
+        status: "pending",
+      },
+      requestId,
+    );
     const reachable =
       checked.status === "alive" ||
       checked.status === "drm" ||
@@ -170,6 +181,8 @@ export async function probeArchivePoint(
       latencyMs: null,
       error: error instanceof Error ? error.message : String(error),
     };
+  } finally {
+    signal?.removeEventListener("abort", cancel);
   }
 }
 

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -4,6 +4,8 @@ import type { ChannelResult } from "./types";
 
 export interface ArchiveProbeOutcome {
   label: string;
+  /** How far back this point reached, in days (0 = the −1 h near point). */
+  daysBack: number;
   ok: boolean;
   latencyMs: number | null;
   error: string | null;
@@ -17,16 +19,20 @@ export interface ArchiveProbeEntry {
 
 export interface ArchiveProbePoint {
   label: string;
+  daysBack: number;
   startEpochS: number;
 }
 
 /** One hour back, plus a point just inside the advertised depth when known. */
 export function archiveProbePoints(result: ChannelResult, nowEpochS: number): ArchiveProbePoint[] {
-  const points: ArchiveProbePoint[] = [{ label: "Archive −1 h", startEpochS: nowEpochS - 3600 }];
+  const points: ArchiveProbePoint[] = [
+    { label: "Archive −1 h", daysBack: 0, startEpochS: nowEpochS - 3600 },
+  ];
   const depthDays = result.catchup_days;
   if (depthDays != null && depthDays > 0) {
     points.push({
       label: `Archive −${depthDays} d`,
+      daysBack: depthDays,
       startEpochS: nowEpochS - depthDays * 86_400 + 1800,
     });
   }
@@ -56,6 +62,7 @@ export async function probeArchivePoint(
     });
     return {
       label: point.label,
+      daysBack: point.daysBack,
       ok: checked.status === "alive",
       latencyMs: checked.latency_ms,
       error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
@@ -63,6 +70,7 @@ export async function probeArchivePoint(
   } catch (error) {
     return {
       label: point.label,
+      daysBack: point.daysBack,
       ok: false,
       latencyMs: null,
       error: error instanceof Error ? error.message : String(error),

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -9,6 +9,8 @@ export interface ArchiveProbeOutcome {
   ok: boolean;
   /** Whether this response identifies media distinct from the near probe. */
   depthVerified: boolean;
+  /** The probe reached through a proxy but cannot establish media identity. */
+  depthUnknown?: boolean;
   responseUrl: string | null;
   latencyMs: number | null;
   error: string | null;
@@ -112,6 +114,7 @@ export async function probeArchivePoint(
       daysBack: point.daysBack,
       ok: reachable,
       depthVerified: reachable && point.daysBack <= 0,
+      depthUnknown: checked.status === "geoblocked_confirmed" && point.daysBack > 0,
       responseUrl: checked.stream_url,
       latencyMs: checked.latency_ms,
       error: reachable ? null : (checked.error_reason ?? checked.status),

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -7,6 +7,9 @@ export interface ArchiveProbeOutcome {
   /** How far back this point reached, in days (0 = the −1 h near point). */
   daysBack: number;
   ok: boolean;
+  /** Whether this response identifies media distinct from the near probe. */
+  depthVerified: boolean;
+  responseUrl: string | null;
   latencyMs: number | null;
   error: string | null;
 }
@@ -21,6 +24,46 @@ export interface ArchiveProbePoint {
   label: string;
   daysBack: number;
   startEpochS: number;
+}
+
+const ARCHIVE_TIME_QUERY_PARAMS = [
+  "begin",
+  "duration",
+  "end",
+  "lutc",
+  "offset",
+  "start",
+  "timestamp",
+  "utc",
+  "utcend",
+];
+
+function responseIdentity(responseUrl: string | null): string | null {
+  if (!responseUrl) return null;
+  try {
+    const parsed = new URL(responseUrl);
+    for (const param of ARCHIVE_TIME_QUERY_PARAMS) {
+      parsed.searchParams.delete(param);
+    }
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return responseUrl;
+  }
+}
+
+/** A deep response only proves depth when it resolves to different media. */
+export function verifyArchiveDepthResponse(
+  outcome: ArchiveProbeOutcome,
+  near: ArchiveProbeOutcome | undefined,
+): ArchiveProbeOutcome {
+  if (!outcome.ok || outcome.daysBack <= 0) return outcome;
+  const response = responseIdentity(outcome.responseUrl);
+  const nearResponse = responseIdentity(near?.responseUrl ?? null);
+  return {
+    ...outcome,
+    depthVerified: response != null && nearResponse != null && response !== nearResponse,
+  };
 }
 
 /** One hour back, plus a point just inside the advertised depth when known. */
@@ -60,18 +103,26 @@ export async function probeArchivePoint(
       stream_url: null,
       status: "pending",
     });
+    const reachable =
+      checked.status === "alive" ||
+      checked.status === "drm" ||
+      checked.status === "geoblocked_confirmed";
     return {
       label: point.label,
       daysBack: point.daysBack,
-      ok: checked.status === "alive",
+      ok: reachable,
+      depthVerified: reachable && point.daysBack <= 0,
+      responseUrl: checked.stream_url,
       latencyMs: checked.latency_ms,
-      error: checked.status === "alive" ? null : (checked.error_reason ?? checked.status),
+      error: reachable ? null : (checked.error_reason ?? checked.status),
     };
   } catch (error) {
     return {
       label: point.label,
       daysBack: point.daysBack,
       ok: false,
+      depthVerified: false,
+      responseUrl: null,
       latencyMs: null,
       error: error instanceof Error ? error.message : String(error),
     };
@@ -91,7 +142,8 @@ export async function probeChannelArchive(
   const outcomes: ArchiveProbeOutcome[] = [];
   onUpdate({ running: true, outcomes: [], checkedAt: null });
   for (const point of archiveProbePoints(result, nowEpochS)) {
-    const outcome = await probeArchivePoint(result, point, nowEpochS);
+    const probed = await probeArchivePoint(result, point, nowEpochS);
+    const outcome = probed ? verifyArchiveDepthResponse(probed, outcomes[0]) : null;
     if (outcome) {
       outcomes.push(outcome);
       onUpdate({ running: true, outcomes: [...outcomes], checkedAt: null });

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -4,6 +4,7 @@ import {
   type ArchiveProbeOutcome,
   probeArchivePoint,
   verifyArchiveDepthResponse,
+  verifyArchivePointResponse,
 } from "./archiveProbe";
 import type { ChannelResult } from "./types";
 
@@ -24,6 +25,7 @@ export function archiveVerdict(
   const outcomes = entry?.outcomes ?? [];
   if (entry?.running || entry?.checkedAt == null || outcomes.length === 0) return "advertised";
   if (!outcomes.some((outcome) => outcome.ok)) return "broken";
+  if (!outcomes.some((outcome) => outcome.ok && outcome.depthVerified)) return "advertised";
   const advertisedDays = result.catchup_days;
   if (advertisedDays == null) return "verified";
   if (
@@ -98,7 +100,8 @@ export async function verifyChannelArchive(
   if (shouldCancel()) {
     return push(null, true, false);
   }
-  const near = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
+  const probedNear = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
+  const near = probedNear ? verifyArchivePointResponse(probedNear) : null;
   if (shouldCancel()) {
     return push(near, true, false);
   }
@@ -129,6 +132,10 @@ export async function verifyChannelArchive(
     return push(deep, true);
   }
   push(deep, false);
+
+  // Without a verified near point there is no working archive depth from
+  // which to start bisection. A reachable live stream is not archive evidence.
+  if (!near.depthVerified) return push(null, true);
 
   // The advertised depth lied; bisect between the working near point and the
   // failing deep point to estimate what the provider actually keeps.

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -37,8 +37,9 @@ export function measuredDepthDays(entry: ArchiveProbeEntry | undefined): number 
     .map((outcome) => outcome.daysBack);
   if (okDays.length === 0) return null;
   const deepest = Math.max(...okDays);
-  // The near point alone proves less than a day of archive.
-  return deepest === 0 ? 1 : deepest;
+  // The near point is one hour back; keep that sub-day evidence distinct from
+  // a probe that actually established a full day of archive.
+  return deepest === 0 ? 1 / 24 : deepest;
 }
 
 function probePointForDays(daysBack: number, nowEpochS: number) {
@@ -62,6 +63,7 @@ const MAX_BISECT_STEPS = 3;
 export async function verifyChannelArchive(
   result: ChannelResult,
   onUpdate: (entry: ArchiveProbeEntry) => void,
+  shouldCancel: () => boolean = () => false,
 ): Promise<ArchiveProbeEntry> {
   const nowEpochS = Math.floor(Date.now() / 1000);
   const outcomes: ArchiveProbeOutcome[] = [];
@@ -77,8 +79,11 @@ export async function verifyChannelArchive(
   };
 
   push(null, false);
+  if (shouldCancel()) {
+    return push(null, true);
+  }
   const near = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
-  if (!near?.ok) {
+  if (!near?.ok || shouldCancel()) {
     return push(near, true);
   }
   push(near, false);
@@ -88,12 +93,16 @@ export async function verifyChannelArchive(
     return push(null, true);
   }
 
+  if (shouldCancel()) {
+    return push(null, true);
+  }
+
   const deep = await probeArchivePoint(
     result,
     probePointForDays(advertisedDays, nowEpochS),
     nowEpochS,
   );
-  if (!deep || deep.ok) {
+  if (!deep || deep.ok || shouldCancel()) {
     return push(deep, true);
   }
   push(deep, false);
@@ -103,6 +112,7 @@ export async function verifyChannelArchive(
   let workingDays = 0;
   let failingDays = advertisedDays;
   for (let step = 0; step < MAX_BISECT_STEPS; step += 1) {
+    if (shouldCancel()) break;
     const midDays = Math.round((workingDays + failingDays) / 2);
     if (midDays <= workingDays || midDays >= failingDays) break;
     const outcome = await probeArchivePoint(

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -1,0 +1,122 @@
+import { hasArchive } from "./archive";
+import {
+  type ArchiveProbeEntry,
+  type ArchiveProbeOutcome,
+  probeArchivePoint,
+} from "./archiveProbe";
+import type { ChannelResult } from "./types";
+
+export type ArchiveVerdict = "advertised" | "verified" | "shallower" | "broken";
+
+/**
+ * Derive a channel's verification verdict from its probe outcomes:
+ * - no completed probes → still just "advertised"
+ * - nothing reachable → "broken"
+ * - the advertised depth answered → "verified"
+ * - otherwise the archive works but is shallower than advertised.
+ */
+export function archiveVerdict(
+  result: Pick<ChannelResult, "catchup" | "catchup_days" | "catchup_source">,
+  entry: ArchiveProbeEntry | undefined,
+): ArchiveVerdict {
+  if (!hasArchive(result)) return "advertised";
+  const outcomes = entry?.outcomes ?? [];
+  if (entry?.running || outcomes.length === 0) return "advertised";
+  if (!outcomes.some((outcome) => outcome.ok)) return "broken";
+  const advertisedDays = result.catchup_days;
+  if (advertisedDays == null) return "verified";
+  return outcomes.some((outcome) => outcome.ok && outcome.daysBack >= advertisedDays)
+    ? "verified"
+    : "shallower";
+}
+
+/** Deepest point that answered, in days; null without any successful probe. */
+export function measuredDepthDays(entry: ArchiveProbeEntry | undefined): number | null {
+  const okDays = (entry?.outcomes ?? [])
+    .filter((outcome) => outcome.ok)
+    .map((outcome) => outcome.daysBack);
+  if (okDays.length === 0) return null;
+  const deepest = Math.max(...okDays);
+  // The near point alone proves less than a day of archive.
+  return deepest === 0 ? 1 : deepest;
+}
+
+function probePointForDays(daysBack: number, nowEpochS: number) {
+  if (daysBack <= 0) {
+    return { label: "Archive −1 h", daysBack: 0, startEpochS: nowEpochS - 3600 };
+  }
+  return {
+    label: `Archive −${daysBack} d`,
+    daysBack,
+    startEpochS: nowEpochS - daysBack * 86_400 + 1800,
+  };
+}
+
+const MAX_BISECT_STEPS = 3;
+
+/**
+ * Verify one channel's archive: probe −1 h, then the advertised depth, and on
+ * a mismatch bisect a few points to estimate the real depth. Streams partial
+ * entries through `onUpdate`; points run sequentially (provider limits).
+ */
+export async function verifyChannelArchive(
+  result: ChannelResult,
+  onUpdate: (entry: ArchiveProbeEntry) => void,
+): Promise<ArchiveProbeEntry> {
+  const nowEpochS = Math.floor(Date.now() / 1000);
+  const outcomes: ArchiveProbeOutcome[] = [];
+  const push = (outcome: ArchiveProbeOutcome | null, done: boolean) => {
+    if (outcome) outcomes.push(outcome);
+    const entry: ArchiveProbeEntry = {
+      running: !done,
+      outcomes: [...outcomes],
+      checkedAt: done ? nowEpochS : null,
+    };
+    onUpdate(entry);
+    return entry;
+  };
+
+  push(null, false);
+  const near = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
+  if (!near?.ok) {
+    return push(near, true);
+  }
+  push(near, false);
+
+  const advertisedDays = result.catchup_days;
+  if (advertisedDays == null || advertisedDays <= 0) {
+    return push(null, true);
+  }
+
+  const deep = await probeArchivePoint(
+    result,
+    probePointForDays(advertisedDays, nowEpochS),
+    nowEpochS,
+  );
+  if (!deep || deep.ok) {
+    return push(deep, true);
+  }
+  push(deep, false);
+
+  // The advertised depth lied; bisect between the working near point and the
+  // failing deep point to estimate what the provider actually keeps.
+  let workingDays = 0;
+  let failingDays = advertisedDays;
+  for (let step = 0; step < MAX_BISECT_STEPS; step += 1) {
+    const midDays = Math.round((workingDays + failingDays) / 2);
+    if (midDays <= workingDays || midDays >= failingDays) break;
+    const outcome = await probeArchivePoint(
+      result,
+      probePointForDays(midDays, nowEpochS),
+      nowEpochS,
+    );
+    if (!outcome) break;
+    if (outcome.ok) {
+      workingDays = midDays;
+    } else {
+      failingDays = midDays;
+    }
+    push(outcome, false);
+  }
+  return push(null, true);
+}

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -65,6 +65,12 @@ function probePointForDays(daysBack: number, nowEpochS: number) {
 
 const MAX_BISECT_STEPS = 3;
 
+/** Next probe point between the deepest working and shallowest failing depths. */
+export function archiveDepthMidpoint(workingDays: number, failingDays: number): number | null {
+  const midpoint = (workingDays + failingDays) / 2;
+  return midpoint > workingDays && midpoint < failingDays ? midpoint : null;
+}
+
 /**
  * Verify one channel's archive: probe −1 h, then the advertised depth, and on
  * a mismatch bisect a few points to estimate the real depth. Streams partial
@@ -130,8 +136,8 @@ export async function verifyChannelArchive(
   let failingDays = advertisedDays;
   for (let step = 0; step < MAX_BISECT_STEPS; step += 1) {
     if (shouldCancel()) return push(null, true, false);
-    const midDays = Math.round((workingDays + failingDays) / 2);
-    if (midDays <= workingDays || midDays >= failingDays) break;
+    const midDays = archiveDepthMidpoint(workingDays, failingDays);
+    if (midDays == null) break;
     const probedOutcome = await probeArchivePoint(
       result,
       probePointForDays(midDays, nowEpochS),

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -3,6 +3,7 @@ import {
   type ArchiveProbeEntry,
   type ArchiveProbeOutcome,
   probeArchivePoint,
+  verifyArchiveDepthResponse,
 } from "./archiveProbe";
 import type { ChannelResult } from "./types";
 
@@ -25,7 +26,9 @@ export function archiveVerdict(
   if (!outcomes.some((outcome) => outcome.ok)) return "broken";
   const advertisedDays = result.catchup_days;
   if (advertisedDays == null) return "verified";
-  return outcomes.some((outcome) => outcome.ok && outcome.daysBack >= advertisedDays)
+  return outcomes.some(
+    (outcome) => outcome.ok && outcome.depthVerified && outcome.daysBack >= advertisedDays,
+  )
     ? "verified"
     : "shallower";
 }
@@ -33,7 +36,7 @@ export function archiveVerdict(
 /** Deepest point that answered, in days; null without any successful probe. */
 export function measuredDepthDays(entry: ArchiveProbeEntry | undefined): number | null {
   const okDays = (entry?.outcomes ?? [])
-    .filter((outcome) => outcome.ok)
+    .filter((outcome) => outcome.ok && outcome.depthVerified)
     .map((outcome) => outcome.daysBack);
   if (okDays.length === 0) return null;
   const deepest = Math.max(...okDays);
@@ -100,12 +103,13 @@ export async function verifyChannelArchive(
     return push(null, true, false);
   }
 
-  const deep = await probeArchivePoint(
+  const probedDeep = await probeArchivePoint(
     result,
     probePointForDays(advertisedDays, nowEpochS),
     nowEpochS,
   );
-  if (!deep || deep.ok || shouldCancel()) {
+  const deep = probedDeep ? verifyArchiveDepthResponse(probedDeep, near) : null;
+  if (!deep || (deep.ok && deep.depthVerified) || shouldCancel()) {
     return push(deep, true);
   }
   push(deep, false);
@@ -118,13 +122,14 @@ export async function verifyChannelArchive(
     if (shouldCancel()) break;
     const midDays = Math.round((workingDays + failingDays) / 2);
     if (midDays <= workingDays || midDays >= failingDays) break;
-    const outcome = await probeArchivePoint(
+    const probedOutcome = await probeArchivePoint(
       result,
       probePointForDays(midDays, nowEpochS),
       nowEpochS,
     );
+    const outcome = probedOutcome ? verifyArchiveDepthResponse(probedOutcome, near) : null;
     if (!outcome) break;
-    if (outcome.ok) {
+    if (outcome.ok && outcome.depthVerified) {
       workingDays = midDays;
     } else {
       failingDays = midDays;

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -82,6 +82,7 @@ export async function verifyChannelArchive(
   result: ChannelResult,
   onUpdate: (entry: ArchiveProbeEntry) => void,
   shouldCancel: () => boolean = () => false,
+  signal?: AbortSignal,
 ): Promise<ArchiveProbeEntry> {
   const nowEpochS = Math.floor(Date.now() / 1000);
   const outcomes: ArchiveProbeOutcome[] = [];
@@ -100,7 +101,12 @@ export async function verifyChannelArchive(
   if (shouldCancel()) {
     return push(null, true, false);
   }
-  const probedNear = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
+  const probedNear = await probeArchivePoint(
+    result,
+    probePointForDays(0, nowEpochS),
+    nowEpochS,
+    signal,
+  );
   const near = probedNear ? verifyArchivePointResponse(probedNear) : null;
   if (shouldCancel()) {
     return push(near, true, false);
@@ -123,6 +129,7 @@ export async function verifyChannelArchive(
     result,
     probePointForDays(advertisedDays, nowEpochS),
     nowEpochS,
+    signal,
   );
   const deep = probedDeep ? verifyArchiveDepthResponse(probedDeep, near) : null;
   if (shouldCancel()) {
@@ -149,6 +156,7 @@ export async function verifyChannelArchive(
       result,
       probePointForDays(midDays, nowEpochS),
       nowEpochS,
+      signal,
     );
     const outcome = probedOutcome ? verifyArchiveDepthResponse(probedOutcome, near) : null;
     if (shouldCancel()) return push(outcome, true, false);

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -21,7 +21,7 @@ export function archiveVerdict(
 ): ArchiveVerdict {
   if (!hasArchive(result)) return "advertised";
   const outcomes = entry?.outcomes ?? [];
-  if (entry?.running || outcomes.length === 0) return "advertised";
+  if (entry?.running || entry?.checkedAt == null || outcomes.length === 0) return "advertised";
   if (!outcomes.some((outcome) => outcome.ok)) return "broken";
   const advertisedDays = result.catchup_days;
   if (advertisedDays == null) return "verified";
@@ -67,12 +67,12 @@ export async function verifyChannelArchive(
 ): Promise<ArchiveProbeEntry> {
   const nowEpochS = Math.floor(Date.now() / 1000);
   const outcomes: ArchiveProbeOutcome[] = [];
-  const push = (outcome: ArchiveProbeOutcome | null, done: boolean) => {
+  const push = (outcome: ArchiveProbeOutcome | null, done: boolean, completed = done) => {
     if (outcome) outcomes.push(outcome);
     const entry: ArchiveProbeEntry = {
       running: !done,
       outcomes: [...outcomes],
-      checkedAt: done ? nowEpochS : null,
+      checkedAt: completed ? nowEpochS : null,
     };
     onUpdate(entry);
     return entry;
@@ -80,11 +80,14 @@ export async function verifyChannelArchive(
 
   push(null, false);
   if (shouldCancel()) {
-    return push(null, true);
+    return push(null, true, false);
   }
   const near = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
-  if (!near?.ok || shouldCancel()) {
+  if (!near?.ok) {
     return push(near, true);
+  }
+  if (shouldCancel()) {
+    return push(near, true, false);
   }
   push(near, false);
 
@@ -94,7 +97,7 @@ export async function verifyChannelArchive(
   }
 
   if (shouldCancel()) {
-    return push(null, true);
+    return push(null, true, false);
   }
 
   const deep = await probeArchivePoint(

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -26,6 +26,13 @@ export function archiveVerdict(
   if (!outcomes.some((outcome) => outcome.ok)) return "broken";
   const advertisedDays = result.catchup_days;
   if (advertisedDays == null) return "verified";
+  if (
+    outcomes.some(
+      (outcome) => outcome.ok && outcome.depthUnknown && outcome.daysBack >= advertisedDays,
+    )
+  ) {
+    return "advertised";
+  }
   return outcomes.some(
     (outcome) => outcome.ok && outcome.depthVerified && outcome.daysBack >= advertisedDays,
   )
@@ -86,11 +93,11 @@ export async function verifyChannelArchive(
     return push(null, true, false);
   }
   const near = await probeArchivePoint(result, probePointForDays(0, nowEpochS), nowEpochS);
-  if (!near?.ok) {
-    return push(near, true);
-  }
   if (shouldCancel()) {
     return push(near, true, false);
+  }
+  if (!near?.ok) {
+    return push(near, true);
   }
   push(near, false);
 
@@ -109,7 +116,10 @@ export async function verifyChannelArchive(
     nowEpochS,
   );
   const deep = probedDeep ? verifyArchiveDepthResponse(probedDeep, near) : null;
-  if (!deep || (deep.ok && deep.depthVerified) || shouldCancel()) {
+  if (shouldCancel()) {
+    return push(deep, true, false);
+  }
+  if (!deep || (deep.ok && (deep.depthVerified || deep.depthUnknown))) {
     return push(deep, true);
   }
   push(deep, false);
@@ -119,7 +129,7 @@ export async function verifyChannelArchive(
   let workingDays = 0;
   let failingDays = advertisedDays;
   for (let step = 0; step < MAX_BISECT_STEPS; step += 1) {
-    if (shouldCancel()) break;
+    if (shouldCancel()) return push(null, true, false);
     const midDays = Math.round((workingDays + failingDays) / 2);
     if (midDays <= workingDays || midDays >= failingDays) break;
     const probedOutcome = await probeArchivePoint(
@@ -128,6 +138,7 @@ export async function verifyChannelArchive(
       nowEpochS,
     );
     const outcome = probedOutcome ? verifyArchiveDepthResponse(probedOutcome, near) : null;
+    if (shouldCancel()) return push(outcome, true, false);
     if (!outcome) break;
     if (outcome.ok && outcome.depthVerified) {
       workingDays = midDays;

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -1,0 +1,42 @@
+import { useAppStore } from "../store";
+import { hasArchive } from "./archive";
+import { verifyChannelArchive } from "./archiveVerification";
+
+let bulkRunActive = false;
+let bulkCancelRequested = false;
+
+export function cancelArchiveVerification(): void {
+  bulkCancelRequested = true;
+}
+
+/** Verify every catch-up channel sequentially, with progress in the store. */
+export async function verifyAllArchives(): Promise<void> {
+  if (bulkRunActive) {
+    return;
+  }
+  const targets = useAppStore.getState().flatResults.filter(hasArchive);
+  if (targets.length === 0) {
+    return;
+  }
+  bulkRunActive = true;
+  bulkCancelRequested = false;
+  const setProgress = (done: number) =>
+    useAppStore.getState().setArchiveVerifyRun({ running: true, done, total: targets.length });
+  setProgress(0);
+  try {
+    let done = 0;
+    for (const target of targets) {
+      if (bulkCancelRequested) {
+        break;
+      }
+      await verifyChannelArchive(target, (entry) =>
+        useAppStore.getState().setArchiveProbe(target.index, entry),
+      );
+      done += 1;
+      setProgress(done);
+    }
+  } finally {
+    useAppStore.getState().setArchiveVerifyRun(null);
+    bulkRunActive = false;
+  }
+}

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -11,6 +11,11 @@ export function cancelArchiveVerification(): void {
   bulkCancelRequested = true;
 }
 
+export function isArchiveVerificationBlockingPlayback(): boolean {
+  const state = useAppStore.getState();
+  return state.archiveVerifyRun != null && isSingleConnectionPlaylist(state.playlist);
+}
+
 /** Verify every catch-up channel sequentially, with progress in the store. */
 export async function verifyAllArchives(): Promise<void> {
   const initialState = useAppStore.getState();

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from "../store";
 import { hasArchive } from "./archive";
 import { verifyChannelArchive } from "./archiveVerification";
+import { isSingleConnectionPlaylist } from "./playback";
 import { isScanActive } from "./scanState";
 
 let bulkRunActive = false;
@@ -13,15 +14,16 @@ export function cancelArchiveVerification(): void {
 /** Verify every catch-up channel sequentially, with progress in the store. */
 export async function verifyAllArchives(): Promise<void> {
   const initialState = useAppStore.getState();
+  const playlist = initialState.playlist;
   if (
     bulkRunActive ||
     isScanActive(initialState.scanState) ||
     initialState.archiveGuideTestRunning ||
-    Object.values(initialState.archiveProbes).some((entry) => entry.running)
+    Object.values(initialState.archiveProbes).some((entry) => entry.running) ||
+    (initialState.playIntentActive && isSingleConnectionPlaylist(playlist))
   ) {
     return;
   }
-  const playlist = initialState.playlist;
   const targets = initialState.flatResults.filter(hasArchive);
   if (targets.length === 0) {
     return;
@@ -33,7 +35,12 @@ export async function verifyAllArchives(): Promise<void> {
   const playlistChanged = () => useAppStore.getState().playlist !== playlist;
   const shouldCancel = () => {
     const state = useAppStore.getState();
-    return bulkCancelRequested || state.playlist !== playlist || isScanActive(state.scanState);
+    return (
+      bulkCancelRequested ||
+      state.playlist !== playlist ||
+      isScanActive(state.scanState) ||
+      (state.playIntentActive && isSingleConnectionPlaylist(playlist))
+    );
   };
   setProgress(0);
   try {

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -14,7 +14,9 @@ export function cancelArchiveVerification(): void {
 export function isArchiveVerificationBlockingPlayback(): boolean {
   const state = useAppStore.getState();
   return (
-    (state.archiveVerifyRun != null || state.archiveGuideTestRunning) &&
+    (state.archiveVerifyRun != null ||
+      state.archiveGuideTestRunning ||
+      Object.values(state.archiveProbes).some((entry) => entry.running)) &&
     isSingleConnectionPlaylist(state.playlist)
   );
 }

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -13,7 +13,10 @@ export function cancelArchiveVerification(): void {
 
 export function isArchiveVerificationBlockingPlayback(): boolean {
   const state = useAppStore.getState();
-  return state.archiveVerifyRun != null && isSingleConnectionPlaylist(state.playlist);
+  return (
+    (state.archiveVerifyRun != null || state.archiveGuideTestRunning) &&
+    isSingleConnectionPlaylist(state.playlist)
+  );
 }
 
 /** Verify every catch-up channel sequentially, with progress in the store. */

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -27,6 +27,7 @@ export function isArchiveVerificationBlockingPlayback(): boolean {
 export async function verifyAllArchives(): Promise<void> {
   const initialState = useAppStore.getState();
   const playlist = initialState.playlist;
+  const generation = initialState.archiveProbeGeneration;
   const singleConnection = isSingleConnectionPlaylist(playlist);
   if (
     bulkRunActive ||
@@ -58,12 +59,11 @@ export async function verifyAllArchives(): Promise<void> {
   bulkAbortController = abortController;
   const setProgress = (done: number) =>
     useAppStore.getState().setArchiveVerifyRun({ running: true, done, total: targets.length });
-  const playlistChanged = () => useAppStore.getState().playlist !== playlist;
   const shouldCancel = () => {
     const state = useAppStore.getState();
     return (
       bulkCancelRequested ||
-      state.playlist !== playlist ||
+      state.archiveProbeGeneration !== generation ||
       isScanActive(state.scanState) ||
       ((state.playIntentActive || state.castActive || state.externalPlaybackActive) &&
         singleConnection)
@@ -79,9 +79,7 @@ export async function verifyAllArchives(): Promise<void> {
       await verifyChannelArchive(
         target,
         (entry) => {
-          if (!playlistChanged()) {
-            useAppStore.getState().setArchiveProbe(target.index, entry);
-          }
+          useAppStore.getState().setArchiveProbe(generation, target.index, entry);
         },
         shouldCancel,
         abortController.signal,

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -20,7 +20,8 @@ export async function verifyAllArchives(): Promise<void> {
     isScanActive(initialState.scanState) ||
     initialState.archiveGuideTestRunning ||
     Object.values(initialState.archiveProbes).some((entry) => entry.running) ||
-    (initialState.playIntentActive && isSingleConnectionPlaylist(playlist))
+    ((initialState.playIntentActive || initialState.castActive) &&
+      isSingleConnectionPlaylist(playlist))
   ) {
     return;
   }
@@ -39,7 +40,7 @@ export async function verifyAllArchives(): Promise<void> {
       bulkCancelRequested ||
       state.playlist !== playlist ||
       isScanActive(state.scanState) ||
-      (state.playIntentActive && isSingleConnectionPlaylist(playlist))
+      ((state.playIntentActive || state.castActive) && isSingleConnectionPlaylist(playlist))
     );
   };
   setProgress(0);

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -20,16 +20,24 @@ export function isArchiveVerificationBlockingPlayback(): boolean {
 export async function verifyAllArchives(): Promise<void> {
   const initialState = useAppStore.getState();
   const playlist = initialState.playlist;
+  const singleConnection = isSingleConnectionPlaylist(playlist);
   if (
     bulkRunActive ||
     isScanActive(initialState.scanState) ||
     initialState.archiveGuideTestRunning ||
     Object.values(initialState.archiveProbes).some((entry) => entry.running) ||
-    ((initialState.playIntentActive || initialState.castActive) &&
-      isSingleConnectionPlaylist(playlist))
+    ((initialState.playIntentActive || initialState.castActive) && singleConnection)
   ) {
     return;
   }
+  if (
+    initialState.externalPlaybackActive &&
+    singleConnection &&
+    !window.confirm("Close the external player before verifying catch-up. Continue?")
+  ) {
+    return;
+  }
+  initialState.setExternalPlaybackActive(false);
   const targets = initialState.flatResults.filter(hasArchive);
   if (targets.length === 0) {
     return;
@@ -45,7 +53,8 @@ export async function verifyAllArchives(): Promise<void> {
       bulkCancelRequested ||
       state.playlist !== playlist ||
       isScanActive(state.scanState) ||
-      ((state.playIntentActive || state.castActive) && isSingleConnectionPlaylist(playlist))
+      ((state.playIntentActive || state.castActive || state.externalPlaybackActive) &&
+        singleConnection)
     );
   };
   setProgress(0);

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -6,9 +6,11 @@ import { isScanActive } from "./scanState";
 
 let bulkRunActive = false;
 let bulkCancelRequested = false;
+let bulkAbortController: AbortController | null = null;
 
 export function cancelArchiveVerification(): void {
   bulkCancelRequested = true;
+  bulkAbortController?.abort();
 }
 
 export function isArchiveVerificationBlockingPlayback(): boolean {
@@ -52,6 +54,8 @@ export async function verifyAllArchives(): Promise<void> {
   }
   bulkRunActive = true;
   bulkCancelRequested = false;
+  const abortController = new AbortController();
+  bulkAbortController = abortController;
   const setProgress = (done: number) =>
     useAppStore.getState().setArchiveVerifyRun({ running: true, done, total: targets.length });
   const playlistChanged = () => useAppStore.getState().playlist !== playlist;
@@ -80,6 +84,7 @@ export async function verifyAllArchives(): Promise<void> {
           }
         },
         shouldCancel,
+        abortController.signal,
       );
       if (shouldCancel()) break;
       done += 1;
@@ -88,5 +93,8 @@ export async function verifyAllArchives(): Promise<void> {
   } finally {
     useAppStore.getState().setArchiveVerifyRun(null);
     bulkRunActive = false;
+    if (bulkAbortController === abortController) {
+      bulkAbortController = null;
+    }
   }
 }

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -16,6 +16,7 @@ export async function verifyAllArchives(): Promise<void> {
   if (
     bulkRunActive ||
     isScanActive(initialState.scanState) ||
+    initialState.archiveGuideTestRunning ||
     Object.values(initialState.archiveProbes).some((entry) => entry.running)
   ) {
     return;

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -57,6 +57,14 @@ export async function verifyAllArchives(): Promise<void> {
   bulkCancelRequested = false;
   const abortController = new AbortController();
   bulkAbortController = abortController;
+  const unsubscribeGeneration = useAppStore.subscribe((state, previousState) => {
+    if (
+      state.archiveProbeGeneration !== generation &&
+      state.archiveProbeGeneration !== previousState.archiveProbeGeneration
+    ) {
+      abortController.abort();
+    }
+  });
   const setProgress = (done: number) =>
     useAppStore.getState().setArchiveVerifyRun({ running: true, done, total: targets.length });
   const shouldCancel = () => {
@@ -89,6 +97,7 @@ export async function verifyAllArchives(): Promise<void> {
       setProgress(done);
     }
   } finally {
+    unsubscribeGeneration();
     useAppStore.getState().setArchiveVerifyRun(null);
     bulkRunActive = false;
     if (bulkAbortController === abortController) {

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from "../store";
 import { hasArchive } from "./archive";
 import { verifyChannelArchive } from "./archiveVerification";
+import { isScanActive } from "./scanState";
 
 let bulkRunActive = false;
 let bulkCancelRequested = false;
@@ -11,10 +12,16 @@ export function cancelArchiveVerification(): void {
 
 /** Verify every catch-up channel sequentially, with progress in the store. */
 export async function verifyAllArchives(): Promise<void> {
-  if (bulkRunActive) {
+  const initialState = useAppStore.getState();
+  if (
+    bulkRunActive ||
+    isScanActive(initialState.scanState) ||
+    Object.values(initialState.archiveProbes).some((entry) => entry.running)
+  ) {
     return;
   }
-  const targets = useAppStore.getState().flatResults.filter(hasArchive);
+  const playlist = initialState.playlist;
+  const targets = initialState.flatResults.filter(hasArchive);
   if (targets.length === 0) {
     return;
   }
@@ -22,16 +29,28 @@ export async function verifyAllArchives(): Promise<void> {
   bulkCancelRequested = false;
   const setProgress = (done: number) =>
     useAppStore.getState().setArchiveVerifyRun({ running: true, done, total: targets.length });
+  const playlistChanged = () => useAppStore.getState().playlist !== playlist;
+  const shouldCancel = () => {
+    const state = useAppStore.getState();
+    return bulkCancelRequested || state.playlist !== playlist || isScanActive(state.scanState);
+  };
   setProgress(0);
   try {
     let done = 0;
     for (const target of targets) {
-      if (bulkCancelRequested) {
+      if (shouldCancel()) {
         break;
       }
-      await verifyChannelArchive(target, (entry) =>
-        useAppStore.getState().setArchiveProbe(target.index, entry),
+      await verifyChannelArchive(
+        target,
+        (entry) => {
+          if (!playlistChanged()) {
+            useAppStore.getState().setArchiveProbe(target.index, entry);
+          }
+        },
+        shouldCancel,
       );
+      if (shouldCancel()) break;
       done += 1;
       setProgress(done);
     }

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -43,7 +43,9 @@ export async function verifyAllArchives(): Promise<void> {
     return;
   }
   initialState.setVerifyCatchupAfterScan(false);
-  initialState.setExternalPlaybackActive(false);
+  if (singleConnection) {
+    initialState.setExternalPlaybackActive(false);
+  }
   const targets = initialState.flatResults.filter(hasArchive);
   if (targets.length === 0) {
     return;

--- a/src/lib/archiveVerifyRun.ts
+++ b/src/lib/archiveVerifyRun.ts
@@ -42,6 +42,7 @@ export async function verifyAllArchives(): Promise<void> {
   ) {
     return;
   }
+  initialState.setVerifyCatchupAfterScan(false);
   initialState.setExternalPlaybackActive(false);
   const targets = initialState.flatResults.filter(hasArchive);
   if (targets.length === 0) {

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -37,7 +37,6 @@ export function computeCatchupScore(
   let tested = 0;
   let reliabilityPoints = 0;
   let depthSum = 0;
-  let depthCount = 0;
   for (const channel of catchupChannels) {
     const entry = probes[channel.index];
     const verdict = archiveVerdict(channel, entry);
@@ -56,7 +55,6 @@ export function computeCatchupScore(
         : measuredDepthDays(entry);
     if (depth != null) {
       depthSum += Math.min(depth, DEPTH_CAP_DAYS);
-      depthCount += 1;
     }
   }
 
@@ -65,7 +63,7 @@ export function computeCatchupScore(
   }
 
   const reliability = reliabilityPoints / tested;
-  const depthScore = depthCount > 0 ? Math.min(1, depthSum / depthCount / FULL_DEPTH_DAYS) : 0;
+  const depthScore = Math.min(1, depthSum / tested / FULL_DEPTH_DAYS);
   const verifiedScore = coverage * 0.5 + reliability * 0.35 + depthScore * 0.15;
   const testedFraction = tested / catchupChannels.length;
   return clampScore10((coverage * (1 - testedFraction) + verifiedScore * testedFraction) * 10);

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -73,6 +73,8 @@ export function withCatchupScore(score: PlaylistScore, catchupScore: number | nu
   if (catchupScore == null) return score;
   return {
     ...score,
-    overall: clampScore10(score.overall * 0.85 + catchupScore * 0.15),
+    overall: clampScore10(
+      score.ping * 0.2 + score.content * 0.35 + score.quality * 0.3 + catchupScore * 0.15,
+    ),
   };
 }

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -1,0 +1,83 @@
+import { hasArchive } from "./archive";
+import type { ArchiveProbeEntry } from "./archiveProbe";
+import { archiveVerdict, measuredDepthDays } from "./archiveVerification";
+import type { ChannelResult, PlaylistScore } from "./types";
+
+// A week of archive is the customary full-marks depth; deeper is a bonus that
+// stops mattering, and depth stops counting past two weeks entirely.
+const FULL_DEPTH_DAYS = 7;
+const DEPTH_CAP_DAYS = 14;
+
+function clampScore10(value: number): number {
+  return Math.min(10, Math.max(0, value));
+}
+
+/**
+ * Catch-up score component, or null for playlists without any catch-up (the
+ * component then shows N/A and the overall weights renormalize).
+ *
+ * Before verification the score reflects advertised coverage only. Once
+ * channels are probed it blends coverage, reliability (verified full marks,
+ * shallower partial credit, broken none), and measured depth.
+ */
+export function computeCatchupScore(
+  results: ChannelResult[],
+  probes: Record<number, ArchiveProbeEntry>,
+): number | null {
+  if (results.length === 0) {
+    return null;
+  }
+  const catchupChannels = results.filter(hasArchive);
+  if (catchupChannels.length === 0) {
+    return null;
+  }
+  const coverage = catchupChannels.length / results.length;
+
+  let tested = 0;
+  let reliabilityPoints = 0;
+  let depthSum = 0;
+  let depthCount = 0;
+  for (const channel of catchupChannels) {
+    const entry = probes[channel.index];
+    const verdict = archiveVerdict(channel, entry);
+    if (verdict === "advertised") {
+      continue;
+    }
+    tested += 1;
+    if (verdict === "verified") {
+      reliabilityPoints += 1;
+    } else if (verdict === "shallower") {
+      reliabilityPoints += 0.6;
+    }
+    const depth =
+      verdict === "verified"
+        ? (channel.catchup_days ?? measuredDepthDays(entry) ?? 1)
+        : measuredDepthDays(entry);
+    if (depth != null) {
+      depthSum += Math.min(depth, DEPTH_CAP_DAYS);
+      depthCount += 1;
+    }
+  }
+
+  if (tested === 0) {
+    return clampScore10(coverage * 10);
+  }
+
+  const reliability = reliabilityPoints / tested;
+  const depthScore = depthCount > 0 ? Math.min(1, depthSum / depthCount / FULL_DEPTH_DAYS) : 0;
+  return clampScore10((coverage * 0.5 + reliability * 0.35 + depthScore * 0.15) * 10);
+}
+
+/**
+ * Overall score with catch-up as a fourth component (Ping 20 / Content 35 /
+ * Quality 30 / Catch-up 15). Without a catch-up component the existing
+ * three-component overall stands, so scores stay comparable.
+ */
+export function blendOverallScore(score: PlaylistScore, catchupScore: number | null): number {
+  if (catchupScore == null) {
+    return score.overall;
+  }
+  return clampScore10(
+    score.ping * 0.2 + score.content * 0.35 + score.quality * 0.3 + catchupScore * 0.15,
+  );
+}

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -1,7 +1,7 @@
 import { hasArchive } from "./archive";
 import type { ArchiveProbeEntry } from "./archiveProbe";
 import { archiveVerdict, measuredDepthDays } from "./archiveVerification";
-import type { ChannelResult, PlaylistScore } from "./types";
+import type { ChannelResult } from "./types";
 
 // A week of archive is the customary full-marks depth; deeper is a bonus that
 // stops mattering, and depth stops counting past two weeks entirely.
@@ -13,8 +13,7 @@ function clampScore10(value: number): number {
 }
 
 /**
- * Catch-up score component, or null for playlists without any catch-up (the
- * component then shows N/A and the overall weights renormalize).
+ * Catch-up score component, or null for playlists without any catch-up.
  *
  * Before verification the score reflects advertised coverage only. Once
  * channels are probed it blends coverage, reliability (verified full marks,
@@ -67,18 +66,4 @@ export function computeCatchupScore(
   const verifiedScore = coverage * 0.5 + reliability * 0.35 + depthScore * 0.15;
   const testedFraction = tested / catchupChannels.length;
   return clampScore10((coverage * (1 - testedFraction) + verifiedScore * testedFraction) * 10);
-}
-
-/**
- * Overall score with catch-up as a fourth component (Ping 20 / Content 35 /
- * Quality 30 / Catch-up 15). Without a catch-up component the existing
- * three-component overall stands, so scores stay comparable.
- */
-export function blendOverallScore(score: PlaylistScore, catchupScore: number | null): number {
-  if (catchupScore == null) {
-    return score.overall;
-  }
-  return clampScore10(
-    score.ping * 0.2 + score.content * 0.35 + score.quality * 0.3 + catchupScore * 0.15,
-  );
 }

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -1,7 +1,7 @@
 import { hasArchive } from "./archive";
 import type { ArchiveProbeEntry } from "./archiveProbe";
 import { archiveVerdict, measuredDepthDays } from "./archiveVerification";
-import type { ChannelResult } from "./types";
+import type { ChannelResult, PlaylistScore } from "./types";
 
 // A week of archive is the customary full-marks depth; deeper is a bonus that
 // stops mattering, and depth stops counting past two weeks entirely.
@@ -66,4 +66,13 @@ export function computeCatchupScore(
   const verifiedScore = coverage * 0.5 + reliability * 0.35 + depthScore * 0.15;
   const testedFraction = tested / catchupChannels.length;
   return clampScore10((coverage * (1 - testedFraction) + verifiedScore * testedFraction) * 10);
+}
+
+/** Add catch-up as 15% of the displayed overall score when it is available. */
+export function withCatchupScore(score: PlaylistScore, catchupScore: number | null): PlaylistScore {
+  if (catchupScore == null) return score;
+  return {
+    ...score,
+    overall: clampScore10(score.overall * 0.85 + catchupScore * 0.15),
+  };
 }

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -39,7 +39,8 @@ export function computeCatchupScore(
   for (const channel of catchupChannels) {
     const entry = probes[channel.index];
     const verdict = archiveVerdict(channel, entry);
-    if (verdict === "advertised") {
+    const completed = entry != null && !entry.running && entry.checkedAt != null;
+    if (!completed) {
       continue;
     }
     tested += 1;

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -24,14 +24,15 @@ export function computeCatchupScore(
   results: ChannelResult[],
   probes: Record<number, ArchiveProbeEntry>,
 ): number | null {
-  if (results.length === 0) {
+  const liveChannels = results.filter((result) => result.content_type === "live");
+  if (liveChannels.length === 0) {
     return null;
   }
-  const catchupChannels = results.filter(hasArchive);
+  const catchupChannels = liveChannels.filter(hasArchive);
   if (catchupChannels.length === 0) {
     return null;
   }
-  const coverage = catchupChannels.length / results.length;
+  const coverage = catchupChannels.length / liveChannels.length;
 
   let tested = 0;
   let reliabilityPoints = 0;

--- a/src/lib/catchupScore.ts
+++ b/src/lib/catchupScore.ts
@@ -66,7 +66,9 @@ export function computeCatchupScore(
 
   const reliability = reliabilityPoints / tested;
   const depthScore = depthCount > 0 ? Math.min(1, depthSum / depthCount / FULL_DEPTH_DAYS) : 0;
-  return clampScore10((coverage * 0.5 + reliability * 0.35 + depthScore * 0.15) * 10);
+  const verifiedScore = coverage * 0.5 + reliability * 0.35 + depthScore * 0.15;
+  const testedFraction = tested / catchupChannels.length;
+  return clampScore10((coverage * (1 - testedFraction) + verifiedScore * testedFraction) * 10);
 }
 
 /**

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -99,8 +99,18 @@ export async function resetScan(): Promise<void> {
   return invoke("reset_scan");
 }
 
-export async function quickCheckChannel(channel: ChannelResult): Promise<ChannelResult> {
-  return invoke("quick_check_channel", { channel: toCommandChannelResult(channel) });
+export async function quickCheckChannel(
+  channel: ChannelResult,
+  requestId?: string,
+): Promise<ChannelResult> {
+  return invoke("quick_check_channel", {
+    channel: toCommandChannelResult(channel),
+    requestId,
+  });
+}
+
+export async function cancelQuickCheck(requestId: string): Promise<void> {
+  return invoke("cancel_quick_check", { requestId });
 }
 
 export async function loadEpg(

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -12,6 +12,5 @@ export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = 
   setEpgLoadSummary: (epgLoadSummary) => set({ epgLoadSummary }),
   setArchiveVerifyRun: (archiveVerifyRun) => set({ archiveVerifyRun }),
   setVerifyCatchupAfterScan: (verifyCatchupAfterScan) => set({ verifyCatchupAfterScan }),
-  clearArchiveProbes: () =>
-    set({ archiveProbes: {}, epgLoadSummary: null, archiveVerifyRun: null }),
+  clearArchiveProbes: () => set({ archiveProbes: {}, epgLoadSummary: null }),
 });

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -4,9 +4,14 @@ import type { AppStore, ArchiveSlice } from "../types";
 export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = (set) => ({
   archiveProbes: {},
   epgLoadSummary: null,
+  archiveVerifyRun: null,
+  verifyCatchupAfterScan: false,
 
   setArchiveProbe: (index, entry) =>
     set((state) => ({ archiveProbes: { ...state.archiveProbes, [index]: entry } })),
   setEpgLoadSummary: (epgLoadSummary) => set({ epgLoadSummary }),
-  clearArchiveProbes: () => set({ archiveProbes: {}, epgLoadSummary: null }),
+  setArchiveVerifyRun: (archiveVerifyRun) => set({ archiveVerifyRun }),
+  setVerifyCatchupAfterScan: (verifyCatchupAfterScan) => set({ verifyCatchupAfterScan }),
+  clearArchiveProbes: () =>
+    set({ archiveProbes: {}, epgLoadSummary: null, archiveVerifyRun: null }),
 });

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -3,12 +3,14 @@ import type { AppStore, ArchiveSlice } from "../types";
 
 export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = (set) => ({
   archiveProbes: {},
+  archiveGuideTestRunning: false,
   epgLoadSummary: null,
   archiveVerifyRun: null,
   verifyCatchupAfterScan: false,
 
   setArchiveProbe: (index, entry) =>
     set((state) => ({ archiveProbes: { ...state.archiveProbes, [index]: entry } })),
+  setArchiveGuideTestRunning: (archiveGuideTestRunning) => set({ archiveGuideTestRunning }),
   setEpgLoadSummary: (epgLoadSummary) => set({ epgLoadSummary }),
   setArchiveVerifyRun: (archiveVerifyRun) => set({ archiveVerifyRun }),
   setVerifyCatchupAfterScan: (verifyCatchupAfterScan) => set({ verifyCatchupAfterScan }),

--- a/src/store/slices/archiveSlice.ts
+++ b/src/store/slices/archiveSlice.ts
@@ -3,16 +3,27 @@ import type { AppStore, ArchiveSlice } from "../types";
 
 export const createArchiveSlice: StateCreator<AppStore, [], [], ArchiveSlice> = (set) => ({
   archiveProbes: {},
+  archiveProbeGeneration: 0,
   archiveGuideTestRunning: false,
   epgLoadSummary: null,
   archiveVerifyRun: null,
   verifyCatchupAfterScan: false,
 
-  setArchiveProbe: (index, entry) =>
-    set((state) => ({ archiveProbes: { ...state.archiveProbes, [index]: entry } })),
+  setArchiveProbe: (generation, index, entry) =>
+    set((state) => {
+      if (state.archiveProbeGeneration !== generation) {
+        return state;
+      }
+      return { archiveProbes: { ...state.archiveProbes, [index]: entry } };
+    }),
   setArchiveGuideTestRunning: (archiveGuideTestRunning) => set({ archiveGuideTestRunning }),
   setEpgLoadSummary: (epgLoadSummary) => set({ epgLoadSummary }),
   setArchiveVerifyRun: (archiveVerifyRun) => set({ archiveVerifyRun }),
   setVerifyCatchupAfterScan: (verifyCatchupAfterScan) => set({ verifyCatchupAfterScan }),
-  clearArchiveProbes: () => set({ archiveProbes: {}, epgLoadSummary: null }),
+  clearArchiveProbes: () =>
+    set((state) => ({
+      archiveProbes: {},
+      archiveProbeGeneration: state.archiveProbeGeneration + 1,
+      epgLoadSummary: null,
+    })),
 });

--- a/src/store/slices/playerSlice.ts
+++ b/src/store/slices/playerSlice.ts
@@ -4,9 +4,11 @@ import type { AppStore, PlayerSlice } from "../types";
 export const createPlayerSlice: StateCreator<AppStore, [], [], PlayerSlice> = (set) => ({
   playIntentActive: false,
   castActive: false,
+  externalPlaybackActive: false,
   pendingPlaybackChannel: null,
 
   setPlayIntentActive: (playIntentActive) => set({ playIntentActive }),
   setCastActive: (castActive) => set({ castActive }),
+  setExternalPlaybackActive: (externalPlaybackActive) => set({ externalPlaybackActive }),
   setPendingPlaybackChannel: (pendingPlaybackChannel) => set({ pendingPlaybackChannel }),
 });

--- a/src/store/slices/playerSlice.ts
+++ b/src/store/slices/playerSlice.ts
@@ -3,8 +3,10 @@ import type { AppStore, PlayerSlice } from "../types";
 
 export const createPlayerSlice: StateCreator<AppStore, [], [], PlayerSlice> = (set) => ({
   playIntentActive: false,
+  castActive: false,
   pendingPlaybackChannel: null,
 
   setPlayIntentActive: (playIntentActive) => set({ playIntentActive }),
+  setCastActive: (castActive) => set({ castActive }),
   setPendingPlaybackChannel: (pendingPlaybackChannel) => set({ pendingPlaybackChannel }),
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -231,10 +231,12 @@ export interface UiSlice {
 export interface PlayerSlice {
   playIntentActive: boolean;
   castActive: boolean;
+  externalPlaybackActive: boolean;
   pendingPlaybackChannel: ChannelResult | null;
 
   setPlayIntentActive: (active: boolean) => void;
   setCastActive: (active: boolean) => void;
+  setExternalPlaybackActive: (active: boolean) => void;
   setPendingPlaybackChannel: (channel: ChannelResult | null) => void;
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -114,6 +114,8 @@ export interface FilterSlice {
 export interface ArchiveSlice {
   /** Spot-probe results for catch-up channels, keyed by channel index. */
   archiveProbes: Record<number, ArchiveProbeEntry>;
+  /** Whether a programme selected in the Guide is being tested. */
+  archiveGuideTestRunning: boolean;
   /** Result of the most recent XMLTV load for the current playlist. */
   epgLoadSummary: EpgLoadSummary | null;
   /** Progress of a playlist-wide catch-up verification run. */
@@ -122,6 +124,7 @@ export interface ArchiveSlice {
   verifyCatchupAfterScan: boolean;
 
   setArchiveProbe: (index: number, entry: ArchiveProbeEntry) => void;
+  setArchiveGuideTestRunning: (running: boolean) => void;
   setEpgLoadSummary: (summary: EpgLoadSummary | null) => void;
   setArchiveVerifyRun: (run: { running: boolean; done: number; total: number } | null) => void;
   setVerifyCatchupAfterScan: (value: boolean) => void;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -114,6 +114,8 @@ export interface FilterSlice {
 export interface ArchiveSlice {
   /** Spot-probe results for catch-up channels, keyed by channel index. */
   archiveProbes: Record<number, ArchiveProbeEntry>;
+  /** Changes whenever per-playlist archive state is reset. */
+  archiveProbeGeneration: number;
   /** Whether a programme selected in the Guide is being tested. */
   archiveGuideTestRunning: boolean;
   /** Result of the most recent XMLTV load for the current playlist. */
@@ -123,7 +125,7 @@ export interface ArchiveSlice {
   /** When set, a full verification pass starts after the scan completes. */
   verifyCatchupAfterScan: boolean;
 
-  setArchiveProbe: (index: number, entry: ArchiveProbeEntry) => void;
+  setArchiveProbe: (generation: number, index: number, entry: ArchiveProbeEntry) => void;
   setArchiveGuideTestRunning: (running: boolean) => void;
   setEpgLoadSummary: (summary: EpgLoadSummary | null) => void;
   setArchiveVerifyRun: (run: { running: boolean; done: number; total: number } | null) => void;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -116,9 +116,15 @@ export interface ArchiveSlice {
   archiveProbes: Record<number, ArchiveProbeEntry>;
   /** Result of the most recent XMLTV load for the current playlist. */
   epgLoadSummary: EpgLoadSummary | null;
+  /** Progress of a playlist-wide catch-up verification run. */
+  archiveVerifyRun: { running: boolean; done: number; total: number } | null;
+  /** When set, a full verification pass starts after the scan completes. */
+  verifyCatchupAfterScan: boolean;
 
   setArchiveProbe: (index: number, entry: ArchiveProbeEntry) => void;
   setEpgLoadSummary: (summary: EpgLoadSummary | null) => void;
+  setArchiveVerifyRun: (run: { running: boolean; done: number; total: number } | null) => void;
+  setVerifyCatchupAfterScan: (value: boolean) => void;
   /** Reset all per-playlist archive state (probes and EPG summary). */
   clearArchiveProbes: () => void;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -230,9 +230,11 @@ export interface UiSlice {
 
 export interface PlayerSlice {
   playIntentActive: boolean;
+  castActive: boolean;
   pendingPlaybackChannel: ChannelResult | null;
 
   setPlayIntentActive: (active: boolean) => void;
+  setCastActive: (active: boolean) => void;
   setPendingPlaybackChannel: (channel: ChannelResult | null) => void;
 }
 

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -91,9 +91,9 @@ describe("buildArchiveUrl", () => {
       buildArchiveUrl(urlFields("http://h/s.m3u8?token=x", "shift", "?utc=${start}"), WINDOW),
     ).toBe(`http://h/s.m3u8?token=x&utc=${START}`);
     // A leading & normalizes to ? when the URL has no query yet.
-    expect(
-      buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW),
-    ).toBe(`http://h/s.m3u8?start=${START}`);
+    expect(buildArchiveUrl(urlFields("http://h/s.m3u8", "append", "&start=${start}"), WINDOW)).toBe(
+      `http://h/s.m3u8?start=${START}`,
+    );
     // Non-query relative templates concatenate verbatim.
     expect(
       buildArchiveUrl(urlFields("http://h/video", "append", "-${start}-${duration}.m3u8"), WINDOW),
@@ -115,9 +115,9 @@ describe("buildArchiveUrl", () => {
   });
 
   it("builds flussonic archive URLs", () => {
-    expect(
-      buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW),
-    ).toBe(`http://host/channel/archive-${START}-3600.m3u8`);
+    expect(buildArchiveUrl(urlFields("http://host/channel/index.m3u8", "flussonic"), WINDOW)).toBe(
+      `http://host/channel/archive-${START}-3600.m3u8`,
+    );
     expect(
       buildArchiveUrl(urlFields("http://host/channel/mono.ts?tok=1", "flussonic"), WINDOW),
     ).toBe(`http://host/channel/timeshift_abs-${START}.ts?tok=1`);

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   archiveBadgeText,
+  archivePickerDefault,
   archiveSortValue,
   archiveTitle,
   buildArchiveUrl,
@@ -130,5 +131,17 @@ describe("buildArchiveUrl", () => {
     expect(buildArchiveUrl(urlFields("http://h/s.m3u8?a=1", "shift"), WINDOW)).toBe(
       `http://h/s.m3u8?a=1&utc=${START}&lutc=${START + 8000}`,
     );
+  });
+});
+
+describe("archivePickerDefault", () => {
+  it("starts 59:30 before now on the same day", () => {
+    const now = new Date(2026, 7, 29, 14, 7, 0);
+    expect(archivePickerDefault(now)).toEqual({ daysBack: 0, time: "13:07" });
+  });
+
+  it("rolls to yesterday when 59:30 back crosses midnight", () => {
+    const now = new Date(2026, 7, 29, 0, 20, 0);
+    expect(archivePickerDefault(now)).toEqual({ daysBack: 1, time: "23:20" });
   });
 });

--- a/tests/archiveStore.test.ts
+++ b/tests/archiveStore.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { ArchiveProbeEntry } from "../src/lib/archiveProbe";
+import { toPendingChannelResult } from "../src/lib/channelResults";
+import type { Channel } from "../src/lib/types";
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    clear() {},
+    getItem() {
+      return null;
+    },
+    key() {
+      return null;
+    },
+    length: 0,
+    removeItem() {},
+    setItem() {},
+  } satisfies Storage,
+});
+
+const { useAppStore } = await import("../src/store");
+
+function result(url: string) {
+  const channel: Channel = {
+    index: 7,
+    playlist: "fixture.m3u8",
+    name: "Channel",
+    group: "Group",
+    language: null,
+    tvg_id: null,
+    tvg_name: null,
+    tvg_logo: null,
+    tvg_chno: null,
+    url,
+    content_type: "live",
+    extinf_line: "#EXTINF:-1,Channel",
+    metadata_lines: [],
+  };
+  return toPendingChannelResult(channel);
+}
+
+const entry: ArchiveProbeEntry = {
+  running: false,
+  outcomes: [],
+  checkedAt: 1,
+};
+
+describe("archive probe store", () => {
+  afterEach(() => {
+    useAppStore.setState({
+      flatResults: [],
+      resultPositions: new Map(),
+      archiveProbes: {},
+      archiveProbeGeneration: 0,
+    });
+  });
+
+  it("discards updates from a superseded playlist generation", () => {
+    const currentResult = result("https://new.example/channel.ts");
+    useAppStore.setState({
+      flatResults: [currentResult],
+      resultPositions: new Map([[currentResult.index, 0]]),
+      archiveProbes: {},
+      archiveProbeGeneration: 2,
+    });
+
+    useAppStore.getState().setArchiveProbe(2, currentResult.index, entry);
+    expect(useAppStore.getState().archiveProbes).toEqual({ [currentResult.index]: entry });
+
+    useAppStore.getState().clearArchiveProbes();
+    expect(useAppStore.getState().archiveProbeGeneration).toBe(3);
+    expect(useAppStore.getState().archiveProbes).toEqual({});
+
+    useAppStore.getState().setArchiveProbe(2, currentResult.index, entry);
+    expect(useAppStore.getState().archiveProbes).toEqual({});
+  });
+});

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -118,6 +118,22 @@ describe("archiveVerdict", () => {
         ]),
       ),
     ).toBe("shallower");
+    expect(
+      archiveVerdict(ch, {
+        ...entry([
+          [0, true, 400],
+          [7, true, 700, false],
+        ]),
+        outcomes: [
+          responseOutcome(0, "https://host/live/segment-100.ts"),
+          {
+            ...responseOutcome(7, "https://host/archive/segment-20.ts"),
+            depthVerified: false,
+            depthUnknown: true,
+          },
+        ],
+      }),
+    ).toBe("advertised");
   });
 
   it("measures depth as the deepest answering point", () => {

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -117,6 +117,14 @@ describe("verifyArchivePointResponse", () => {
       depthUnknown: true,
     });
   });
+
+  it("rejects a live segment returned one hour after the requested archive time", () => {
+    const outcome = responseOutcome(0, "https://host/live/1700003600.ts");
+    expect(verifyArchivePointResponse(outcome)).toMatchObject({
+      depthVerified: false,
+      depthUnknown: false,
+    });
+  });
 });
 
 describe("archiveVerdict", () => {

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -63,7 +63,7 @@ describe("archiveVerdict", () => {
   });
 
   it("measures depth as the deepest answering point", () => {
-    expect(measuredDepthDays(entry([[0, true, 400]]))).toBe(1);
+    expect(measuredDepthDays(entry([[0, true, 400]]))).toBe(1 / 24);
     expect(
       measuredDepthDays(
         entry([

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -4,8 +4,12 @@ import {
   type ArchiveProbeOutcome,
   verifyArchiveDepthResponse,
 } from "../src/lib/archiveProbe";
-import { archiveVerdict, measuredDepthDays } from "../src/lib/archiveVerification";
-import { computeCatchupScore } from "../src/lib/catchupScore";
+import {
+  archiveDepthMidpoint,
+  archiveVerdict,
+  measuredDepthDays,
+} from "../src/lib/archiveVerification";
+import { computeCatchupScore, withCatchupScore } from "../src/lib/catchupScore";
 import type { ChannelResult } from "../src/lib/types";
 
 function channel(index: number, catchupDays: number | null, catchup = "xc"): ChannelResult {
@@ -211,5 +215,24 @@ describe("computeCatchupScore", () => {
     };
 
     expect(computeCatchupScore(results, probes)).toBe(7.5);
+  });
+});
+
+describe("archiveDepthMidpoint", () => {
+  it("keeps sub-day precision when a one-day archive needs bisection", () => {
+    expect(archiveDepthMidpoint(0, 1)).toBe(0.5);
+  });
+});
+
+describe("withCatchupScore", () => {
+  const base = { overall: 7, ping: 6, content: 8, quality: 7 };
+
+  it("keeps the original score without catch-up", () => {
+    expect(withCatchupScore(base, null)).toBe(base);
+  });
+
+  it("includes catch-up in the overall score", () => {
+    expect(withCatchupScore(base, 10).overall).toBeCloseTo(7.45, 5);
+    expect(withCatchupScore(base, 0).overall).toBeCloseTo(5.95, 5);
   });
 });

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -66,10 +66,16 @@ describe("verifyArchiveDepthResponse", () => {
     expect(verifyArchiveDepthResponse(deep, near).depthVerified).toBe(true);
   });
 
-  it("rejects an endpoint that only echoes different timestamp parameters", () => {
+  it("accepts successful direct streams for distinct archive windows", () => {
     const queryNear = responseOutcome(0, "https://host/live.ts?utc=100&lutc=200&token=x");
     const deep = responseOutcome(7, "https://host/live.ts?utc=10&lutc=200&token=x");
-    expect(verifyArchiveDepthResponse(deep, queryNear).depthVerified).toBe(false);
+    expect(verifyArchiveDepthResponse(deep, queryNear).depthVerified).toBe(true);
+  });
+
+  it("ignores URL fragments when comparing responses", () => {
+    const fragmentNear = responseOutcome(0, "https://host/live.ts?utc=100#near");
+    const deep = responseOutcome(7, "https://host/live.ts?utc=100#deep");
+    expect(verifyArchiveDepthResponse(deep, fragmentNear).depthVerified).toBe(false);
   });
 });
 

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { ArchiveProbeEntry } from "../src/lib/archiveProbe";
+import {
+  type ArchiveProbeEntry,
+  type ArchiveProbeOutcome,
+  verifyArchiveDepthResponse,
+} from "../src/lib/archiveProbe";
 import { archiveVerdict, measuredDepthDays } from "../src/lib/archiveVerification";
 import { blendOverallScore, computeCatchupScore } from "../src/lib/catchupScore";
 import type { ChannelResult } from "../src/lib/types";
@@ -24,19 +28,50 @@ function plain(index: number): ChannelResult {
   } as ChannelResult;
 }
 
-function entry(outcomes: Array<[number, boolean, number | null]>): ArchiveProbeEntry {
+function entry(
+  outcomes: Array<[number, boolean, number | null, depthVerified?: boolean]>,
+): ArchiveProbeEntry {
   return {
     running: false,
     checkedAt: 1,
-    outcomes: outcomes.map(([daysBack, ok, latencyMs]) => ({
+    outcomes: outcomes.map(([daysBack, ok, latencyMs, depthVerified = ok]) => ({
       label: `−${daysBack}d`,
       daysBack,
       ok,
+      depthVerified,
+      responseUrl: null,
       latencyMs,
       error: ok ? null : "dead",
     })),
   };
 }
+
+function responseOutcome(daysBack: number, responseUrl: string): ArchiveProbeOutcome {
+  return {
+    label: `−${daysBack}d`,
+    daysBack,
+    ok: true,
+    depthVerified: daysBack === 0,
+    responseUrl,
+    latencyMs: 100,
+    error: null,
+  };
+}
+
+describe("verifyArchiveDepthResponse", () => {
+  const near = responseOutcome(0, "https://host/live/segment-100.ts");
+
+  it("accepts a deep probe that resolves to different media", () => {
+    const deep = responseOutcome(7, "https://host/archive/segment-20.ts");
+    expect(verifyArchiveDepthResponse(deep, near).depthVerified).toBe(true);
+  });
+
+  it("rejects an endpoint that only echoes different timestamp parameters", () => {
+    const queryNear = responseOutcome(0, "https://host/live.ts?utc=100&lutc=200&token=x");
+    const deep = responseOutcome(7, "https://host/live.ts?utc=10&lutc=200&token=x");
+    expect(verifyArchiveDepthResponse(deep, queryNear).depthVerified).toBe(false);
+  });
+});
 
 describe("archiveVerdict", () => {
   const ch = channel(1, 7);
@@ -71,6 +106,15 @@ describe("archiveVerdict", () => {
           [0, true, 400],
           [7, false, null],
           [3, true, 500],
+        ]),
+      ),
+    ).toBe("shallower");
+    expect(
+      archiveVerdict(
+        ch,
+        entry([
+          [0, true, 400],
+          [7, true, 700, false],
         ]),
       ),
     ).toBe("shallower");
@@ -126,6 +170,12 @@ describe("computeCatchupScore", () => {
     const broken = { 0: entry([[0, false, null]]), 1: entry([[0, false, null]]) };
     // Full coverage but nothing works: only the coverage half survives.
     expect(computeCatchupScore(results, broken as Record<number, ArchiveProbeEntry>)).toBe(5);
+  });
+
+  it("retains the advertised baseline for untested catch-up channels", () => {
+    const results = Array.from({ length: 100 }, (_, index) => channel(index, 7));
+    const probes = { 0: entry([[0, false, null]]) };
+    expect(computeCatchupScore(results, probes)).toBeCloseTo(9.95, 5);
   });
 });
 

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -140,6 +140,15 @@ describe("archiveVerdict", () => {
       archiveVerdict(
         ch,
         entry([
+          [0, true, 400, false],
+          [7, false, null],
+        ]),
+      ),
+    ).toBe("advertised");
+    expect(
+      archiveVerdict(
+        ch,
+        entry([
           [0, true, 400],
           [7, true, 700],
         ]),

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -101,6 +101,20 @@ describe("verifyArchiveDepthResponse", () => {
 });
 
 describe("verifyArchivePointResponse", () => {
+  it("accepts a direct response with a timestamped archive pathname", () => {
+    const requestedStartEpochS = 1_699_913_600;
+    const outcome = responseOutcome(
+      1,
+      `https://host/archive/${requestedStartEpochS}.ts`,
+      requestedStartEpochS,
+    );
+    outcome.requestUrl = outcome.responseUrl!;
+    expect(verifyArchivePointResponse(outcome)).toMatchObject({
+      depthVerified: true,
+      depthUnknown: false,
+    });
+  });
+
   it("verifies returned media whose timestamp matches the requested programme", () => {
     const outcome = responseOutcome(1, "https://host/archive/1699913605.ts");
     expect(verifyArchivePointResponse(outcome)).toMatchObject({

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -199,6 +199,19 @@ describe("computeCatchupScore", () => {
     const probes = { 0: entry([[0, false, null]]) };
     expect(computeCatchupScore(results, probes)).toBeCloseTo(9.95, 5);
   });
+
+  it("counts failed probes as zero measured depth", () => {
+    const results = [channel(0, 7), channel(1, 7)];
+    const probes = {
+      0: entry([
+        [0, true, 400],
+        [7, true, 700],
+      ]),
+      1: entry([[0, false, null]]),
+    };
+
+    expect(computeCatchupScore(results, probes)).toBe(7.5);
+  });
 });
 
 describe("blendOverallScore", () => {

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -5,7 +5,7 @@ import {
   verifyArchiveDepthResponse,
 } from "../src/lib/archiveProbe";
 import { archiveVerdict, measuredDepthDays } from "../src/lib/archiveVerification";
-import { blendOverallScore, computeCatchupScore } from "../src/lib/catchupScore";
+import { computeCatchupScore } from "../src/lib/catchupScore";
 import type { ChannelResult } from "../src/lib/types";
 
 function channel(index: number, catchupDays: number | null, catchup = "xc"): ChannelResult {
@@ -211,18 +211,5 @@ describe("computeCatchupScore", () => {
     };
 
     expect(computeCatchupScore(results, probes)).toBe(7.5);
-  });
-});
-
-describe("blendOverallScore", () => {
-  const base = { overall: 7.0, ping: 6, content: 8, quality: 7 };
-
-  it("keeps the original overall without a catch-up component", () => {
-    expect(blendOverallScore(base, null)).toBe(7.0);
-  });
-
-  it("folds the catch-up component in at 15% weight", () => {
-    // 6*0.2 + 8*0.35 + 7*0.3 + 10*0.15 = 7.6
-    expect(blendOverallScore(base, 10)).toBeCloseTo(7.6, 5);
   });
 });

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -10,11 +10,18 @@ function channel(index: number, catchupDays: number | null, catchup = "xc"): Cha
     catchup: catchupDays != null || catchup ? catchup : null,
     catchup_days: catchupDays,
     catchup_source: null,
+    content_type: "live",
   } as ChannelResult;
 }
 
 function plain(index: number): ChannelResult {
-  return { index, catchup: null, catchup_days: null, catchup_source: null } as ChannelResult;
+  return {
+    index,
+    catchup: null,
+    catchup_days: null,
+    catchup_source: null,
+    content_type: "live",
+  } as ChannelResult;
 }
 
 function entry(outcomes: Array<[number, boolean, number | null]>): ArchiveProbeEntry {
@@ -37,6 +44,13 @@ describe("archiveVerdict", () => {
   it("stays advertised without completed probes", () => {
     expect(archiveVerdict(ch, undefined)).toBe("advertised");
     expect(archiveVerdict(ch, { running: true, outcomes: [], checkedAt: null })).toBe("advertised");
+    expect(
+      archiveVerdict(ch, {
+        running: false,
+        outcomes: entry([[0, true, 400]]).outcomes,
+        checkedAt: null,
+      }),
+    ).toBe("advertised");
   });
 
   it("classifies broken, verified, and shallower archives", () => {
@@ -86,6 +100,12 @@ describe("computeCatchupScore", () => {
   it("scores advertised coverage before verification", () => {
     const results = [channel(0, 7), channel(1, 7), plain(2), plain(3)];
     expect(computeCatchupScore(results, {})).toBe(5);
+  });
+
+  it("calculates coverage from live channels only", () => {
+    const movie = { ...plain(2), content_type: "movie" as const };
+    const series = { ...plain(3), content_type: "series" as const };
+    expect(computeCatchupScore([channel(0, 7), plain(1), movie, series], {})).toBe(5);
   });
 
   it("blends reliability and depth after verification", () => {

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -3,6 +3,7 @@ import {
   type ArchiveProbeEntry,
   type ArchiveProbeOutcome,
   verifyArchiveDepthResponse,
+  verifyArchivePointResponse,
 } from "../src/lib/archiveProbe";
 import {
   archiveDepthMidpoint,
@@ -96,6 +97,25 @@ describe("verifyArchiveDepthResponse", () => {
     const fragmentNear = responseOutcome(0, "https://host/live.ts?utc=100#near");
     const deep = responseOutcome(7, "https://host/live.ts?utc=100#deep");
     expect(verifyArchiveDepthResponse(deep, fragmentNear).depthVerified).toBe(false);
+  });
+});
+
+describe("verifyArchivePointResponse", () => {
+  it("verifies returned media whose timestamp matches the requested programme", () => {
+    const outcome = responseOutcome(1, "https://host/archive/1699913605.ts");
+    expect(verifyArchivePointResponse(outcome)).toMatchObject({
+      depthVerified: true,
+      depthUnknown: false,
+    });
+  });
+
+  it("leaves reachable media unverified without temporal evidence", () => {
+    const outcome = responseOutcome(1, "https://host/live/current.ts");
+    expect(verifyArchivePointResponse(outcome)).toMatchObject({
+      ok: true,
+      depthVerified: false,
+      depthUnknown: true,
+    });
   });
 });
 

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import type { ArchiveProbeEntry } from "../src/lib/archiveProbe";
+import { archiveVerdict, measuredDepthDays } from "../src/lib/archiveVerification";
+import { blendOverallScore, computeCatchupScore } from "../src/lib/catchupScore";
+import type { ChannelResult } from "../src/lib/types";
+
+function channel(index: number, catchupDays: number | null, catchup = "xc"): ChannelResult {
+  return {
+    index,
+    catchup: catchupDays != null || catchup ? catchup : null,
+    catchup_days: catchupDays,
+    catchup_source: null,
+  } as ChannelResult;
+}
+
+function plain(index: number): ChannelResult {
+  return { index, catchup: null, catchup_days: null, catchup_source: null } as ChannelResult;
+}
+
+function entry(outcomes: Array<[number, boolean, number | null]>): ArchiveProbeEntry {
+  return {
+    running: false,
+    checkedAt: 1,
+    outcomes: outcomes.map(([daysBack, ok, latencyMs]) => ({
+      label: `−${daysBack}d`,
+      daysBack,
+      ok,
+      latencyMs,
+      error: ok ? null : "dead",
+    })),
+  };
+}
+
+describe("archiveVerdict", () => {
+  const ch = channel(1, 7);
+
+  it("stays advertised without completed probes", () => {
+    expect(archiveVerdict(ch, undefined)).toBe("advertised");
+    expect(archiveVerdict(ch, { running: true, outcomes: [], checkedAt: null })).toBe("advertised");
+  });
+
+  it("classifies broken, verified, and shallower archives", () => {
+    expect(archiveVerdict(ch, entry([[0, false, null]]))).toBe("broken");
+    expect(
+      archiveVerdict(
+        ch,
+        entry([
+          [0, true, 400],
+          [7, true, 700],
+        ]),
+      ),
+    ).toBe("verified");
+    expect(
+      archiveVerdict(
+        ch,
+        entry([
+          [0, true, 400],
+          [7, false, null],
+          [3, true, 500],
+        ]),
+      ),
+    ).toBe("shallower");
+  });
+
+  it("measures depth as the deepest answering point", () => {
+    expect(measuredDepthDays(entry([[0, true, 400]]))).toBe(1);
+    expect(
+      measuredDepthDays(
+        entry([
+          [0, true, 400],
+          [7, false, null],
+          [3, true, 500],
+        ]),
+      ),
+    ).toBe(3);
+    expect(measuredDepthDays(entry([[0, false, null]]))).toBeNull();
+  });
+});
+
+describe("computeCatchupScore", () => {
+  it("is null without catch-up channels", () => {
+    expect(computeCatchupScore([], {})).toBeNull();
+    expect(computeCatchupScore([plain(0), plain(1)], {})).toBeNull();
+  });
+
+  it("scores advertised coverage before verification", () => {
+    const results = [channel(0, 7), channel(1, 7), plain(2), plain(3)];
+    expect(computeCatchupScore(results, {})).toBe(5);
+  });
+
+  it("blends reliability and depth after verification", () => {
+    const results = [channel(0, 7), channel(1, 7)];
+    const probes = {
+      0: entry([
+        [0, true, 400],
+        [7, true, 700],
+      ]),
+      1: entry([
+        [0, true, 400],
+        [7, true, 800],
+      ]),
+    };
+    // Full coverage, full reliability, full depth.
+    expect(computeCatchupScore(results, probes)).toBe(10);
+
+    const broken = { 0: entry([[0, false, null]]), 1: entry([[0, false, null]]) };
+    // Full coverage but nothing works: only the coverage half survives.
+    expect(computeCatchupScore(results, broken as Record<number, ArchiveProbeEntry>)).toBe(5);
+  });
+});
+
+describe("blendOverallScore", () => {
+  const base = { overall: 7.0, ping: 6, content: 8, quality: 7 };
+
+  it("keeps the original overall without a catch-up component", () => {
+    expect(blendOverallScore(base, null)).toBe(7.0);
+  });
+
+  it("folds the catch-up component in at 15% weight", () => {
+    // 6*0.2 + 8*0.35 + 7*0.3 + 10*0.15 = 7.6
+    expect(blendOverallScore(base, 10)).toBeCloseTo(7.6, 5);
+  });
+});

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -285,7 +285,7 @@ describe("withCatchupScore", () => {
   });
 
   it("includes catch-up in the overall score", () => {
-    expect(withCatchupScore(base, 10).overall).toBeCloseTo(7.45, 5);
-    expect(withCatchupScore(base, 0).overall).toBeCloseTo(5.95, 5);
+    expect(withCatchupScore(base, 10).overall).toBeCloseTo(7.6, 5);
+    expect(withCatchupScore(base, 0).overall).toBeCloseTo(6.1, 5);
   });
 });

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -283,6 +283,22 @@ describe("computeCatchupScore", () => {
 
     expect(computeCatchupScore(results, probes)).toBe(7.5);
   });
+
+  it("counts completed but unverified probes as failed verification", () => {
+    const results = [channel(0, 7), channel(1, 7)];
+    const probes = {
+      0: entry([
+        [0, true, 400, false],
+        [7, true, 700, false],
+      ]),
+      1: entry([
+        [0, true, 400, false],
+        [7, true, 700, false],
+      ]),
+    };
+
+    expect(computeCatchupScore(results, probes)).toBe(5);
+  });
 });
 
 describe("archiveDepthMidpoint", () => {

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -43,6 +43,8 @@ function entry(
       daysBack,
       ok,
       depthVerified,
+      requestedStartEpochS: 1_700_000_000 - daysBack * 86_400,
+      requestUrl: `https://host/archive.ts?start=${1_700_000_000 - daysBack * 86_400}`,
       responseUrl: null,
       latencyMs,
       error: ok ? null : "dead",
@@ -50,12 +52,18 @@ function entry(
   };
 }
 
-function responseOutcome(daysBack: number, responseUrl: string): ArchiveProbeOutcome {
+function responseOutcome(
+  daysBack: number,
+  responseUrl: string,
+  requestedStartEpochS = 1_700_000_000 - daysBack * 86_400,
+): ArchiveProbeOutcome {
   return {
     label: `−${daysBack}d`,
     daysBack,
     ok: true,
     depthVerified: daysBack === 0,
+    requestedStartEpochS,
+    requestUrl: `https://host/archive.m3u8?start=${requestedStartEpochS}`,
     responseUrl,
     latencyMs: 100,
     error: null,
@@ -63,17 +71,25 @@ function responseOutcome(daysBack: number, responseUrl: string): ArchiveProbeOut
 }
 
 describe("verifyArchiveDepthResponse", () => {
-  const near = responseOutcome(0, "https://host/live/segment-100.ts");
+  const near = responseOutcome(0, "https://host/live/1700000000.ts");
 
-  it("accepts a deep probe that resolves to different media", () => {
-    const deep = responseOutcome(7, "https://host/archive/segment-20.ts");
+  it("accepts returned media whose timestamp matches the requested archive window", () => {
+    const deep = responseOutcome(7, "https://host/archive/1699395205.ts");
     expect(verifyArchiveDepthResponse(deep, near).depthVerified).toBe(true);
   });
 
-  it("accepts successful direct streams for distinct archive windows", () => {
+  it("does not treat differing direct request URLs as media verification", () => {
     const queryNear = responseOutcome(0, "https://host/live.ts?utc=100&lutc=200&token=x");
     const deep = responseOutcome(7, "https://host/live.ts?utc=10&lutc=200&token=x");
-    expect(verifyArchiveDepthResponse(deep, queryNear).depthVerified).toBe(true);
+    expect(verifyArchiveDepthResponse(deep, queryNear)).toMatchObject({
+      depthVerified: false,
+      depthUnknown: true,
+    });
+  });
+
+  it("rejects rotating live segments that do not match the requested archive time", () => {
+    const deep = responseOutcome(7, "https://host/live/1700000001.ts");
+    expect(verifyArchiveDepthResponse(deep, near).depthVerified).toBe(false);
   });
 
   it("ignores URL fragments when comparing responses", () => {


### PR DESCRIPTION
Phase 4, the last phase of the catch-up plan (Ref #229, design: https://plans.kristofferr.com/d/5nwq8d7wj9h8). Stacked on #234.

Advertised catch-up is a claim; providers lie about depth or serve dead archives. This adds the verification layer:

- `verifyChannelArchive`: probe −1 h, then the advertised depth, bisect up to 3 extra points on a mismatch to estimate real depth (2-6 requests per channel, sequential)
- Playlist-wide pass, cancellable with live progress: from the report panel's **Verify** button, or opt-in via the new Scan button dropdown (**Scan + Verify Catch-up**) which runs it after the scan completes
- Chips graduate with the verdict: ✓ green verified, ⚠ amber measured/advertised for shallower archives, ✕ red broken; violet stays advertised-only
- Report panel **Catch-up** section: verified/shallower/broken tiles, verified-depth histogram, median archive vs live startup latency
- Catch-up becomes a **fourth Health Score component** (Ping 20 / Content 35 / Quality 30 / Catch-up 15): advertised coverage before verification, blended with reliability and measured depth after. Playlists without catch-up show N/A and keep the original three-component overall, so scores stay comparable

Validation: bun test 134 (verdict/depth/score units), tsc, biome (new files clean). Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added catch-up archive verification for individual channels or entire playlists.
  - Added “Scan + Verify Catch-up” as an optional scan mode.
  - Playlist reports now show catch-up scores, verdicts, depth, latency, and verification progress.
  - Channel rows display archive status badges for advertised, verified, shallower, and broken archives.
  - Overall playlist scores now incorporate catch-up performance.

- **Bug Fixes**
  - Improved geoblock confirmation during quick checks.
  - Prevented conflicting scans, archive tests, and playback from running simultaneously.
  - Improved playback failure handling for live channels and archived content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->