### PR TITLE
docs: describe catch-up verification and the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Click any channel to see its thumbnail, preview it in the built-in player, or op
 
 Export results as CSV, M3U (alive only, split by group, or renamed), or a full JSON scan log. Export everything, just alive channels, or your current selection.
 
+### Catch-up that actually works
+
+Channels that advertise catch-up (`catchup`/`catchup-days` in M3U, `tv_archive` on Xtream) get a chip in the table and a pill in the status bar. Verify tells you which ones are real: quick mode asks each archive for the last hour, full mode also measures how many days are really kept. Fakes come back with a reason (empty archive, serves the live stream, HTTP error, timeout), filter to them, and export either a playlist of only the working catch-up channels or your list with the fake flags stripped. Verdicts are remembered per playlist.
+
+The Guide view shows the EPG for every channel as one scrollable timeline. Double-click a past programme on a catch-up channel to replay it, right-click to record it to disk with ffmpeg, or play the current programme live on any channel.
+
 ### Lightweight and fast
 
 Liquid Glass vibrancy on macOS, platform menus, keyboard shortcuts, dark/light/system theme, and desktop notifications when scans finish. Handles playlists with thousands of channels without breaking a sweat.


### PR DESCRIPTION
The README's feature list did not mention anything the catch-up work added.

Adds a short section covering detection, quick/full verification with fake reasons, the verdict-based exports, and the Guide view with replay, recording, and live play.

Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for identifying channels with catch-up support and verifying whether archives are genuine.
  * Documented quick and full verification modes, failure reasons, filtering, exporting, and saved verification results.
  * Added information about the Guide timeline, replaying past programmes, recording via ffmpeg, and live playback across channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->