### PR TITLE
fix(catchup): review fixes for verdicts, exports, and the pill

### DIFF
--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -140,16 +140,18 @@ export const StatsPanel = memo(function StatsPanel() {
   );
   const verdictTally = useMemo(() => {
     let real = 0;
+    let shallower = 0;
     let fake = 0;
     let untested = 0;
     for (const channel of channels) {
       if (!hasArchive(channel)) continue;
       const verdict = archiveVerdict(channel, archiveProbes[channel.index]);
-      if (verdict === "verified" || verdict === "shallower") real += 1;
+      if (verdict === "verified") real += 1;
+      else if (verdict === "shallower") shallower += 1;
       else if (verdict === "fake") fake += 1;
       else untested += 1;
     }
-    return { real, fake, untested, tested: real + fake };
+    return { real, shallower, fake, untested, tested: real + shallower + fake };
   }, [channels, archiveProbes]);
 
   const selectedCatchupCount = useMemo(() => {
@@ -163,7 +165,9 @@ export const StatsPanel = memo(function StatsPanel() {
   }, [channels, selectedChannelIndices]);
   const catchupLabel =
     verdictTally.tested > 0
-      ? `${verdictTally.real} real · ${verdictTally.fake} fake${
+      ? `${verdictTally.real} real${
+          verdictTally.shallower > 0 ? ` · ${verdictTally.shallower} shallower` : ""
+        } · ${verdictTally.fake} fake${
           verdictTally.untested > 0 ? ` · ${verdictTally.untested} untested` : ""
         }`
       : visibleCatchupCount === catchupCount
@@ -176,12 +180,11 @@ export const StatsPanel = memo(function StatsPanel() {
       toggleFilter("catchup");
       return;
     }
-    const next =
-      statusFilter === "catchup_real"
-        ? "catchup_fake"
-        : statusFilter === "catchup_fake"
-          ? "all"
-          : "catchup_real";
+    const cycle = ["catchup_real", "catchup_shallower", "catchup_fake"].filter(
+      (filter) => filter !== "catchup_shallower" || verdictTally.shallower > 0,
+    );
+    const position = cycle.indexOf(statusFilter);
+    const next = position === -1 ? cycle[0] : (cycle[position + 1] ?? "all");
     startTransition(() => setStatusFilter(next));
   };
 

--- a/src/lib/archiveExport.ts
+++ b/src/lib/archiveExport.ts
@@ -19,26 +19,52 @@ const CATCHUP_ATTR_PATTERN = new RegExp(
   "gi",
 );
 
-/** Remove every catch-up attribute from an EXTINF line. */
+/**
+ * Index of the comma that separates EXTINF attributes from the title, ignoring
+ * commas inside quoted attribute values (`group-title="Sports, US"`).
+ */
+export function findUnquotedComma(line: string): number {
+  let quote: string | null = null;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (quote) {
+      if (char === "\\") index += 1;
+      else if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ",") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function splitExtinf(extinf: string): { attrs: string; title: string } {
+  const comma = findUnquotedComma(extinf);
+  return comma === -1
+    ? { attrs: extinf, title: "" }
+    : { attrs: extinf.slice(0, comma), title: extinf.slice(comma) };
+}
+
+/** Remove every catch-up attribute from an EXTINF line, leaving the title alone. */
 export function stripCatchupAttributes(extinf: string): string {
-  return extinf.replace(CATCHUP_ATTR_PATTERN, "");
+  const { attrs, title } = splitExtinf(extinf);
+  return attrs.replace(CATCHUP_ATTR_PATTERN, "") + title;
 }
 
 /** Rewrite the advertised depth attributes to `days`, adding one when absent. */
 export function setCatchupDays(extinf: string, days: number): string {
   const value = String(Math.max(1, Math.round(days)));
+  const { attrs, title } = splitExtinf(extinf);
   let touched = false;
-  const rewritten = extinf.replace(
+  const rewritten = attrs.replace(
     /(\s(?:catchup-days|tvg-rec|timeshift)=)(?:"[^"]*"|'[^']*'|[^\s,]*)/gi,
     (_match, prefix: string) => {
       touched = true;
       return `${prefix}"${value}"`;
     },
   );
-  if (touched) return rewritten;
-  const comma = rewritten.indexOf(",");
-  const insertAt = comma === -1 ? rewritten.length : comma;
-  return `${rewritten.slice(0, insertAt)} catchup-days="${value}"${rewritten.slice(insertAt)}`;
+  return touched ? rewritten + title : `${rewritten} catchup-days="${value}"${title}`;
 }
 
 /**

--- a/src/lib/archiveProbe.ts
+++ b/src/lib/archiveProbe.ts
@@ -81,13 +81,19 @@ function responseMediaTimeMatchesRequest(outcome: ArchiveProbeOutcome): boolean 
   if (pathname == null) return null;
 
   const withinTolerance = (a: number, b: number) => Math.abs(a - b) <= MEDIA_TIME_TOLERANCE_SECONDS;
+  // Only digit runs that look like an epoch near the request count; stream
+  // and session ids of the same length must not flip a working archive to
+  // "serves live".
+  const plausibleWindowS = 400 * 86_400;
   const numericMatches = Array.from(
     pathname.matchAll(/(?:^|\D)(\d{13}|\d{10})(?=\D|$)/g),
     (match) => {
       const value = Number(match[1]);
       return match[1].length === 13 ? value / 1000 : value;
     },
-  ).map((timestamp) => withinTolerance(timestamp, outcome.requestedStartEpochS));
+  )
+    .filter((timestamp) => Math.abs(timestamp - outcome.requestedStartEpochS) <= plausibleWindowS)
+    .map((timestamp) => withinTolerance(timestamp, outcome.requestedStartEpochS));
   // The panel echoes the wall-clock stamp we asked for; compare against the
   // request's stamp in the same naive frame, or the UTC epoch when the
   // request carried no stamp.

--- a/src/lib/archiveVerification.ts
+++ b/src/lib/archiveVerification.ts
@@ -1,4 +1,4 @@
-import { hasArchive } from "./archive";
+import { hasArchive, MAX_CATCHUP_DAYS } from "./archive";
 import {
   type ArchiveProbeEntry,
   type ArchiveProbeOutcome,
@@ -105,13 +105,17 @@ export function archiveVerdict(
   if (!outcomes.some((outcome) => outcome.daysBack > 0)) return "verified";
   if (
     outcomes.some(
-      (outcome) => outcome.ok && outcome.depthUnknown && outcome.daysBack >= advertisedDays,
+      (outcome) =>
+        outcome.ok &&
+        outcome.depthUnknown &&
+        outcome.daysBack >= Math.min(MAX_CATCHUP_DAYS, advertisedDays),
     )
   ) {
     return "advertised";
   }
+  const measurableDays = Math.min(MAX_CATCHUP_DAYS, advertisedDays);
   return outcomes.some(
-    (outcome) => outcome.ok && outcome.depthVerified && outcome.daysBack >= advertisedDays,
+    (outcome) => outcome.ok && outcome.depthVerified && outcome.daysBack >= measurableDays,
   )
     ? "verified"
     : "shallower";
@@ -201,7 +205,8 @@ export async function verifyChannelArchive(
   }
   push(near, false);
 
-  const advertisedDays = result.catchup_days;
+  const advertisedDays =
+    result.catchup_days == null ? null : Math.min(MAX_CATCHUP_DAYS, result.catchup_days);
   if (advertisedDays == null || advertisedDays <= 0) {
     return push(null, true);
   }

--- a/tests/archiveExport.test.ts
+++ b/tests/archiveExport.test.ts
@@ -100,3 +100,17 @@ describe("verdict-based exports", () => {
     expect(exported[4]).toBe(plain);
   });
 });
+
+describe("EXTINF titles with commas", () => {
+  it("inserts and strips attributes without touching quoted commas or the title", async () => {
+    const { findUnquotedComma } = await import("../src/lib/archiveExport");
+    const line = '#EXTINF:-1 tvg-id="a" group-title="Sports, US" catchup="xc",Sky catchup=1';
+    expect(findUnquotedComma(line)).toBe(line.indexOf(",Sky"));
+    expect(setCatchupDays(line, 3)).toBe(
+      '#EXTINF:-1 tvg-id="a" group-title="Sports, US" catchup="xc" catchup-days="3",Sky catchup=1',
+    );
+    expect(stripCatchupAttributes(line)).toBe(
+      '#EXTINF:-1 tvg-id="a" group-title="Sports, US",Sky catchup=1',
+    );
+  });
+});

--- a/tests/catchupScore.test.ts
+++ b/tests/catchupScore.test.ts
@@ -132,6 +132,15 @@ describe("verifyArchivePointResponse", () => {
     });
   });
 
+  it("ignores digit runs that cannot be an epoch near the request", () => {
+    // A ten-digit stream id in the path is not media time; verdict stays unknown.
+    const outcome = responseOutcome(0, "https://cdn/hls/1234567890/user/pass/index.m3u8");
+    expect(verifyArchivePointResponse(outcome)).toMatchObject({
+      depthVerified: false,
+      depthUnknown: true,
+    });
+  });
+
   it("accepts a panel that echoes the requested local wall-clock stamp", () => {
     // Europe/Ljubljana panel: 00:51 UTC is asked for as 02:51 local and echoed as such.
     const outcome: ArchiveProbeOutcome = {


### PR DESCRIPTION
Four correctness issues found reviewing the verification work.

- **Export corruption.** Inserting `catchup-days` looked for the first comma in the EXTINF line, so a quoted comma in `group-title` put the attribute inside the quotes. The attribute region is now split at the unquoted comma, and stripping attributes never touches the title.
- **False "LIVE" verdicts.** Any 10- or 13-digit number in a response path was treated as a media timestamp; a stream or session id then flipped a working archive to fake. Only values plausibly near the requested time count now; otherwise the point stays unverified.
- **Absurd advertised depths.** `catchup-days="9999"` probed 27 years back plus three doomed bisections. Depth is probed and verified at the 31-day cap.
- **Pill mismatch.** The status pill counted shallower as real but its click filtered to verified only. It now shows real, shallower, and fake separately and cycles through the matching filters.

Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing shallower archive results in catch-up statistics and filters.
  * Catch-up labels now show the shallower archive count when applicable.

* **Bug Fixes**
  * Improved playlist handling for quoted commas and commas in channel titles.
  * Prevented unrelated numeric path segments from being mistaken for archive timestamps.
  * Capped archive-depth checks at the supported maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->