### PR TITLE
fix(rust): review fixes for recordings, proxy manifests, and EPG merges

### DIFF
--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -87,27 +87,48 @@ pub async fn download_archive(
     request: ArchiveDownloadRequest,
 ) -> Result<(), AppError> {
     validate(&request)?;
-    let (ffmpeg_available, _) = ffmpeg::check_availability(&app).await;
-    if !ffmpeg_available {
-        return Err(AppError::FfmpegNotAvailable);
-    }
-    let user_agent = state.settings.lock().await.user_agent.clone();
+    // Register before any slow step so an early Cancel is not lost.
     let cancel = CancellationToken::new();
     state
         .register_archive_download(request.id.clone(), cancel.clone())
         .await;
-    let result = run_download(&app, &request, &user_agent, &cancel).await;
-    state.unregister_archive_download(&request.id).await;
-    if result.is_err() {
-        // A cancelled or failed recording leaves a useless partial file behind.
-        let _ = std::fs::remove_file(&request.path);
+    let result = async {
+        let (ffmpeg_available, _) = ffmpeg::check_availability(&app).await;
+        if !ffmpeg_available {
+            return Err(AppError::FfmpegNotAvailable);
+        }
+        if cancel.is_cancelled() {
+            return Err(AppError::Cancelled);
+        }
+        let user_agent = state.settings.lock().await.user_agent.clone();
+        // Record into a sibling .part file so a failure never touches an
+        // existing file at the chosen path, then move it into place.
+        let part_path = partial_path(&request.path);
+        let outcome = run_download(&app, &request, &part_path, &user_agent, &cancel).await;
+        match outcome {
+            Ok(()) => crate::engine::disk::atomic_rename(
+                std::path::Path::new(&request.path),
+                std::path::Path::new(&part_path),
+            ),
+            Err(error) => {
+                let _ = std::fs::remove_file(&part_path);
+                Err(error)
+            }
+        }
     }
+    .await;
+    state.unregister_archive_download(&request.id).await;
     result
+}
+
+fn partial_path(path: &str) -> String {
+    format!("{path}.part")
 }
 
 async fn run_download(
     app: &AppHandle,
     request: &ArchiveDownloadRequest,
+    output_path: &str,
     user_agent: &str,
     cancel: &CancellationToken,
 ) -> Result<(), AppError> {
@@ -133,7 +154,7 @@ async fn run_download(
         "mpegts",
         "-progress",
         "pipe:1",
-        &request.path,
+        output_path,
     ];
     let resolved_bin = ffmpeg::resolve_binary(app, "ffmpeg");
     let mut command = tokio::process::Command::new(&resolved_bin);

--- a/src-tauri/src/commands/epg.rs
+++ b/src-tauri/src/commands/epg.rs
@@ -82,7 +82,11 @@ pub async fn load_epg(
         .cloned()
         .collect();
     if wanted.is_empty() {
-        *state.epg.lock().await = Some(Arc::new(EpgIndex::default()));
+        // Nothing to index (results not populated yet, or a superseded call):
+        // leave whatever guide is loaded rather than replacing it with nothing.
+        if cancel.is_cancelled() {
+            return Err(superseded_error());
+        }
         return Ok(EpgLoadSummary {
             sources_requested,
             sources_loaded: 0,

--- a/src-tauri/src/engine/proxy_common.rs
+++ b/src-tauri/src/engine/proxy_common.rs
@@ -12,7 +12,9 @@ pub const MAX_JSON_API_BYTES: u64 = 64 * 1024 * 1024;
 /// Whether a response is an HLS manifest, by content type or .m3u8 path.
 pub fn is_m3u8_response(content_type: &str, url: &str) -> bool {
     let ct = content_type.to_lowercase();
-    if ct.contains("application/vnd.apple.mpegurl") || ct.contains("application/x-mpegurl") {
+    // Panels also serve playlists as audio/x-mpegurl, audio/mpegurl, or
+    // video/x-mpegurl; anything mpegurl-flavoured is a manifest.
+    if ct.contains("mpegurl") {
         return true;
     }
     if let Ok(parsed) = Url::parse(url) {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -183,14 +183,23 @@ impl AppState {
         self.quick_check_tokens.lock().await.remove(request_id);
     }
 
+    /// A cancel that arrived before registration leaves a cancelled
+    /// tombstone; honour it so the recording never outlives its Cancel click.
     pub async fn register_archive_download(&self, id: String, token: CancellationToken) {
-        self.archive_download_tokens.lock().await.insert(id, token);
+        let mut tokens = self.archive_download_tokens.lock().await;
+        if tokens.get(&id).is_some_and(CancellationToken::is_cancelled) {
+            token.cancel();
+        }
+        tokens.insert(id, token);
     }
 
     pub async fn cancel_archive_download(&self, id: &str) {
-        if let Some(token) = self.archive_download_tokens.lock().await.get(id) {
-            token.cancel();
-        }
+        self.archive_download_tokens
+            .lock()
+            .await
+            .entry(id.to_string())
+            .or_insert_with(CancellationToken::new)
+            .cancel();
     }
 
     pub async fn unregister_archive_download(&self, id: &str) {


### PR DESCRIPTION
Fixes from reviewing the Rust side of the catch-up work.

- **Lost Cancel.** A Cancel click before the recording token was registered (the ffmpeg availability check can take seconds on first use) did nothing, and the recording ran to the end. Cancel now leaves a tombstone that registration honours, and registration happens first.
- **Deleting the user's file.** Any failure removed the chosen path, even when ffmpeg never wrote it, so re-recording over an existing file and hitting a 404 deleted the good recording. Recordings now go to a `.part` sibling and are moved into place on success.
- **False 409s.** The proxy treated `audio/x-mpegurl` and friends as raw media. Any mpegurl-flavoured content type is a playlist.
- **Guide gaps.** Overlap removal tracked a running maximum stop, so one over-long or synthetic slot swallowed every later listing. It now compares with the previous kept programme and drops only fully contained entries (test added).
- **Emptied guide.** A load with no channel ids replaced the index with an empty one; it now leaves the loaded guide alone and reports superseded when cancelled.

Ref #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download cancellation and recovery, preventing incomplete files from replacing completed downloads.
  - Preserved the existing TV guide when an empty or superseded guide load occurs.
  - Improved recognition of HLS streams across a broader range of playlist content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->